### PR TITLE
add localization to passives per #73

### DIFF
--- a/Content/GUI/PassiveElement.cs
+++ b/Content/GUI/PassiveElement.cs
@@ -94,7 +94,7 @@ internal class PassiveElement : SmartUIElement
 
 		if (IsMouseHovering)
 		{
-			string name = _passive.Name;
+			string name = _passive.DisplayName;
 
 			if (_passive.MaxLevel > 1)
 			{
@@ -102,7 +102,7 @@ internal class PassiveElement : SmartUIElement
 			}
 
 			Tooltip.SetName(name);
-			Tooltip.SetTooltip(_passive.Tooltip);
+			Tooltip.SetTooltip(_passive.DisplayTooltip);
 		}
 
 		Recalculate();

--- a/Core/Systems/TreeSystem/Passive.cs
+++ b/Core/Systems/TreeSystem/Passive.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using PathOfTerraria.Data.Models;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Core.Systems.TreeSystem;
 
@@ -33,6 +34,16 @@ internal abstract class Passive
 
 	public virtual string Name => "Unknown";
 	public virtual string Tooltip => "Who knows what this will do!";
+
+	/// <summary>
+	/// Name to be used in ALL display situations. This is automatically populated by <see cref="Name"/> and <see cref="Language.GetOrRegister(string, Func{string})"/>.
+	/// </summary>
+	public virtual string DisplayName => Language.GetTextValue("Mods.PathOfTerraria.Passives." + InternalIdentifier + ".Name");
+
+	/// <summary>
+	/// Tooltip to be used in ALL display situations. This is automatically populated by <see cref="Tooltip"/> and <see cref="Language.GetOrRegister(string, Func{string})"/>.
+	/// </summary>
+	public virtual string DisplayTooltip => Language.GetTextValue("Mods.PathOfTerraria.Passives." + InternalIdentifier + ".Tooltip");
 
 	public int Level;
 	public int MaxLevel;
@@ -78,6 +89,11 @@ internal abstract class Passive
 
 			var instance = (Passive)Activator.CreateInstance(type);
 			instance.OnLoad();
+
+			// Automatically registers the given keys for each instance loaded, and sets them to their set name and tooltip if they do not exist.
+			Language.GetOrRegister("Mods.PathOfTerraria.Passives." + instance.InternalIdentifier + ".Name", () => instance.Name);
+			Language.GetOrRegister("Mods.PathOfTerraria.Passives." + instance.InternalIdentifier + ".Tooltip", () => instance.Tooltip);
+
 			Passives.Add(instance.InternalIdentifier, type);
 		}
 	}

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -1,0 +1,74 @@
+IncreasedMeleeDamage: {
+	Name: Martial Mastery
+	Tooltip: Increases your melee damage by 5% per level
+}
+
+IncreasedRangedDamage: {
+	Name: Marksmanship Mastery
+	Tooltip: Increases your ranged damage by 5% per level
+}
+
+IncreasedMagicDamage: {
+	Name: Arcane Mastery
+	Tooltip: Increases your magic damage by 5% per level
+}
+
+IncreasedSummoningDamage: {
+	Name: Summoning Mastery
+	Tooltip: Increases your summon damage by 5% per level
+}
+
+AddedLife: {
+	Name: Empowered Flesh
+	Tooltip: Increases your maximum life by 20 per level
+}
+
+AddedMana: {
+	Name: Open Mind
+	Tooltip: Increases your maximum mana by 20 per level
+}
+
+IncreasedDistantDamage: {
+	Name: Sniper
+	Tooltip: Increases your damage against distant enemies by 10% per level
+}
+
+IncreasedCloseDamage: {
+	Name: Close Combatant
+	Tooltip: Increases your damage against nearby enemies by 10% per level
+}
+
+BleedingDamageOverTime: {
+	Name: Crimson Dance
+	Tooltip: Your melee attacks inflict bleeding, dealing 5 damage per second per level
+}
+
+IncreasedDamageReduction: {
+	Name: Iron Will
+	Tooltip: Gain 0.25% damage reduction per level.
+}
+
+AddedContactDamageReflection: {
+	Name: Thorny Exterior
+	Tooltip: Reflect 10 more damage to enemies that deal contact damage per level.
+}
+
+AmmoEfficiency: {
+	Name: Secret Compartment
+	Tooltip: 5% chance to not consume ammo per level
+}
+
+Anchor: {
+	Name: Anchor
+	Tooltip: Your journey starts here
+}
+
+IncreasedMinionDamage: {
+	Name: Empowered Horde
+	Tooltip: Increases your minions' damage by 10% per level
+}
+
+IncreasedSentryDamage: {
+	Name: Steadfast Sentries
+	Tooltip: Increases your sentries' damage by 10% per level
+}

--- a/PathOfTerraria.csproj
+++ b/PathOfTerraria.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <None Remove="Effects\LunarEffect.glsl" />
     <None Remove="Localization\en-US\Mods.PathOfTerraria.Items.hjson" />
+    <None Remove="Localization\en-US\Mods.PathOfTerraria.Passives.hjson" />
     <None Remove="Localization\en-US\Mods.PathOfTerraria.Projectiles.hjson" />
   </ItemGroup>
   <ItemGroup>
@@ -33,6 +34,6 @@
     </Reference>
   </ItemGroup>
 	<Target Name="BuildMod" AfterTargets="Build">
-		<Exec Command="$(BuildCommand) $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)"/>
+		<Exec Command="$(BuildCommand) $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)" />
 	</Target>
 </Project>


### PR DESCRIPTION
﻿### Link Issues
Resolves: #73 

### Description of Work
`Passive.Name` and `.Tooltip` now autogenerate localization in `Mods.PathOfTerraria.Passives`.

### Comments
Unsure if `Name` and `Tooltip` should be preserved, since they have one use, once, during the first build after they're added.