### PR TITLE
add boss tracker for evil bosses

### DIFF
--- a/Core/Systems/BossTracker.cs
+++ b/Core/Systems/BossTracker.cs
@@ -1,0 +1,44 @@
+﻿using Terraria.ID;
+using Terraria.ModLoader.IO;
+
+namespace PathOfTerraria.Core.Systems;
+
+internal class BossTracker : ModSystem
+{
+	public static bool DownedEaterOfWorlds = false;
+	public static bool DownedBrainOfCthulhu = false;
+
+	public override void SaveWorldData(TagCompound tag)
+	{
+		tag.Add(nameof(DownedEaterOfWorlds), DownedEaterOfWorlds);
+		tag.Add(nameof(DownedBrainOfCthulhu), DownedBrainOfCthulhu);
+	}
+
+	public override void LoadWorldData(TagCompound tag)
+	{
+		DownedEaterOfWorlds = tag.GetBool(nameof(DownedEaterOfWorlds));
+		DownedBrainOfCthulhu = tag.GetBool(nameof(DownedBrainOfCthulhu));
+	}
+
+	public class BossTrackerNPC : GlobalNPC
+	{
+		public override void OnKill(NPC npc)
+		{
+			if (npc.type == NPCID.EaterofWorldsHead && NPC.CountNPCS(NPCID.EaterofWorldsBody) == 0)
+			{
+				// EoW is dumb and won't register as a boss before death so this is the workaround
+				DownedEaterOfWorlds = true;
+			}
+
+			if (!npc.boss)
+			{
+				return;
+			}
+
+			if (npc.type == NPCID.BrainofCthulhu)
+			{
+				DownedBrainOfCthulhu = true;
+			}
+		}
+	}
+}

--- a/Core/Systems/BossTracker.cs
+++ b/Core/Systems/BossTracker.cs
@@ -6,31 +6,29 @@ namespace PathOfTerraria.Core.Systems;
 
 internal class BossTracker : ModSystem
 {
-	public static bool DownedEaterOfWorlds = false;
-	public static bool DownedBrainOfCthulhu = false;
+	public static BitsByte DownedFlags = new();
+
+	public static bool DownedEaterOfWorlds { get => DownedFlags[0]; set => DownedFlags[0] = value; }
+	public static bool DownedBrainOfCthulhu { get => DownedFlags[1]; set => DownedFlags[1] = value; }
 
 	public override void SaveWorldData(TagCompound tag)
 	{
-		tag.Add(nameof(DownedEaterOfWorlds), DownedEaterOfWorlds);
-		tag.Add(nameof(DownedBrainOfCthulhu), DownedBrainOfCthulhu);
+		tag.Add(nameof(DownedFlags), (byte)DownedFlags);
 	}
 
 	public override void LoadWorldData(TagCompound tag)
 	{
-		DownedEaterOfWorlds = tag.GetBool(nameof(DownedEaterOfWorlds));
-		DownedBrainOfCthulhu = tag.GetBool(nameof(DownedBrainOfCthulhu));
+		DownedFlags = tag.GetByte(nameof(DownedFlags));
 	}
 
 	public override void NetSend(BinaryWriter writer)
 	{
-		writer.Write(DownedEaterOfWorlds);
-		writer.Write(DownedBrainOfCthulhu);
+		writer.Write((byte)DownedFlags);
 	}
 
 	public override void NetReceive(BinaryReader reader)
 	{
-		DownedEaterOfWorlds = reader.ReadBoolean();
-		DownedBrainOfCthulhu = reader.ReadBoolean();
+		DownedFlags = reader.ReadByte();
 	}
 
 	public class BossTrackerNPC : GlobalNPC

--- a/Core/Systems/BossTracker.cs
+++ b/Core/Systems/BossTracker.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ID;
+﻿using System.IO;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Core.Systems;
@@ -20,6 +21,18 @@ internal class BossTracker : ModSystem
 		DownedBrainOfCthulhu = tag.GetBool(nameof(DownedBrainOfCthulhu));
 	}
 
+	public override void NetSend(BinaryWriter writer)
+	{
+		writer.Write(DownedEaterOfWorlds);
+		writer.Write(DownedBrainOfCthulhu);
+	}
+
+	public override void NetReceive(BinaryReader reader)
+	{
+		DownedEaterOfWorlds = reader.ReadBoolean();
+		DownedBrainOfCthulhu = reader.ReadBoolean();
+	}
+
 	public class BossTrackerNPC : GlobalNPC
 	{
 		public override void OnKill(NPC npc)
@@ -28,6 +41,11 @@ internal class BossTracker : ModSystem
 			{
 				// EoW is dumb and won't register as a boss before death so this is the workaround
 				DownedEaterOfWorlds = true;
+
+				if (Main.netMode != NetmodeID.SinglePlayer)
+				{
+					NetMessage.SendData(MessageID.WorldData);
+				}
 			}
 
 			if (!npc.boss)
@@ -38,6 +56,11 @@ internal class BossTracker : ModSystem
 			if (npc.type == NPCID.BrainofCthulhu)
 			{
 				DownedBrainOfCthulhu = true;
+
+				if (Main.netMode != NetmodeID.SinglePlayer)
+				{
+					NetMessage.SendData(MessageID.WorldData);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #281 

### Description of Work
Adds in `BossTracker.DownedEaterOfWorlds` and `DownedBrainOfCthulhu` flags. It also syncs these automatically in multiplayer.

### Comments
