### PR TITLE
fix autoloading issue with manually added PoTItems

### DIFF
--- a/Content/Items/Gear/VanillaItems/InstancedVanillaClone.cs
+++ b/Content/Items/Gear/VanillaItems/InstancedVanillaClone.cs
@@ -9,6 +9,7 @@ internal class InstancedVanillaClone(short itemId, ItemType itemType, string nam
 	protected override bool CloneNewInstances => true;
 	public override string Name => InstanceName;
 	public override float DropChance => 0f;
+	public override bool IsUnique => true;
 
 	protected string InstanceName = name;
 	protected short ItemId = itemId;

--- a/Core/ManuallyLoadPoTItemAttribute.cs
+++ b/Core/ManuallyLoadPoTItemAttribute.cs
@@ -1,6 +1,6 @@
 ﻿namespace PathOfTerraria.Core;
 
-[AttributeUsage(AttributeTargets.Class)]
+[AttributeUsage(AttributeTargets.Class, Inherited = true)]
 internal class ManuallyLoadPoTItemAttribute : Attribute
 {
 }

--- a/Core/PoTItem.cs
+++ b/Core/PoTItem.cs
@@ -49,14 +49,14 @@ internal class PoTItemMiddleMouseButtonClick : ILoadable
 
 public abstract class PoTItem : ModItem
 {
-	// <Drop chance, item rarity, type of item>
-	internal static readonly List<Tuple<float, Rarity, Type>> AllItems = [];
+	// <Drop chance, item rarity, item id of item>
+	internal static readonly List<Tuple<float, Rarity, int>> AllItems = [];
 
 	/// <summary>
 	/// Same as above, but should be used through <see cref="ManuallyLoadPoTItem(Mod, PoTItem)"/>.<br/>
 	/// Otherwise, used to append manually-added items through <see cref="Mod.AddContent(ILoadable)"/>.
 	/// </summary>
-	private static readonly List<(float dropChance, Type itemType)> ManuallyLoadedItems = [];
+	private static readonly List<(float dropChance, int itemId)> ManuallyLoadedItems = [];
 
 	private static bool _addedDetour;
 
@@ -447,25 +447,27 @@ public abstract class PoTItem : ModItem
 				continue;
 			}
 
-			PoTItem instance = (PoTItem)Activator.CreateInstance(type);
+			var instance = (PoTItem)Activator.CreateInstance(type);
+			int id = ModLoader.GetMod(PathOfTerraria.ModName).Find<ModItem>(instance.Name).Type;
 
 			if (instance.IsUnique)
 			{
-				AllItems.Add(new(instance.DropChance, Rarity.Unique, type));
+				AllItems.Add(new(instance.DropChance, Rarity.Unique, id));
 			}
 			else
 			{
+
 				if (!type.IsSubclassOf(typeof(Jewel)))
 				{
-					AllItems.Add(new(instance.DropChance * 0.70f, Rarity.Normal, type));
+					AllItems.Add(new(instance.DropChance * 0.70f, Rarity.Normal, id));
 				}
 
-				AllItems.Add(new(instance.DropChance * 0.25f, Rarity.Magic, type));
-				AllItems.Add(new(instance.DropChance * 0.05f, Rarity.Rare, type));
+				AllItems.Add(new(instance.DropChance * 0.25f, Rarity.Magic, id));
+				AllItems.Add(new(instance.DropChance * 0.05f, Rarity.Rare, id));
 			}
 		}
 
-		foreach ((float dropChance, Type itemType) in ManuallyLoadedItems) 
+		foreach ((float dropChance, int itemType) in ManuallyLoadedItems) 
 		{
 			AllItems.Add(new(dropChance * 0.7f, Rarity.Normal, itemType));
 			AllItems.Add(new(dropChance * 0.25f, Rarity.Magic, itemType));
@@ -478,7 +480,7 @@ public abstract class PoTItem : ModItem
 	public static void ManuallyLoadPoTItem(Mod mod, PoTItem instance)
 	{
 		mod.AddContent(instance);
-		ManuallyLoadedItems.Add((instance.DropChance, instance.GetType()));
+		ManuallyLoadedItems.Add((instance.DropChance, instance.Type));
 	}
 
 	private const float _magicFindPowerDecrease = 100f;


### PR DESCRIPTION
﻿### Link Issues
Resolves: #265 

### Description of Work
Fixes an issue where manually loaded PoTItems, namely InstancedVanillaClones, would throw an error upon using `/spawnitem` in-game due to `Activator.CreateInstance` expecting a parameterless ctor.
Reworked PoTItem.AllItems and all peripheral code to store item by ID instead of by `Type`, so a single `Type` can have more than one item.
Fixed all item spawning code to take an ID instead of a `Type`, and properly cloned the item instead of using `Activator.CreateInstance` with manually loaded items.

### Comments
I did rewrite a good portion of PoTItem's autoloading. This should not change anything as the IoC will do it all automatically, and using `ItemSpawner.GetTypeFromId(int)` will get you the Type from an item ID automatically if needed.