### PR TITLE
multiplicative life regen affix #150

### DIFF
--- a/Core/Systems/Affixes/ItemTypes/ArmorAffixes/LifeAffixes.cs
+++ b/Core/Systems/Affixes/ItemTypes/ArmorAffixes/LifeAffixes.cs
@@ -3,6 +3,7 @@
 internal class BaseLifeAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.MaximumLife.Base += 10f + Value * 30f + item.ItemLevel / 100f;
@@ -11,6 +12,7 @@ internal class BaseLifeAffix : ItemAffix
 internal class AddedLifeAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.MaximumLife += (1f + Value) * item.ItemLevel / 10f / 100f;
@@ -19,6 +21,7 @@ internal class AddedLifeAffix : ItemAffix
 internal class MultipliedLifeAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.MaximumLife *= 1f + (1f + Value) * item.ItemLevel / 20f / 100f;
@@ -27,6 +30,7 @@ internal class MultipliedLifeAffix : ItemAffix
 internal class FlatLifeAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.MaximumLife.Flat += 4f + (Value + 0.5f) * item.ItemLevel / 10;
@@ -35,16 +39,28 @@ internal class FlatLifeAffix : ItemAffix
 
 internal class LifeRegenAffix : ItemAffix
 {
-	public override ItemType PossibleTypes => ItemType.Armor;
+	public override ItemType PossibleTypes => ItemType.Chestplate;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.LifeRegen.Base += 1f + Value * 4f + item.ItemLevel / 40f;
 	}
 }
 
+internal class LifeRegenMultiplierAffix : ItemAffix
+{
+	public override ItemType PossibleTypes => ItemType.Armor;
+
+	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
+	{
+		modifier.LifeRegen += (1f + Value + item.ItemLevel) / 170f;
+	}
+}
+
 internal class LifePotionPowerAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.PotionHealPower.Base += 10f + Value * 10f + item.ItemLevel / 20f;
@@ -54,6 +70,7 @@ internal class LifePotionPowerAffix : ItemAffix
 internal class LifePotionCapAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.MaxHealthPotions.Base += 1 + Value + item.ItemLevel / 100f;
@@ -63,6 +80,7 @@ internal class LifePotionCapAffix : ItemAffix
 internal class LifePotionCooldownAffix : ItemAffix
 {
 	public override ItemType PossibleTypes => ItemType.Armor;
+
 	public override void ApplyAffix(EntityModifier modifier, PoTItem item)
 	{
 		modifier.PotionHealDelay.Base -= 60 * (0.5f + Value * 0.5f);

--- a/Core/Systems/ModPlayers/UniversalBuffingPlayer.cs
+++ b/Core/Systems/ModPlayers/UniversalBuffingPlayer.cs
@@ -10,6 +10,7 @@ internal class UniversalBuffingPlayer : ModPlayer
 
 	public override void PostUpdateEquips()
 	{
+		Player.lifeRegen = Player.lifeRegen;
 		(Player.inventory[0].ModItem as Gear)?.ApplyAffixes(UniversalModifier);
 
 		UniversalModifier.ApplyTo(Player);


### PR DESCRIPTION
﻿### Link Issues
Resolves: #150

### Description of Work
Adds a % based life regen affix.
Also makes the additive life regen affix apply only to chestplates, and fixes formatting a bit.

### Comments
