### PR TITLE
replace vanilla w/ alternatives in chests

### DIFF
--- a/Content/Items/Gear/GearAlternatives.cs
+++ b/Content/Items/Gear/GearAlternatives.cs
@@ -1,6 +1,10 @@
 ﻿using System.Collections.Generic;
 using PathOfTerraria.Content.Items.Gear.VanillaItems;
+using PathOfTerraria.Core;
+using PathOfTerraria.Core.Systems.Affixes;
+using PathOfTerraria.Core.Systems.VanillaModifications.BossItemRemovals;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.Gear;
 
@@ -41,6 +45,42 @@ internal class GearAlternativeGlobalItem : GlobalItem
 			if (item.ModItem is VanillaClone)
 			{
 				item.CloneDefaults(GearAlternatives.GearToVanillaAlternative[item.type]);
+			}
+		}
+	}
+}
+
+internal class GearAlternativeChestReplacement : ModSystem
+{
+	public override void PostWorldGen()
+	{
+		foreach (Chest chest in Main.chest)
+		{
+			if (chest is null)
+			{
+				continue;
+			}
+
+			foreach (Item item in chest.item)
+			{
+				if (GearAlternatives.VanillaAlternativeToGear.TryGetValue(item.type, out int value) && !item.IsAir)
+				{
+					item.SetDefaults(value);
+					item.stack = 1;
+
+					if (item.ModItem is PoTItem pot)
+					{
+						pot.Rarity = Rarity.Magic;
+
+						if (WorldGen.genRand.NextBool(10))
+						{
+							pot.Rarity = Rarity.Rare;
+						}
+
+						pot.ClearAffixes();
+						pot.Roll(PoTItem.PickItemLevel());
+					}
+				}
 			}
 		}
 	}

--- a/Core/PoTItem.cs
+++ b/Core/PoTItem.cs
@@ -706,6 +706,11 @@ public abstract class PoTItem : ModItem
 		Affixes.ForEach(n => n.ApplyAffix(entityModifier, this));
 	}
 
+	public void ClearAffixes()
+	{
+		Affixes.Clear();
+	}
+
 	public override void SaveData(TagCompound tag)
 	{
 		tag["type"] = (int)ItemType;

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -323,3 +323,8 @@ AshWoodSword: {
 	DisplayName: Ash Wood Sword
 	Tooltip: ""
 }
+
+FlareGun: {
+	DisplayName: Flare Gun
+	Tooltip: ""
+}

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -95,15 +95,15 @@ DecreasedManaCost: {
 
 AddedCriticalStrikeChance: {
 	Name: Added Critical Strike Chance
-	Tooltip: "Adds 2% flat crit strike chance per level"
+	Tooltip: Adds 2% flat crit strike chance per level
 }
 
 IncreasedCriticalStrikeChance: {
 	Name: Increased Critical Strike Chance
-	Tooltip: "Adds 5% increased crit strike chance per level"
+	Tooltip: Adds 5% increased crit strike chance per level
 }
 
 IncreasedCriticalStrikeMultiplier: {
 	Name: Increased Critical Strike Multiplier
-	Tooltip: "Adds 5% crit strike multipler per level"
+	Tooltip: Adds 5% crit strike multipler per level
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #247

### Description of Work
Replaces all VanillaClones and other items registered in GearAlternatives with their PoTItem clones, with their proper rarity and affixes.

### Comments
On main, there's currently no chest item to replace. Once #257 is replaced, there'll be a few to test with. For this, I just made a Flare Gun alternative and removed it when pushing.