### PR TITLE
Fix New Hotbar Rendering

### DIFF
--- a/Content/GUI/NewHotbar.cs
+++ b/Content/GUI/NewHotbar.cs
@@ -31,13 +31,6 @@ internal class NewHotbar : SmartUIState
 
 	public override void Draw(SpriteBatch spriteBatch)
 	{
-		var hideTarget = new Rectangle(0, 0, Main.LocalPlayer.selectedItem > 10 ? 510 : 466, 72);
-
-		if (!Main.screenTarget.IsDisposed)
-		{
-			Main.spriteBatch.Draw(Main.screenTarget, hideTarget, hideTarget, Color.White);
-		}
-
 		float prog;
 
 		if (Main.LocalPlayer.selectedItem == 0)

--- a/Core/Systems/HotbarHijack.cs
+++ b/Core/Systems/HotbarHijack.cs
@@ -11,19 +11,25 @@ internal class HotbarHijack : ModSystem
 	public override void Load()
 	{
 		On_ItemSlot.LeftClick_ItemArray_int_int += StopHotbar;
-		On_Main.GUIHotbarDrawInner += StopHoverText;
+		On_Main.GUIHotbarDrawInner += StopVanillaHotbarDrawing;
 	}
 
-	private void StopHoverText(On_Main.orig_GUIHotbarDrawInner orig, Main self)
+	private void StopVanillaHotbarDrawing(On_Main.orig_GUIHotbarDrawInner orig, Main self)
 	{
-		string lastHover = Main.hoverItemName;
+		// This detour previously handled preventing the hover text that would
+		// draw when hovering over items in the hotbar.
+		// It has been reworked to prevent all associated drawing of the vanilla
+		// hotbar instead.
+		// This allows for other mods' detours to run if they hook this method
+		// while still sufficiently preventing the vanilla hotbar from drawing.
+
+		// Always set it to true to cause an early return in the vanilla method.
+		bool origPlayerInventory = Main.playerInventory;
+		Main.playerInventory = true;
 
 		orig(self);
 
-		if (Main.LocalPlayer.selectedItem == 0 && !Main.hoverItemName.StartsWith(Main.LocalPlayer.HeldItem.AffixName()))
-		{
-			Main.hoverItemName = lastHover;
-		}
+		Main.playerInventory = origPlayerInventory;
 	}
 
 	private void StopHotbar(On_ItemSlot.orig_LeftClick_ItemArray_int_int orig, Item[] inv, int context, int slot)


### PR DESCRIPTION
﻿### Link Issues

Resolves: #139

### Description of Work

Rewrites handling of hotbar rendering to properly hide the vanilla hotbar. Recycles an existing detour to accomplish this.

### Comments

The detour is designed to cleanly cancel vanilla behavior while preserving any new behavior added by mods. I could have gone with an IL edit instead to always branch to a `ret`, but this was faster and more immediately obvious in terms of functionality.