### PR TITLE
Ranged weapon clones

### DIFF
--- a/Content/Items/Gear/VanillaItems/Clones/Bows/AerialBane.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/AerialBane.cs
@@ -1,0 +1,19 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class AerialBane : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.DD2BetsyBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		type = ProjectileID.DD2BetsyArrow;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/BloodRainBow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/BloodRainBow.cs
@@ -1,0 +1,67 @@
+﻿using System.Drawing;
+using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class BloodRainBow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.BloodRainBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		player.itemRotation = (Main.MouseWorld.X - player.Center.X) / 2000f - MathHelper.PiOver2 * player.direction;
+
+		NetMessage.SendData(MessageID.PlayerControls, -1, -1, null, player.whoAmI);
+		NetMessage.SendData(MessageID.ShotAnimationAndSound, -1, -1, null, player.whoAmI);
+
+		int projCount = Main.rand.Next(1, 3);
+
+		if (Main.rand.NextBool(3))
+		{
+			projCount++;
+		}
+
+		for (int l = 0; l < projCount; l++)
+		{
+			float baseX = position.X + player.width * 0.5f + Main.rand.Next(61) * -player.direction + (Main.MouseWorld.X - position.X);
+			var pos = new Vector2(baseX, player.MountedCenter.Y - 600f);
+			pos.X = (pos.X * 10f + player.Center.X) / 11f + Main.rand.Next(-30, 31);
+			pos.Y -= 150f * Main.rand.NextFloat();
+
+			Vector2 useVel = velocity;
+			useVel.X = Main.mouseX + Main.screenPosition.X - pos.X;
+			useVel.Y = Main.mouseY + Main.screenPosition.Y - pos.Y;
+
+			if (useVel.Y < 0f)
+			{
+				useVel.Y *= -1f;
+			}
+
+			if (useVel.Y < 20f)
+			{
+				useVel.Y = 20f;
+			}
+
+			float magnitude = useVel.Length();
+			magnitude = Item.shootSpeed / magnitude;
+			useVel.X *= magnitude;
+			useVel.Y *= magnitude;
+			float xVel = useVel.X + Main.rand.Next(-20, 21) * 0.03f;
+			float yVel = useVel.Y + Main.rand.Next(-40, 41) * 0.03f;
+			xVel *= Main.rand.Next(55, 80) * 0.01f;
+			pos.X += Main.rand.Next(-50, 51);
+
+			int proj = Projectile.NewProjectile(source, pos.X, pos.Y, xVel, yVel, ProjectileID.BloodArrow, damage, knockback, Main.myPlayer);
+			Main.projectile[proj].noDropItem = true;
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/BowLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/BowLoader.cs
@@ -1,0 +1,44 @@
+﻿using PathOfTerraria.Core;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class BowLoader : ModSystem
+{
+	public override void Load()
+	{
+		// Prehardmode
+		LoadBow(ItemID.BorealWoodBow, "BorealWoodBow");
+		LoadBow(ItemID.CopperBow, "CopperBow");
+		LoadBow(ItemID.PalmWoodBow, "PalmWoodBow");
+		LoadBow(ItemID.RichMahoganyBow, "RichMahoganyBow");
+		LoadBow(ItemID.TinBow, "TinBow");
+		LoadBow(ItemID.EbonwoodBow, "EbonwoodBow");
+		LoadBow(ItemID.IronBow, "IronBow");
+		LoadBow(ItemID.ShadewoodBow, "ShadewoodBow");
+		LoadBow(ItemID.LeadBow, "LeadBow");
+		LoadBow(ItemID.SilverBow, "SilverBow");
+		LoadBow(ItemID.TungstenBow, "TungstenBow");
+		LoadBow(ItemID.AshWoodBow, "AshWoodBow");
+		LoadBow(ItemID.GoldBow, "GoldBow");
+		LoadBow(ItemID.PlatinumBow, "PlatinumBow");
+		LoadBow(ItemID.DemonBow, "DemonBow");
+		LoadBow(ItemID.TendonBow, "TendonBow");
+
+		// Hardmode
+		LoadBow(ItemID.PearlwoodBow, "PearlwoodBow");
+		LoadBow(ItemID.CobaltRepeater, "CobaltRepeater");
+		LoadBow(ItemID.PalladiumRepeater, "PalladiumRepeater");
+		LoadBow(ItemID.MythrilRepeater, "MythrilRepeater");
+		LoadBow(ItemID.OrichalcumRepeater, "OrichalcumRepeater");
+		LoadBow(ItemID.AdamantiteRepeater, "AdamantiteRepeater");
+		LoadBow(ItemID.TitaniumRepeater, "TitaniumRepeater");
+		LoadBow(ItemID.HallowedRepeater, "HallowedRepeater");
+		LoadBow(ItemID.StakeLauncher, "StakeLauncher");
+
+		void LoadBow(short itemId, string name)
+		{
+			PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(itemId, ItemType.Ranged, name));
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/ChloropyteShotbow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/ChloropyteShotbow.cs
@@ -1,0 +1,42 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class ChlorophyteShotbow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.ChlorophyteShotbow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		int projCount = 2;
+
+		if (Main.rand.NextBool(3))
+		{
+			projCount++;
+		}
+
+		for (int i = 0; i < projCount; i++)
+		{
+			float velX = velocity.X;
+			float velY = velocity.Y;
+
+			for (int j = -1; j < i; ++j)
+			{
+				velX += Main.rand.Next(-35, 36) * 0.04f;
+				velY += Main.rand.Next(-35, 36) * 0.04f;
+			}
+
+			int proj = Projectile.NewProjectile(source, position.X, position.Y, velX, velY, type, damage, knockback, player.whoAmI);
+			Main.projectile[proj].noDropItem = true;
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/DaedalusStormbow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/DaedalusStormbow.cs
@@ -1,0 +1,70 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class DaedalusStormbow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.DaedalusStormbow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		player.itemRotation = (Main.MouseWorld.X - player.Center.X) / 2000f - MathHelper.PiOver2 * player.direction;
+
+		NetMessage.SendData(MessageID.PlayerControls, -1, -1, null, player.whoAmI);
+		NetMessage.SendData(MessageID.ShotAnimationAndSound, -1, -1, null, player.whoAmI);
+
+		int projectileCount = 3;
+
+		if (type == ProjectileID.HolyArrow || type == ProjectileID.UnholyArrow || type == ProjectileID.JestersArrow || type == ProjectileID.HellfireArrow)
+		{
+			if (Main.rand.NextBool(3))
+			{
+				projectileCount--;
+			}
+		}
+		else if (Main.rand.NextBool(3))
+		{
+			projectileCount++;
+		}
+
+		for (int k = 0; k < projectileCount; k++)
+		{
+			float baseX = position.X + player.width * 0.5f + Main.rand.Next(201) * -player.direction + (Main.MouseWorld.X - position.X);
+			Vector2 basePos = new Vector2(baseX, player.MountedCenter.Y - 600f);
+			basePos.X = (basePos.X * 10f + player.Center.X) / 11f + Main.rand.Next(-100, 101);
+			basePos.Y -= 150 * k;
+			velocity.X = Main.mouseX + Main.screenPosition.X - basePos.X;
+			velocity.Y = Main.mouseY + Main.screenPosition.Y - basePos.Y;
+
+			if (velocity.Y < 0f)
+			{
+				velocity.Y *= -1f;
+			}
+
+			if (velocity.Y < 20f)
+			{
+				velocity.Y = 20f;
+			}
+
+			float magnitude = velocity.Length();
+			magnitude = Item.shootSpeed / magnitude;
+			velocity.X *= magnitude;
+			velocity.Y *= magnitude;
+			float velX = velocity.X + Main.rand.Next(-40, 41) * 0.03f;
+			float velY = velocity.Y + Main.rand.Next(-40, 41) * 0.03f;
+			velX *= Main.rand.Next(75, 150) * 0.01f;
+			basePos.X += Main.rand.Next(-50, 51);
+			int proj = Projectile.NewProjectile(source, basePos.X, basePos.Y, velX, velY, type, damage, knockback, Main.myPlayer);
+			Main.projectile[proj].noDropItem = true;
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/Eventide.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/Eventide.cs
@@ -1,0 +1,78 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class Eventide : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.FairyQueenRangedItem;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.WoodenArrowFriendly)
+		{
+			type = ProjectileID.FairyQueenRangedItemShot;
+		}
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		const float PiOver10 = (float)Math.PI / 10f;
+
+		Vector2 baseVelocity = Vector2.Normalize(velocity) * 40;
+		bool inTiles = Collision.CanHit(position, 0, 0, position + baseVelocity, 0, 0);
+		int timer = (player.itemAnimationMax - player.itemAnimation) / 2;
+		int baseRotation = timer;
+
+		if (player.direction == 1)
+		{
+			baseRotation = 4 - timer;
+		}
+
+		float rotation = baseRotation - (5 - 1f) / 2f;
+		Vector2 vector16 = baseVelocity.RotatedBy(PiOver10 * rotation);
+
+		if (!inTiles)
+		{
+			vector16 -= baseVelocity;
+		}
+
+		Vector2 origin = position + vector16;
+		Vector2 velocityMod = origin.DirectionTo(Main.MouseWorld).SafeNormalize(-Vector2.UnitY);
+		Vector2 adjustedTarget = player.Center.DirectionTo(player.Center + baseVelocity).SafeNormalize(-Vector2.UnitY);
+		float lerpValue = Utils.GetLerpValue(100f, 40f, Main.MouseWorld.Distance(player.Center), clamped: true);
+
+		if (lerpValue > 0f)
+		{
+			velocityMod = Vector2.Lerp(velocityMod, adjustedTarget, lerpValue).SafeNormalize(velocity.SafeNormalize(-Vector2.UnitY));
+		}
+
+		Vector2 finalVelocity = velocityMod * Item.shootSpeed;
+
+		if (timer == 2)
+		{
+			type = ProjectileID.FairyQueenRangedItemShot;
+			damage *= 2;
+		}
+
+		if (type == ProjectileID.FairyQueenRangedItemShot)
+		{
+			float ai3 = player.miscCounterNormalized * 12f % 1f;
+			finalVelocity = finalVelocity.SafeNormalize(Vector2.Zero) * (Item.shootSpeed * 2f);
+			Projectile.NewProjectile(source, origin, finalVelocity, type, damage, knockback, player.whoAmI, 0f, ai3);
+		}
+		else
+		{
+			int proj = Projectile.NewProjectile(source, origin, finalVelocity, type, damage, knockback, player.whoAmI);
+			Main.projectile[proj].noDropItem = true;
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/HellwingBow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/HellwingBow.cs
@@ -1,0 +1,40 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class HellwingBow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.HellwingBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.WoodenArrowFriendly)
+		{
+			type = ProjectileID.Hellwing;
+		}
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		Vector2 baseVelocity = velocity;
+		float magnitude = baseVelocity.Length();
+		baseVelocity.X += Main.rand.Next(-100, 101) * 0.01f * magnitude * 0.15f;
+		baseVelocity.Y += Main.rand.Next(-100, 101) * 0.01f * magnitude * 0.15f;
+		float velX = velocity.X + Main.rand.Next(-40, 41) * 0.03f;
+		float velY = velocity.Y + Main.rand.Next(-40, 41) * 0.03f;
+		baseVelocity = Vector2.Normalize(baseVelocity) * magnitude;
+		velX *= Main.rand.Next(50, 150) * 0.01f;
+		velY *= Main.rand.Next(50, 150) * 0.01f;
+		Vector2 finalVel = Vector2.Normalize(new Vector2(velX + Main.rand.Next(-100, 101) * 0.025f, velY + Main.rand.Next(-100, 101) * 0.025f)) * magnitude;
+		Projectile.NewProjectile(source, position.X, position.Y, finalVel.X, finalVel.Y, type, damage, knockback, player.whoAmI, baseVelocity.X, baseVelocity.Y);
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/IceBow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/IceBow.cs
@@ -1,0 +1,19 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class IceBow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.IceBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		type = ProjectileID.FrostArrow;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/Marrow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/Marrow.cs
@@ -1,0 +1,22 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class Marrow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Marrow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.WoodenArrowFriendly)
+		{
+			type = ProjectileID.BoneArrow;
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/MoltenFury.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/MoltenFury.cs
@@ -1,0 +1,23 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class MoltenFury : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.MoltenFury;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.WoodenArrowFriendly)
+		{
+			type = ProjectileID.FireArrow;
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/Phantasm.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/Phantasm.cs
@@ -1,0 +1,26 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class Phantasm : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Phantasm;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, ProjectileID.Phantasm, damage, knockback, player.whoAmI);
+		return false;
+	}
+
+	public override bool CanConsumeAmmo(Item ammo, Player player)
+	{
+		return !Main.rand.NextBool(3);
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/PhantomPhoenix.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/PhantomPhoenix.cs
@@ -1,0 +1,21 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class PhantomPhoenix : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.DD2PhoenixBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, ProjectileID.DD2PhoenixBow, damage, knockback, player.whoAmI);
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/PulseBow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/PulseBow.cs
@@ -1,0 +1,19 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class PulseBow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.PulseBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		type = ProjectileID.PulseBolt;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/ShadowflameBow.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/ShadowflameBow.cs
@@ -1,0 +1,19 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class ShadowflameBow : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.ShadowFlameBow;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		type = ProjectileID.ShadowFlameArrow;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/TheBeesKnees.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/TheBeesKnees.cs
@@ -1,0 +1,22 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class TheBeesKnees : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.BeesKnees;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.WoodenArrowFriendly)
+		{
+			type = ProjectileID.BeeArrow;
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Bows/Tsunami.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Bows/Tsunami.cs
@@ -1,0 +1,40 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Bows;
+
+internal class Tsunami : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Tsunami;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Ranged;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 vel, int type, int damage, float knockback)
+	{
+		const int ShotCount = 5;
+
+		float num128 = (float)Math.PI / 10f;
+		Vector2 baseOffset = Vector2.Normalize(vel) * 40f;
+		bool inTiles = Collision.CanHit(position, 0, 0, position + baseOffset, 0, 0);
+
+		for (int i = 0; i < ShotCount; i++)
+		{
+			float rotation = i - (ShotCount - 1f) / 2f;
+			Vector2 posOffset = baseOffset.RotatedBy(num128 * rotation);
+
+			if (!inTiles)
+			{
+				posOffset -= baseOffset;
+			}
+
+			int proj = Projectile.NewProjectile(source, position.X + posOffset.X, position.Y + posOffset.Y, vel.X, vel.Y, type, damage, knockback, Main.myPlayer);
+			Main.projectile[proj].noDropItem = true;
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Boomstick.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Boomstick.cs
@@ -1,0 +1,30 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Boomstick : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Boomstick;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		int projCount = Main.rand.Next(3, 5);
+
+		for (int i = 0; i < projCount; i++)
+		{
+			Vector2 useVel = velocity;
+			useVel.X += Main.rand.Next(-35, 36) * 0.04f;
+			useVel.Y += Main.rand.Next(-35, 36) * 0.04f;
+			Projectile.NewProjectile(source, position.X, position.Y, useVel.X, useVel.Y, type, damage, knockback, player.whoAmI);
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/ChainGun.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/ChainGun.cs
@@ -1,0 +1,43 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class ChainGun : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.ChainGun;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		float speed = velocity.Length();
+
+		if (float.IsNaN(velocity.X) && float.IsNaN(velocity.Y) || velocity.X == 0f && velocity.Y == 0f)
+		{
+			velocity.X = player.direction;
+			velocity.Y = 0f;
+			speed = Item.shootSpeed;
+		}
+		else
+		{
+			speed = Item.shootSpeed / speed;
+		}
+
+		velocity.X += Main.rand.Next(-50, 51) * 0.03f / speed;
+		velocity.Y += Main.rand.Next(-50, 51) * 0.03f / speed;
+
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		return false;
+	}
+
+	public override bool CanConsumeAmmo(Item ammo, Player player)
+	{
+		return Main.rand.NextBool(2);
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Gatligator.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Gatligator.cs
@@ -1,0 +1,38 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Gatligator : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Gatligator;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		float speed = velocity.Length();
+
+		if (float.IsNaN(velocity.X) && float.IsNaN(velocity.Y) || velocity.X == 0f && velocity.Y == 0f)
+		{
+			velocity.X = player.direction;
+			velocity.Y = 0f;
+			speed = Item.shootSpeed;
+		}
+		else
+		{
+			speed = Item.shootSpeed / speed;
+		}
+
+		velocity.X += Main.rand.Next(-50, 51) * 0.03f / speed;
+		velocity.Y += Main.rand.Next(-50, 51) * 0.03f / speed;
+
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/GunsLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/GunsLoader.cs
@@ -1,0 +1,28 @@
+﻿using PathOfTerraria.Core;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Guns;
+
+internal class GunsLoader : ModSystem
+{
+	public override void Load()
+	{
+		// Prehardmode
+		LoadGun(ItemID.RedRyder, "RedRyder");
+		LoadGun(ItemID.FlintlockPistol, "FlintlockPistol");
+		LoadGun(ItemID.Musket, "Musket");
+		LoadGun(ItemID.TheUndertaker, "TheUndertaker");
+		LoadGun(ItemID.Revolver, "Revolver");
+		LoadGun(ItemID.Handgun, "Handgun");
+		LoadGun(ItemID.PhoenixBlaster, "PhoenixBlaster");
+
+		// Hardmode
+		LoadGun(ItemID.ClockworkAssaultRifle, "ClockworkAssaultRifle");
+		LoadGun(ItemID.CandyCornRifle, "CandyCornRifle");
+
+		void LoadGun(short itemId, string name)
+		{
+			PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(itemId, ItemType.Ranged, name));
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Megashark.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Megashark.cs
@@ -1,0 +1,29 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Megashark : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Megashark;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		velocity.X += Main.rand.Next(-40, 41) * 0.01f;
+		velocity.Y += Main.rand.Next(-40, 41) * 0.01f;
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		return false;
+	}
+
+	public override bool CanConsumeAmmo(Item ammo, Player player)
+	{
+		return Main.rand.NextBool(2);
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Minishark.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Minishark.cs
@@ -1,0 +1,29 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Minishark : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Minishark;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		velocity.X += Main.rand.Next(-40, 41) * 0.01f;
+		velocity.Y += Main.rand.Next(-40, 41) * 0.01f;
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		return false;
+	}
+
+	public override bool CanConsumeAmmo(Item ammo, Player player)
+	{
+		return !Main.rand.NextBool(3);
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/OnyxBlaster.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/OnyxBlaster.cs
@@ -1,0 +1,33 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class OnyxBlaster : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.OnyxBlaster;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 pos, Vector2 vel, int type, int damage, float knockback)
+	{
+		const float OneFourthPi = MathHelper.PiOver4;
+
+		for (int num82 = 0; num82 < 2; num82++)
+		{
+			Vector2 firstVel = vel + vel.SafeNormalize(Vector2.Zero).RotatedBy(OneFourthPi * Main.rand.NextFloat(0.5f, 1f)) * Main.rand.NextFloatDirection() * 2f;
+			Projectile.NewProjectile(source, pos, firstVel, type, damage, knockback, player.whoAmI);
+
+			Vector2 secondVel = vel + vel.SafeNormalize(Vector2.Zero).RotatedBy(-OneFourthPi * Main.rand.NextFloat(0.5f, 1f)) * Main.rand.NextFloatDirection() * 2f;
+			Projectile.NewProjectile(source, pos, secondVel, type, damage, knockback, player.whoAmI);
+		}
+
+		Vector2 onyxVel = vel.SafeNormalize(Vector2.UnitX * player.direction) * (Item.shootSpeed * 1.3f);
+		Projectile.NewProjectile(source, pos, onyxVel, ProjectileID.BlackBolt, damage * 2, knockback, Main.myPlayer);
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/PewMaticHorn.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/PewMaticHorn.cs
@@ -1,0 +1,35 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class PewMaticHorn : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.PewMaticHorn;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		type = ProjectileID.PewMaticHornShot;
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		velocity.X += Main.rand.Next(-15, 16) * 0.075f;
+		velocity.Y += Main.rand.Next(-15, 16) * 0.075f;
+		int frame = Main.rand.Next(Main.projFrames[Item.shoot]);
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI, 0f, frame);
+
+		return false;
+	}
+
+	public override Vector2? HoldoutOffset()
+	{
+		return new Vector2(2, 0);
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/QuadBarrelShotgun.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/QuadBarrelShotgun.cs
@@ -1,0 +1,35 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class QuadBarrelShotgun : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.QuadBarrelShotgun;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		for (int i = 0; i < 7; i++)
+		{
+			Vector2 adjustedVelocity = velocity;
+			float magnitude = adjustedVelocity.Length();
+			adjustedVelocity += adjustedVelocity.SafeNormalize(Vector2.Zero).RotatedBy(MathHelper.PiOver2 * Main.rand.NextFloat()) * Main.rand.NextFloatDirection() * 5f;
+			adjustedVelocity = adjustedVelocity.SafeNormalize(Vector2.Zero) * magnitude;
+			float useVelX = adjustedVelocity.X;
+			float useVelY = adjustedVelocity.Y;
+			useVelX += Main.rand.Next(-40, 41) * 0.05f;
+			useVelY += Main.rand.Next(-40, 41) * 0.05f;
+			Projectile.NewProjectile(source, position.X, position.Y, useVelX, useVelY, type, damage, knockback, player.whoAmI);
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/SDMG.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/SDMG.cs
@@ -1,0 +1,29 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class SDMG : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.SDMG;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		velocity.X += Main.rand.Next(-40, 41) * 0.01f;
+		velocity.Y += Main.rand.Next(-40, 41) * 0.01f;
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		return false;
+	}
+
+	public override bool CanConsumeAmmo(Item ammo, Player player)
+	{
+		return Main.rand.NextBool(3);
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Shotgun.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Shotgun.cs
@@ -1,0 +1,30 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Shotgun : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Shotgun;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		int projCount = Main.rand.Next(4, 6);
+
+		for (int i = 0; i < projCount; i++)
+		{
+			Vector2 useVel = velocity;
+			useVel.X += Main.rand.Next(-40, 41) * 0.05f;
+			useVel.Y += Main.rand.Next(-40, 41) * 0.05f;
+			Projectile.NewProjectile(source, position.X, position.Y, useVel.X, useVel.Y, type, damage, knockback, player.whoAmI);
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/SniperRifle.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/SniperRifle.cs
@@ -1,0 +1,29 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class SniperRifle : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.SniperRifle;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.Bullet)
+		{
+			type = ProjectileID.BulletHighVelocity;
+		}
+	}
+
+	public override void HoldItem(Player player)
+	{
+		base.HoldItem(player);
+
+		player.scope = true;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/TacticalShotgun.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/TacticalShotgun.cs
@@ -1,0 +1,28 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class TacticalShotgun : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.TacticalShotgun;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		for (int i = 0; i < 6; i++)
+		{
+			Vector2 useVel = velocity;
+			useVel.X += Main.rand.Next(-40, 41) * 0.05f;
+			useVel.Y += Main.rand.Next(-40, 41) * 0.05f;
+			Projectile.NewProjectile(source, position.X, position.Y, useVel.X, useVel.Y, type, damage, knockback, player.whoAmI);
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Uzi.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Uzi.cs
@@ -1,0 +1,32 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Uzi : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Uzi;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.Bullet)
+		{
+			type = ProjectileID.BulletHighVelocity;
+		}
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		velocity.X += Main.rand.Next(-30, 31) * 0.03f;
+		velocity.Y += Main.rand.Next(-30, 31) * 0.03f;
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, player.whoAmI);
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/VenusMagnum.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/VenusMagnum.cs
@@ -1,0 +1,22 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class VenusMagnum : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.VenusMagnum;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (type == ProjectileID.Bullet)
+		{
+			type = ProjectileID.BulletHighVelocity;
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/VortexBeater.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/VortexBeater.cs
@@ -1,0 +1,21 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class VortexBeater : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.VortexBeater;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, ProjectileID.VortexBeater, damage, knockback, player.whoAmI, 5 * Main.rand.Next(0, 20));
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Guns/Xenopopper.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Guns/Xenopopper.cs
@@ -1,0 +1,46 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Xenopopper : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Xenopopper;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		Vector2 tipOfGun = Vector2.Normalize(velocity) * 40f * Item.scale;
+
+		if (Collision.CanHit(position, 0, 0, position + tipOfGun, 0, 0))
+		{
+			position += tipOfGun;
+		}
+
+		const float TwoThirdsPi = (float)Math.PI * 2f / 3f;
+
+		float ai = velocity.ToRotation();
+		int shotCount = Main.rand.Next(4, 5);
+
+		if (Main.rand.NextBool(4))
+		{
+			shotCount++;
+		}
+
+		for (int i = 0; i < shotCount; i++)
+		{
+			float speedMod = (float)Main.rand.NextDouble() * 0.2f + 0.05f;
+			Vector2 useVel = velocity.RotatedBy(TwoThirdsPi * (float)Main.rand.NextDouble() - TwoThirdsPi / 2f) * speedMod;
+			int num108 = Projectile.NewProjectile(source, position.X, position.Y, useVel.X, useVel.Y, ProjectileID.Xenopopper, damage, knockback, player.whoAmI, ai);
+			Main.projectile[num108].localAI[0] = type;
+			Main.projectile[num108].localAI[1] = Item.shootSpeed;
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Launchers/Celebration.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Launchers/Celebration.cs
@@ -1,0 +1,29 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class Celebration : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.FireworksLauncher;
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		for (int i = 0; i < 2; i++)
+		{
+			Vector2 useVel = velocity;
+			useVel.X += Main.rand.Next(-40, 41) * 0.05f;
+			useVel.Y += Main.rand.Next(-40, 41) * 0.05f;
+			Vector2 adjPos = position + Vector2.Normalize(useVel.RotatedBy(-(float)Math.PI / 2f * player.direction)) * 6f;
+			Projectile.NewProjectile(source, adjPos.X, adjPos.Y, useVel.X, useVel.Y, 167 + Main.rand.Next(4), damage, knockback, player.whoAmI, 0f, 1f);
+		}
+
+		return false;
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Launchers/CelebrationMK2.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Launchers/CelebrationMK2.cs
@@ -1,0 +1,54 @@
+﻿using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Miscellaneous;
+
+internal class CelebrationMK2 : VanillaClone
+{
+	protected override short VanillaItemId => ItemID.Celeb2;
+
+	public override void Load()
+	{
+		On_Projectile.AI += HijackTypeDuringAI;
+	}
+
+	private void HijackTypeDuringAI(On_Projectile.orig_AI orig, Projectile self)
+	{
+		// The vanilla projectile chooses ammo based on the held weapon.
+		// This is an issue for the clone, which is not the normal Celeb2 weapon.
+		// This makes it Celeb2 during AI, so it fires properly, then unsets it.
+
+		bool isHoldingClone = self.type == ProjectileID.Celeb2Weapon && Main.player[self.owner].HeldItem.type == ModContent.ItemType<CelebrationMK2>();
+
+		if (isHoldingClone)
+		{
+			Main.player[self.owner].HeldItem.type = ItemID.Celeb2;
+		}
+
+		orig(self);
+
+		if (isHoldingClone)
+		{
+			Main.player[self.owner].HeldItem.type = ModContent.ItemType<CelebrationMK2>();
+		}
+	}
+
+	public override void Defaults()
+	{
+		ItemType = Core.ItemType.Melee;
+		base.Defaults();
+	}
+
+	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		int subId = 5 * Main.rand.Next(0, 20);
+		Projectile.NewProjectile(source, position.X, position.Y, velocity.X, velocity.Y, ProjectileID.Celeb2Weapon, damage, knockback, player.whoAmI, subId);
+		return false;
+	}
+
+	public override bool CanConsumeAmmo(Item ammo, Player player)
+	{
+		return Main.rand.NextBool();
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Launchers/LauncherLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Launchers/LauncherLoader.cs
@@ -1,0 +1,25 @@
+﻿using PathOfTerraria.Core;
+using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Launchers;
+
+internal class LauncherLoader : ModSystem
+{
+	public override void Load()
+	{
+		LoadLauncher(ItemID.GrenadeLauncher, "GrenadeLauncher");
+		LoadLauncher(ItemID.ProximityMineLauncher, "ProximityMineLauncher");
+		LoadLauncher(ItemID.RocketLauncher, "RocketLauncher");
+		LoadLauncher(ItemID.NailGun, "NailGun");
+		LoadLauncher(ItemID.Stynger, "Stynger");
+		LoadLauncher(ItemID.JackOLanternLauncher, "JackOLanternLauncher");
+		LoadLauncher(ItemID.SnowmanCannon, "SnowmanCannon");
+		LoadLauncher(ItemID.ElectrosphereLauncher, "ElectrosphereLauncher");
+		LoadLauncher(ItemID.Celeb2, "CelebrationMK2");
+
+		void LoadLauncher(short itemId, string name)
+		{
+			PoTItem.ManuallyLoadPoTItem(Mod, new InstancedVanillaClone(itemId, ItemType.Ranged, name));
+		}
+	}
+}

--- a/Content/Items/Gear/VanillaItems/Clones/Launchers/LauncherLoader.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Launchers/LauncherLoader.cs
@@ -15,7 +15,6 @@ internal class LauncherLoader : ModSystem
 		LoadLauncher(ItemID.JackOLanternLauncher, "JackOLanternLauncher");
 		LoadLauncher(ItemID.SnowmanCannon, "SnowmanCannon");
 		LoadLauncher(ItemID.ElectrosphereLauncher, "ElectrosphereLauncher");
-		LoadLauncher(ItemID.Celeb2, "CelebrationMK2");
 
 		void LoadLauncher(short itemId, string name)
 		{

--- a/Content/Items/Gear/VanillaItems/VanillaClone.cs
+++ b/Content/Items/Gear/VanillaItems/VanillaClone.cs
@@ -42,7 +42,13 @@ internal abstract class VanillaClone : Gear
 	{
 		CloneRecipes(VanillaItemId, Type);
 	}
-	
+
+	// Disable alt function use by default since most vanilla clones don't have alt uses
+	public override bool AltFunctionUse(Player player)
+	{
+		return false;
+	}
+
 	/// <summary>
 	/// Clones the original item's recipes to the new item.
 	/// </summary>

--- a/Content/Items/Gear/Weapons/Bow/WoodenBow.cs
+++ b/Content/Items/Gear/Weapons/Bow/WoodenBow.cs
@@ -1,8 +1,17 @@
-﻿namespace PathOfTerraria.Content.Items.Gear.Weapons.Bow;
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Content.Items.Gear.Weapons.Bow;
 
 internal class WoodenBow : Bow
 {
 	public override float DropChance => 1f;
+
+	public override void SetStaticDefaults()
+	{
+		base.SetStaticDefaults();
+
+		GearAlternatives.Register(Type, ItemID.WoodenBow);
+	}
 
 	public override void Defaults()
 	{

--- a/Content/Skills/Ranged/RainOfArrows.cs
+++ b/Content/Skills/Ranged/RainOfArrows.cs
@@ -32,6 +32,13 @@ public class RainOfArrows : Skill
 		Timer = Cooldown;
 
 		player.PickAmmo(player.HeldItem, out int projToShoot, out float speed, out int damage, out float knockBack, out int _, true);
+
+		if (player.HeldItem.ModItem is not null)
+		{
+			Vector2 throwaway = Vector2.Zero;
+			ItemLoader.ModifyShootStats(player.HeldItem, player, ref throwaway, ref throwaway, ref projToShoot, ref damage, ref knockBack);
+		}
+
 		damage = (int)(damage * (0.7f + Level * 0.15f));
 
 		if (projToShoot <= 0)


### PR DESCRIPTION
﻿### Link Issues
Resolves: #278 #279 #280

### Description of Work
Adds in clones for all vanilla bows/repeaters.
Makes the Rain of Arrows skill use modifications from mods, which now synergizes with all the "convert arrows to special arrows" clones.

### Comments
This could probably be flattened to use a manually loaded bow that converts arrows into other arrows, but I didn't feel like it was necessary.