### PR TITLE
Hotbar click fixes

### DIFF
--- a/Content/GUI/NewHotbar.cs
+++ b/Content/GUI/NewHotbar.cs
@@ -319,7 +319,6 @@ public class HijackHotbarClick : ModSystem
 						Main.LocalPlayer.changeItem = i;
 					}
 
-
 					if (Main.LocalPlayer.inventory[i].stack > 1)
 					{
 						Main.hoverItemName = Main.hoverItemName + " (" + Main.LocalPlayer.inventory[i].stack + ")";

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -213,3 +213,8 @@ StoneBoomerang: {
 	DisplayName: Stone Boomerang
 	Tooltip: ""
 }
+
+YellowJewel: {
+	DisplayName: Yellow Jewel
+	Tooltip: ""
+}

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -77,3 +77,8 @@ IncreasedSentryDamage: {
 	Name: Steadfast Sentries
 	Tooltip: Increases your sentries' damage by 10% per level
 }
+
+JewelSocket: {
+	Name: JewelSocket
+	Tooltip: ""
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #123 

### Description of Work
The combat bar now doesn't click onto other items since that'd be unclear.
The building bar does click onto other items, and has the proper clickboxes. Additionally, this adds back the hover name for each hover, aside from the first two items.

This also fixes the rendertarget hack used to hide the original hotbar breaking when zooming. Since the fix covers the item name, now we also draw the name manually - which looks better anyway. The item name also now uses the item's rarity color, which just looks fancy and there's never an excuse to not be fancy.

There's also a few minor tweaks to existing code, namely a brace pair that was just hanging out.

### Comments
`HijackHotbarClick` is in the same file as `NewHotbar` since I'm unsure of where to put it. It's small enough to where I don't think it matters much, but it's important to note for anyone who might disagree.