### PR TITLE
fix(#80): all tools are hotbar tools, items enter correct hotbar slots, starting inventory corrected

### DIFF
--- a/Core/Systems/HotbarHijack.cs
+++ b/Core/Systems/HotbarHijack.cs
@@ -118,6 +118,6 @@ internal class HotbarHijack : ModSystem
 
 	private static bool IsTool(Item item)
 	{
-		return item.pick > 0;
+		return item.pick > 0 || item.axe > 0 || item.hammer > 0;
 	}
 }

--- a/Core/Systems/HotbarHijack.cs
+++ b/Core/Systems/HotbarHijack.cs
@@ -13,10 +13,6 @@ internal class HotbarHijack : ModSystem
 		On_Main.GUIHotbarDrawInner += StopVanillaHotbarDrawing;
 		On_ItemSlot.LeftClick_ItemArray_int_int += ReserveHotbarSlots_PreventLeftClickingItemsIntoHotbar;
 		On_Player.GetItem_FillEmptyInventorySlot += ReserveHotbarSlors_PreventFillingHotbarWithItems;
-
-		// mouseItem is held item
-		// selectedItem is item selected in inventory
-		// mouseItem is index 58
 	}
 
 	private static void StopVanillaHotbarDrawing(On_Main.orig_GUIHotbarDrawInner orig, Main self)

--- a/Core/Systems/HotbarHijack.cs
+++ b/Core/Systems/HotbarHijack.cs
@@ -59,6 +59,11 @@ internal class HotbarHijack : ModSystem
 			return;
 		}
 
+		if (slot < 2)
+		{
+			return;
+		}
+
 		// Tools can go elsewhere, weapons can't
 		if (weapon && !tool)
 		{
@@ -89,6 +94,11 @@ internal class HotbarHijack : ModSystem
 		if (tool && i == 1)
 		{
 			return orig(self, plr, newItem, settings, returnItem, i);
+		}
+
+		if (i < 2)
+		{
+			return false;
 		}
 
 		// Tools can go elsewhere, weapons can't.

--- a/Core/Systems/HotbarHijack.cs
+++ b/Core/Systems/HotbarHijack.cs
@@ -118,6 +118,6 @@ internal class HotbarHijack : ModSystem
 
 	private static bool IsTool(Item item)
 	{
-		return item.pick > 0 || item.axe > 0 || item.hammer > 0;
+		return item.pick > 0;
 	}
 }

--- a/Core/Systems/HotbarHijack.cs
+++ b/Core/Systems/HotbarHijack.cs
@@ -52,20 +52,15 @@ internal class HotbarHijack : ModSystem
 			return;
 		}
 
-		// Slot 2 should be forced to be the equipped pickaxe
+		// Slot 2 should be forced to be the equipped tool
 		if (tool && slot == 1)
 		{
 			orig(inv, context, slot);
 			return;
 		}
 
-		// The rest of the slots cannot be weapons or picks
-		if (slot < 2)
-		{
-			return;
-		}
-
-		if (weapon || tool)
+		// Tools can go elsewhere, weapons can't
+		if (weapon && !tool)
 		{
 			return;
 		}
@@ -96,14 +91,8 @@ internal class HotbarHijack : ModSystem
 			return orig(self, plr, newItem, settings, returnItem, i);
 		}
 
-		// Don't fill with any other items if they aren't tools or weapons..
-		if (i < 2)
-		{
-			return false;
-		}
-
-		// Tools and weapons can't go anywhere else in the hotbar.
-		if (weapon || tool)
+		// Tools can go elsewhere, weapons can't.
+		if (weapon && !tool)
 		{
 			return false;
 		}

--- a/Core/Systems/ModPlayers/ClassModPlayer.cs
+++ b/Core/Systems/ModPlayers/ClassModPlayer.cs
@@ -21,12 +21,17 @@ public class ClassModPlayer : ModPlayer
 		}
 
 		vanillaItems.Clear();
+
 		var item = new Item();
-		item.SetDefaults(ItemID.CopperAxe);
+		item.TurnToAir();
 		vanillaItems.Add(item);
 
 		item = new Item();
 		item.SetDefaults(ItemID.CopperPickaxe);
+		vanillaItems.Add(item);
+
+		item = new Item();
+		item.SetDefaults(ItemID.CopperAxe);
 		vanillaItems.Add(item);
 	}
 

--- a/Core/Systems/ModPlayers/ClassModPlayer.cs
+++ b/Core/Systems/ModPlayers/ClassModPlayer.cs
@@ -22,6 +22,8 @@ public class ClassModPlayer : ModPlayer
 
 		vanillaItems.Clear();
 
+		// We want the first slot to be empty so the chosen class' weapon can
+		// be placed there.
 		var item = new Item();
 		item.TurnToAir();
 		vanillaItems.Add(item);

--- a/Core/Systems/ModPlayers/ClassModPlayer.cs
+++ b/Core/Systems/ModPlayers/ClassModPlayer.cs
@@ -22,11 +22,11 @@ public class ClassModPlayer : ModPlayer
 
 		vanillaItems.Clear();
 		var item = new Item();
-		item.SetDefaults(ItemID.CopperPickaxe);
+		item.SetDefaults(ItemID.CopperAxe);
 		vanillaItems.Add(item);
 
 		item = new Item();
-		item.SetDefaults(ItemID.CopperAxe);
+		item.SetDefaults(ItemID.CopperPickaxe);
 		vanillaItems.Add(item);
 	}
 


### PR DESCRIPTION
﻿### Link Issues

Resolves: #80

### Description of Work

- Simplifies existing hotbar item slot handling code. Adds another hook to handle picking up items.
- All tools are now considered tools for the hotbar, not just pickaxes.
- Starting inventory leaves the first slot empty, 2nd and 3rd are populated with tools as normal.
- Tools can now go in any slot.

### Comments

N/A
