### PR TITLE
#118 + additional buff boost

### DIFF
--- a/Core/Systems/Affixes/ItemTypes/ArmorAffixes/DefenseAffixes.cs
+++ b/Core/Systems/Affixes/ItemTypes/ArmorAffixes/DefenseAffixes.cs
@@ -19,4 +19,24 @@ internal class DefenseAffixes
 			modifier.DamageReduction.Base += (float)Math.Truncate((Value * 5 + item.ItemLevel / 50) * 10) / 10;
 		}
 	}
+
+	internal class ResistanceHelmetAffix : ItemAffix
+	{
+		public override ItemType PossibleTypes => ItemType.Helmet;
+
+		public override void ApplyAffix(EntityModifier modifier, PoTItem item)
+		{
+			modifier.DebuffResistance *= 1 - (float)Math.Truncate((Value * 2 + item.ItemLevel / 450) * 5) / 300f;
+		}
+	}
+
+	internal class BuffBoostHelmetAffix : ItemAffix
+	{
+		public override ItemType PossibleTypes => ItemType.Helmet;
+
+		public override void ApplyAffix(EntityModifier modifier, PoTItem item)
+		{
+			modifier.BuffBonus *= 1 + (float)Math.Truncate((Value * 2 + item.ItemLevel / 450) * 5) / 300f;
+		}
+	}
 }

--- a/Core/Systems/EntityModifier.cs
+++ b/Core/Systems/EntityModifier.cs
@@ -34,6 +34,10 @@ internal class EntityModifier
 	public StatModifier PotionManaPower = new();
 	public StatModifier PotionManaDelay = new();
 
+	// BufModifierPlayer:
+	public StatModifier DebuffResistance = new();
+	public StatModifier BuffBonus = new();
+
 	public void ApplyTo(NPC npc)
 	{
 		npc.life = (int)MaximumLife.ApplyTo(npc.life);
@@ -76,9 +80,14 @@ internal class EntityModifier
 		ps.MaxMana = (int)MaxHealthPotions.ApplyTo(ps.MaxMana);
 		ps.ManaPower = (int)PotionManaPower.ApplyTo(ps.ManaPower);
 		ps.ManaDelay = (int)PotionManaDelay.ApplyTo(ps.ManaDelay);
+
+		BuffModifierPlayer buffPlayer = player.GetModPlayer<BuffModifierPlayer>();
+		buffPlayer.ResistanceStrength = DebuffResistance;
+		buffPlayer.BuffBonus = BuffBonus;
 	}
 
 	private readonly FieldInfo[] _fields = typeof(EntityModifier).GetFields().Where(f => f.FieldType == typeof(StatModifier)).ToArray();
+
 	public List<string> GetDifference(EntityModifier other)
 	{
 		List<string> strings = new List<string>();
@@ -99,6 +108,7 @@ internal class EntityModifier
 	}
 
 	public static List<string> GetChange(EntityModifier changed) { return _default.GetDifference(changed); }
+
 	private string[] GetDifferences(StatModifier m1, StatModifier m2)
 	{
 		List<string> differences = new List<string>();

--- a/Core/Systems/ModPlayers/BuffModifierPlayer.cs
+++ b/Core/Systems/ModPlayers/BuffModifierPlayer.cs
@@ -1,0 +1,34 @@
+﻿namespace PathOfTerraria.Core.Systems.ModPlayers;
+
+public class BuffModifierPlayer : ModPlayer
+{
+	public StatModifier ResistanceStrength = StatModifier.Default;
+	public StatModifier BuffBonus = StatModifier.Default;
+
+	public override void Load()
+	{
+		On_Player.AddBuff += BoostBuffsAndReduceDebuffs;
+	}
+
+	private void BoostBuffsAndReduceDebuffs(On_Player.orig_AddBuff orig, Player self, int type, int timeToAdd, bool quiet, bool foodHack)
+	{
+		if (timeToAdd > 10)
+		{
+			if (Main.debuff[type])
+			{
+				timeToAdd = (int)self.GetModPlayer<BuffModifierPlayer>().ResistanceStrength.ApplyTo(timeToAdd);
+			}
+			else
+			{
+				timeToAdd = (int)self.GetModPlayer<BuffModifierPlayer>().BuffBonus.ApplyTo(timeToAdd);
+			}
+		}
+
+		orig(self, type, timeToAdd, quiet, foodHack);
+	}
+
+	public override void ResetEffects()
+	{
+		ResistanceStrength = BuffBonus = StatModifier.Default;
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #118

### Description of Work
Added `ResistanceHelmetAffix` and `BuffBoostHelmetAffix`. Both are programmed to apply to helmets only. Their buffs are not final, but seem reasonable from my limited understanding of the affix system. 
These both use `BuffModifierPlayer`.

### Comments
ResistanceHelmetAffix is marked as negative because it reduces values, even though -x% debuff time is good.