### PR TITLE
Boomerang flail other clones

### DIFF
--- a/Content/Items/Gear/VanillaItems/Clones/Boomerangs/BoomerangLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Boomerangs/BoomerangLoader.cs
@@ -1,0 +1,29 @@
+﻿using PathOfTerraria.Core;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Boomerangs;
+
+internal class BoomerangLoader : ModSystem
+{
+	public override void Load()
+	{
+		// Prehardmode
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.EnchantedBoomerang, ItemType.Ranged, "EnchantedBoomerang"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.FruitcakeChakram, ItemType.Ranged, "FruitcakeChakram"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.BloodyMachete, ItemType.Ranged, "BloodyMachete"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Shroomerang, ItemType.Ranged, "Shroomerang"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.IceBoomerang, ItemType.Ranged, "IceBoomerang"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ThornChakram, ItemType.Ranged, "ThornChakram"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.CombatWrench, ItemType.Ranged, "CombatWrench"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Trimarang, ItemType.Ranged, "Trimarang"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Flamarang, ItemType.Ranged, "Flamarang"));
+
+		// Hardmode
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.FlyingKnife, ItemType.Ranged, "FlyingKnife"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.BouncingShield, ItemType.Ranged, "SergeantUnitedShield"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.LightDisc, ItemType.Ranged, "LightDisc"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Bananarang, ItemType.Ranged, "Bananarang"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.PossessedHatchet, ItemType.Ranged, "PossessedHatchet"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.PaladinsHammer, ItemType.Ranged, "PaladinsHammer"));
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Flails/FlailLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Flails/FlailLoader.cs
@@ -1,0 +1,29 @@
+﻿using PathOfTerraria.Core;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class FlailLoader : ModSystem
+{
+	public override void Load()
+	{
+		// Prehardmode
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Mace, ItemType.Melee, "Mace"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.FlamingMace, ItemType.Melee, "FlamingMace"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.BallOHurt, ItemType.Melee, "BallOHurt"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.TheMeatball, ItemType.Melee, "TheMeatball"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.BlueMoon, ItemType.Melee, "BlueMoon"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Sunfury, ItemType.Melee, "Sunfury"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ChainKnife, ItemType.Melee, "ChainKnife"));
+
+		// Hardmode
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.DripplerFlail, ItemType.Ranged, "DripplerCrippler"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.DaoofPow, ItemType.Ranged, "DaoOfPow"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.FlowerPow, ItemType.Ranged, "FlowerPow"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Anchor, ItemType.Ranged, "Anchor"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ChainGuillotines, ItemType.Ranged, "ChainGuillotines"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.KOCannon, ItemType.Ranged, "KOCannon"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.GolemFist, ItemType.Ranged, "GolemFist"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Flairon, ItemType.Ranged, "Flairon"));
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/MiscellaneousLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/MiscellaneousLoader.cs
@@ -1,0 +1,25 @@
+﻿using PathOfTerraria.Core;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class MiscellaneousLoader : ModSystem
+{
+	public override void Load()
+	{
+		// Prehardmode
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Terragrim, ItemType.Ranged, "Terragrim"));
+
+		// Hardmode
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Arkhalis, ItemType.Ranged, "Arkhalis"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.JoustingLance, ItemType.Ranged, "JoustingLance"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ShadowFlameKnife, ItemType.Ranged, "ShadowFlameKnife"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.HallowJoustingLance, ItemType.Ranged, "HallowedJoustingLance"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.MonkStaffT1, ItemType.Ranged, "SleepyOctopod"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ScourgeoftheCorruptor, ItemType.Ranged, "ScourgeOfTheCorruptor"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ShadowJoustingLance, ItemType.Ranged, "ShadowJoustingLance"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.MonkStaffT3, ItemType.Ranged, "SkyDragon'sFury"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.DayBreak, ItemType.Ranged, "Daybreak"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Zenith, ItemType.Ranged, "Zenith"));
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/MiscellaneousLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/MiscellaneousLoader.cs
@@ -18,7 +18,7 @@ internal class MiscellaneousLoader : ModSystem
 		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.MonkStaffT1, ItemType.Ranged, "SleepyOctopod"));
 		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ScourgeoftheCorruptor, ItemType.Ranged, "ScourgeOfTheCorruptor"));
 		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.ShadowJoustingLance, ItemType.Ranged, "ShadowJoustingLance"));
-		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.MonkStaffT3, ItemType.Ranged, "SkyDragon'sFury"));
+		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.MonkStaffT3, ItemType.Ranged, "SkyDragonsFury"));
 		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.DayBreak, ItemType.Ranged, "Daybreak"));
 		PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(ItemID.Zenith, ItemType.Ranged, "Zenith"));
 	}

