### PR TITLE
fix(#143): correct `CopyItemInfo` key name and add localization

### DIFF
--- a/Core/PoTItem.cs
+++ b/Core/PoTItem.cs
@@ -24,7 +24,7 @@ internal class PoTItemMiddleMouseButtonClick : ILoadable
 	public static ModKeybind CopyItem { get; private set; }
 	public void Load(Mod mod)
 	{
-		CopyItem = KeybindLoader.RegisterKeybind(mod, "Copy Item Info", "I");
+		CopyItem = KeybindLoader.RegisterKeybind(mod, "CopyItemInfo", "I");
 		On_ItemSlot.LeftClick_ItemArray_int_int += AddKeybindPressEvent;
 	}
 

--- a/Localization/en-US/Mods.PathOfTerraria.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.hjson
@@ -5,6 +5,7 @@ Keybinds: {
 	UseSkill4.DisplayName: Use Skill4
 	UseSkill5.DisplayName: Use Skill5
 	WeaponSwap.DisplayName: Swap Weapons
+	CopyItemInfo.DisplayName: Copy Item Info
 }
 
 GUI: {


### PR DESCRIPTION
﻿### Link Issues

Resolves: #143 

### Description of Work

Corrects the internal name of the CopyItemInfo key and adds it to the localization files.

### Comments

N/A