### PR TITLE
Modify launch and build commands to be more compatible with other platforms

### DIFF
--- a/PathOfTerraria.csproj
+++ b/PathOfTerraria.csproj
@@ -7,6 +7,16 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExecutablePath Condition=" Exists('/etc/NIXOS') ">steam-run</ExecutablePath>
+    <ExecutablePath Condition=" '$(ExecutablePath)' == '' ">$(DotNetName)</ExecutablePath>
+    <TMLCommandLineArgs Condition=" Exists('/etc/NIXOS') ">$(DotNetName) $(tMLPath)</TMLCommandLineArgs>
+    <TMLCommandLineArgs Condition=" '$(TMLCommandLineArgs)' == '' ">$(tMLPath)</TMLCommandLineArgs>
+    <TMLServerCommandLineArgs Condition=" Exists('/etc/NIXOS') ">$(DotNetName) $(tMLServerPath)</TMLServerCommandLineArgs>
+    <TMLServerCommandLineArgs Condition=" '$(TMLServerCommandLineArgs)' == '' ">$(tMLServerPath)</TMLServerCommandLineArgs>
+    <BuildCommand Condition=" Exists('/etc/NIXOS') ">steam-run dotnet</BuildCommand>
+    <BuildCommand Condition=" '$(BuildCommand)' == '' ">dotnet</BuildCommand>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Update="JsonCreator\CreateMobJsonFiles.cs">
       <Link>ClassLibrary1\CreateMobJsonFiles.cs</Link>
@@ -22,4 +32,7 @@
       <HintPath>Dependencies\SubworldLibrary.dll</HintPath>
     </Reference>
   </ItemGroup>
+	<Target Name="BuildMod" AfterTargets="Build">
+		<Exec Command="$(BuildCommand) $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)"/>
+	</Target>
 </Project>

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,14 +2,14 @@
   "profiles": {
     "Terraria": {
       "commandName": "Executable",
-      "executablePath": "dotnet/dotnet.exe",
-      "commandLineArgs": "$(tMLPath)",
+      "executablePath": "$(executablePath)",
+      "commandLineArgs": "$(tMLCommandLineArgs)",
       "workingDirectory": "$(tMLSteamPath)"
     },
     "TerrariaServer": {
       "commandName": "Executable",
-      "executablePath": "dotnet/dotnet.exe",
-      "commandLineArgs": "$(tMLServerPath)",
+      "executablePath": "$(executablePath)",
+      "commandLineArgs": "$(tMLServerCommandLineArgs)",
       "workingDirectory": "$(tMLSteamPath)"
     }
   }


### PR DESCRIPTION
### Link Issues
Resolves: #86 

### Description of Work
Modifies the csproj and launchSettings.json files, creating some variables that decide which commands to use depending on OS
Switching to the `DotNetName` variable that the tmodloader targets file provides should work with most operating systems, the bulk of this is making it also work with NixOS

### Comments
Need someone on windows to test if it works, I can test on arch linux to verify more normal distros work. Unsure if we have anyone with a mac, but if it works on linux it should work there