--- a/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/SolarEruption.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/SolarEruption.cs
@@ -1,0 +1,23 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class SolarEruption : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.SolarEruption;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		float rotation = (Main.rand.NextFloat() - 0.5f) * ((float)Math.PI / 4f);
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, Main.myPlayer, 0f, rotation);
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/Starlight.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/Starlight.cs
@@ -1,0 +1,23 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Starlight : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.PiercingStarlight;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		float adjustedItemScale7 = player.GetAdjustedItemScale(Item);
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI, 0f, adjustedItemScale7);
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/VampireKnives.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Miscellaneous/VampireKnives.cs
@@ -1,0 +1,56 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class VampireKnives : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.VampireKnives;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		// This code is adapted from vanilla's Player.ItemCheck_Shoot method.
+		// It's a little messy, but this is hard to read and I want to make sure it functions 1:1 or as close as I can get to vanilla.
+		int numShots = 4;
+
+		if (Main.rand.NextBool())
+		{
+			numShots++;
+		}
+
+		for (int i = 2; i <= 4; ++i)
+		{
+			if (Main.rand.NextBool(i * i))
+			{
+				numShots++;
+			}
+		}
+
+		Vector2 pointPoisition = player.RotatedRelativePoint(player.MountedCenter);
+		float baseTargetX = Main.mouseX + Main.screenPosition.X - pointPoisition.X;
+		float baseTargetY = Main.mouseY + Main.screenPosition.Y - pointPoisition.Y;
+
+		for (int i = 0; i < numShots; i++)
+		{
+			float targetX = baseTargetX;
+			float targetY = baseTargetY;
+			float rotationFactor = 1.5f * i;
+			targetX += Main.rand.Next(-35, 36) * rotationFactor;
+			targetY += Main.rand.Next(-35, 36) * rotationFactor;
+			float targetDistance = (float)Math.Sqrt(targetX * targetX + targetY * targetY);
+			targetDistance = Item.shootSpeed / targetDistance;
+			targetX *= targetDistance;
+			targetY *= targetDistance;
+
+			Projectile.NewProjectile(source, pointPoisition.X, pointPoisition.Y, targetX, targetY, type, damage, knockback, Main.myPlayer);
+		}
+
+		return true;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/InstancedVanillaClone.cs
+++ b/Content/Items/Gear/VanillaItems/InstancedVanillaClone.cs
@@ -1,0 +1,32 @@
+﻿using PathOfTerraria.Core;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems;
+
+[ManuallyLoadPoTItem]
+internal class InstancedVanillaClone(short itemId, ItemType itemType, string name) : VanillaClone
+{
+	protected override short VanillaItemId => ItemId;
+	protected override bool CloneNewInstances => true;
+	public override string Name => InstanceName;
+	public override float DropChance => 0f;
+
+	protected string InstanceName = name;
+	protected short ItemId = itemId;
+	protected ItemType InstancedItemType = itemType;
+
+	public override ModItem Clone(Item newEntity)
+	{
+		ModItem clone = base.Clone(newEntity);
+		var inst = (InstancedVanillaClone)clone;
+		inst.ItemId = ItemId;
+		inst.ItemType = ItemType;
+		inst.InstanceName = InstanceName;
+		return clone;
+	}
+
+	public override void Defaults()
+	{
+		ItemType = InstancedItemType;
+		base.Defaults();
+	}
+}

--- a/Content/Items/Gear/VanillaItems/VanillaClone.cs
+++ b/Content/Items/Gear/VanillaItems/VanillaClone.cs
@@ -16,7 +16,14 @@ internal abstract class VanillaClone : Gear
 		base.SetStaticDefaults();
 		GearAlternatives.Register(Type, VanillaItemId);
 	}
-	
+
+	public override void Defaults()
+	{
+		base.Defaults();
+
+		Item.CloneDefaults(VanillaItemId);
+	}
+
 	public override string GeneratePrefix()
 	{
 		return "";

--- a/Content/Items/Gear/Weapons/Boomerangs/WoodenBoomerang.cs
+++ b/Content/Items/Gear/Weapons/Boomerangs/WoodenBoomerang.cs
@@ -1,8 +1,17 @@
-﻿namespace PathOfTerraria.Content.Items.Gear.Weapons.Boomerangs;
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.Weapons.Boomerangs;
 
 internal class WoodenBoomerang : Boomerang
 {
 	public override float DropChance => 1f;
+
+	public override void SetStaticDefaults()
+	{
+		base.SetStaticDefaults();
+
+		GearAlternatives.Register(Type, ItemID.WoodenBoomerang);
+	}
 
 	public override void Defaults()
 	{

--- a/Core/ManuallyLoadPoTItemAttribute.cs
+++ b/Core/ManuallyLoadPoTItemAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace PathOfTerraria.Core;
+
+[AttributeUsage(AttributeTargets.Class)]
+internal class ManuallyLoadPoTItemAttribute : Attribute
+{
+}

--- a/Core/PoTItem.cs
+++ b/Core/PoTItem.cs
@@ -49,8 +49,14 @@ internal class PoTItemMiddleMouseButtonClick : ILoadable
 
 public abstract class PoTItem : ModItem
 {
-	internal static readonly List<Tuple<float, Rarity, Type>> AllItems = [];
 	// <Drop chance, item rarity, type of item>
+	internal static readonly List<Tuple<float, Rarity, Type>> AllItems = [];
+
+	/// <summary>
+	/// Same as above, but should be used through <see cref="ManuallyLoadPoTItem(Mod, PoTItem)"/>.<br/>
+	/// Otherwise, used to append manually-added items through <see cref="Mod.AddContent(ILoadable)"/>.
+	/// </summary>
+	private static readonly List<(float dropChance, Type itemType)> ManuallyLoadedItems = [];
 
 	private static bool _addedDetour;
 
@@ -433,9 +439,10 @@ public abstract class PoTItem : ModItem
 	public static void GenerateItemList()
 	{
 		AllItems.Clear();
+
 		foreach (Type type in PathOfTerraria.Instance.Code.GetTypes())
 		{
-			if (type.IsAbstract || !type.IsSubclassOf(typeof(PoTItem)))
+			if (type.IsAbstract || !type.IsSubclassOf(typeof(PoTItem)) || Attribute.IsDefined(type, typeof(ManuallyLoadPoTItemAttribute)))
 			{
 				continue;
 			}
@@ -457,6 +464,21 @@ public abstract class PoTItem : ModItem
 				AllItems.Add(new(instance.DropChance * 0.05f, Rarity.Rare, type));
 			}
 		}
+
+		foreach ((float dropChance, Type itemType) in ManuallyLoadedItems) 
+		{
+			AllItems.Add(new(dropChance * 0.7f, Rarity.Normal, itemType));
+			AllItems.Add(new(dropChance * 0.25f, Rarity.Magic, itemType));
+			AllItems.Add(new(dropChance * 0.5f, Rarity.Rare, itemType));
+		}
+
+		ManuallyLoadedItems.Clear();
+	}
+
+	public static void ManuallyLoadPoTItem(Mod mod, PoTItem instance)
+	{
+		mod.AddContent(instance);
+		ManuallyLoadedItems.Add((instance.DropChance, instance.GetType()));
 	}
 
 	private const float _magicFindPowerDecrease = 100f;

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -449,11 +449,6 @@ Starlight: {
 	Tooltip: ""
 }
 
-"SkyDragon'sFury": {
-	DisplayName: Sky Dragon's Fury
-	Tooltip: ""
-}
-
 Daybreak: {
 	DisplayName: Daybreak
 	Tooltip: ""
@@ -466,5 +461,85 @@ SolarEruption: {
 
 Zenith: {
 	DisplayName: Zenith
+	Tooltip: ""
+}
+
+Mace: {
+	DisplayName: Mace
+	Tooltip: ""
+}
+
+FlamingMace: {
+	DisplayName: Flaming Mace
+	Tooltip: ""
+}
+
+BallOHurt: {
+	DisplayName: Ball O Hurt
+	Tooltip: ""
+}
+
+TheMeatball: {
+	DisplayName: The Meatball
+	Tooltip: ""
+}
+
+BlueMoon: {
+	DisplayName: Blue Moon
+	Tooltip: ""
+}
+
+Sunfury: {
+	DisplayName: Sunfury
+	Tooltip: ""
+}
+
+ChainKnife: {
+	DisplayName: Chain Knife
+	Tooltip: ""
+}
+
+DripplerCrippler: {
+	DisplayName: Drippler Crippler
+	Tooltip: ""
+}
+
+DaoOfPow: {
+	DisplayName: Dao Of Pow
+	Tooltip: ""
+}
+
+FlowerPow: {
+	DisplayName: Flower Pow
+	Tooltip: ""
+}
+
+Anchor: {
+	DisplayName: Anchor
+	Tooltip: ""
+}
+
+ChainGuillotines: {
+	DisplayName: Chain Guillotines
+	Tooltip: ""
+}
+
+KOCannon: {
+	DisplayName: K O Cannon
+	Tooltip: ""
+}
+
+GolemFist: {
+	DisplayName: Golem Fist
+	Tooltip: ""
+}
+
+Flairon: {
+	DisplayName: Flairon
+	Tooltip: ""
+}
+
+SkyDragonsFury: {
+	DisplayName: Sky Dragon's Fury
 	Tooltip: ""
 }

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -475,7 +475,7 @@ FlamingMace: {
 }
 
 BallOHurt: {
-	DisplayName: Ball O Hurt
+	DisplayName: Ball o' Hurt
 	Tooltip: ""
 }
 
@@ -525,7 +525,7 @@ ChainGuillotines: {
 }
 
 KOCannon: {
-	DisplayName: K O Cannon
+	DisplayName: KO Cannon
 	Tooltip: ""
 }
 

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -398,3 +398,73 @@ PaladinsHammer: {
 	DisplayName: Paladins Hammer
 	Tooltip: ""
 }
+
+Terragrim: {
+	DisplayName: Terragrim
+	Tooltip: ""
+}
+
+Arkhalis: {
+	DisplayName: Arkhalis
+	Tooltip: ""
+}
+
+JoustingLance: {
+	DisplayName: Jousting Lance
+	Tooltip: ""
+}
+
+ShadowFlameKnife: {
+	DisplayName: Shadow Flame Knife
+	Tooltip: ""
+}
+
+HallowedJoustingLance: {
+	DisplayName: Hallowed Jousting Lance
+	Tooltip: ""
+}
+
+SleepyOctopod: {
+	DisplayName: Sleepy Octopod
+	Tooltip: ""
+}
+
+ScourgeOfTheCorruptor: {
+	DisplayName: Scourge of the Corruptor
+	Tooltip: ""
+}
+
+VampireKnives: {
+	DisplayName: Vampire Knives
+	Tooltip: ""
+}
+
+ShadowJoustingLance: {
+	DisplayName: Shadow Jousting Lance
+	Tooltip: ""
+}
+
+Starlight: {
+	DisplayName: Starlight
+	Tooltip: ""
+}
+
+"SkyDragon'sFury": {
+	DisplayName: Sky Dragon's Fury
+	Tooltip: ""
+}
+
+Daybreak: {
+	DisplayName: Daybreak
+	Tooltip: ""
+}
+
+SolarEruption: {
+	DisplayName: Solar Eruption
+	Tooltip: ""
+}
+
+Zenith: {
+	DisplayName: Zenith
+	Tooltip: ""
+}

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -323,3 +323,78 @@ AshWoodSword: {
 	DisplayName: Ash Wood Sword
 	Tooltip: ""
 }
+
+EnchantedBoomerang: {
+	DisplayName: Enchanted Boomerang
+	Tooltip: ""
+}
+
+FruitcakeChakram: {
+	DisplayName: Fruitcake Chakram
+	Tooltip: ""
+}
+
+BloodyMachete: {
+	DisplayName: Bloody Machete
+	Tooltip: ""
+}
+
+Shroomerang: {
+	DisplayName: Shroomerang
+	Tooltip: ""
+}
+
+IceBoomerang: {
+	DisplayName: Ice Boomerang
+	Tooltip: ""
+}
+
+ThornChakram: {
+	DisplayName: Thorn Chakram
+	Tooltip: ""
+}
+
+CombatWrench: {
+	DisplayName: Combat Wrench
+	Tooltip: ""
+}
+
+Trimarang: {
+	DisplayName: Trimarang
+	Tooltip: ""
+}
+
+Flamarang: {
+	DisplayName: Flamarang
+	Tooltip: ""
+}
+
+FlyingKnife: {
+	DisplayName: Flying Knife
+	Tooltip: ""
+}
+
+SergeantUnitedShield: {
+	DisplayName: Sergeant United Shield
+	Tooltip: ""
+}
+
+LightDisc: {
+	DisplayName: Light Disc
+	Tooltip: ""
+}
+
+Bananarang: {
+	DisplayName: Bananarang
+	Tooltip: ""
+}
+
+PossessedHatchet: {
+	DisplayName: Possessed Hatchet
+	Tooltip: ""
+}
+
+PaladinsHammer: {
+	DisplayName: Paladins Hammer
+	Tooltip: ""
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #244 

### Description of Work
Adds in clones for all Boomerangs, Flails, and "Other" (Miscellaneous) weapons.
Added InstancedVanillaClone for manual loading through `Mod.AddContent`.
Added `PoTItem.ManuallyLoadPoTItem` & `PoTItem.ManuallyLoadedItems` to facilitate manually loaded PoTItems without throwing exceptions.

### Comments
