### PR TITLE
feat(#286): implement `SmartContentSource`, redirect asset requests to correct directory

### DIFF
--- a/Content/Buffs/ArmorShredDebuff.cs
+++ b/Content/Buffs/ArmorShredDebuff.cs
@@ -7,8 +7,6 @@ public class ArmorShredDebuff() : SmartBuff(false)
 {
 	private const int DefenseReductionPercent = 25;
 	public static readonly float DefenseMultiplier = 1 - DefenseReductionPercent / 100f;
-	
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Buffs/ArmorShredDebuff";
 }
 
 public class ArmorShredDebuffNpc : GlobalNPC

--- a/Content/Buffs/SmartBuff.cs
+++ b/Content/Buffs/SmartBuff.cs
@@ -4,8 +4,6 @@ namespace PathOfTerraria.Content.Buffs;
 
 public abstract class SmartBuff(bool debuff, bool summon = false) : ModBuff
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Buffs/{GetType().Name}";
-
 	public bool Inflicted(Player Player)
 	{
 		return Player.active && Player.HasBuff(Type);

--- a/Content/Dusts/Sparkle.cs
+++ b/Content/Dusts/Sparkle.cs
@@ -2,7 +2,6 @@
 
 public class Sparkle : ModDust
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Dusts/Sparkle";
 	public override void OnSpawn(Dust dust) {
 		dust.velocity *= 0.4f; // Multiply the dust's start velocity by 0.4, slowing it down
 		dust.noGravity = true; // Makes the dust have no gravity.

--- a/Content/Items/Gear/VanillaItems/Clones/Swords/BrandoftheInferno.cs
+++ b/Content/Items/Gear/VanillaItems/Clones/Swords/BrandoftheInferno.cs
@@ -7,9 +7,6 @@ namespace PathOfTerraria.Content.Items.Gear.VanillaItems.Clones.Swords;
 internal class BrandoftheInferno : VanillaClone
 {
 	protected override short VanillaItemId => ItemID.DD2SquireDemonSword;
-
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/VanillaItems/Clones/Swords/BrandoftheInferno";
-
 	public override void Load()
 	{
 		IL_Player.ItemCheck_ManageRightClickFeatures_ShieldRaise += AddModdedShieldRaiseItem;

--- a/Content/Items/Gear/Weapons/Battleaxe/Battleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/Battleaxe.cs
@@ -8,7 +8,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 
 internal abstract class Battleaxe : Gear
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Battleaxe/{GetType().Name}";
 	public override float DropChance => 1f;
 	public override string AltUseDescription => Language.GetTextValue("Mods.PathOfTerraria.Gear.Battleaxe.AltUse");
 	protected override string GearLocalizationCategory => "Battleaxe";

--- a/Content/Items/Gear/Weapons/Boomerangs/Boomerang.cs
+++ b/Content/Items/Gear/Weapons/Boomerangs/Boomerang.cs
@@ -9,7 +9,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Boomerangs;
 
 internal abstract class Boomerang : Gear
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Boomerangs/{GetType().Name}";
 	public override float DropChance => 1f;
 	public override int ItemLevel => 1;
 	public override string AltUseDescription => Language.GetTextValue("Mods.PathOfTerraria.Gear.Boomerang.AltUse");

--- a/Content/Items/Gear/Weapons/Bow/Bow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Bow.cs
@@ -12,7 +12,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Bow;
 
 internal abstract class Bow : Gear
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Bow/{GetType().Name}";
 
 	/// <summary>
 	/// Stores a Bow's sprite asset automatically for use in <see cref="BowAnimationProjectile"/>.

--- a/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
+++ b/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
@@ -10,7 +10,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Grimoire;
 
 internal class GrimoireItem : Gear
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Grimoire/{GetType().Name}";
 	public override string AltUseDescription => Language.GetTextValue("Mods.PathOfTerraria.Items.GrimoireItem.AltUseDescription");
 	public override string Description => Language.GetTextValue("Mods.PathOfTerraria.Items.GrimoireItem.Description");
 	public override float DropChance => 0;

--- a/Content/Items/Gear/Weapons/Javelins/Javelin.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Javelin.cs
@@ -9,7 +9,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Javelins;
 
 internal abstract class Javelin : Gear
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Javelins/{GetType().Name}";
 	public override string AltUseDescription => Language.GetTextValue("Mods.PathOfTerraria.Gear.Javelin.AltUse");
 	public override float DropChance => 1f;
 

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -15,7 +15,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class BloodOath : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/BloodOath";
 	public override float DropChance => 5f;
 	public override int ItemLevel => 1;
 	public override bool IsUnique => true;

--- a/Content/Items/Gear/Weapons/Sword/Broadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/Broadsword.cs
@@ -2,8 +2,6 @@
 
 internal class Broadsword : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/Broadsword";
-	
 	public override void Defaults()
 	{
 		base.Defaults();

--- a/Content/Items/Gear/Weapons/Sword/CopperBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/CopperBroadsword.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class CopperBroadsword : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/CopperBroadsword";
-
 	public override float DropChance => 1f;
 	public override int MinDropItemLevel => 5;
 

--- a/Content/Items/Gear/Weapons/Sword/FireStarter.cs
+++ b/Content/Items/Gear/Weapons/Sword/FireStarter.cs
@@ -12,7 +12,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class FireStarter : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/FireStarter";
 	public override float DropChance => 5f;
 	public override int ItemLevel => 1;
 	public override bool IsUnique => true;

--- a/Content/Items/Gear/Weapons/Sword/IronBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/IronBroadsword.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class IronBroadsword : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/IronBroadsword";
-
 	public override float DropChance => 1f;
 	public override int MinDropItemLevel => 11;
 

--- a/Content/Items/Gear/Weapons/Sword/Katana.cs
+++ b/Content/Items/Gear/Weapons/Sword/Katana.cs
@@ -2,8 +2,6 @@
 
 internal class Katana : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/Katana";
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/Items/Gear/Weapons/Sword/SteelBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/SteelBroadsword.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class SteelBroadsword : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/SteelBroadsword";
-
 	public override float DropChance => 1f;
 	public override int MinDropItemLevel => 20;
 

--- a/Content/Items/Gear/Weapons/Sword/StoneSword.cs
+++ b/Content/Items/Gear/Weapons/Sword/StoneSword.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class StoneSword : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/StoneSword";
-
 	public override float DropChance => 1f;
 	public override int ItemLevel => 1;
 

--- a/Content/Items/Gear/Weapons/Sword/WoodenSword.cs
+++ b/Content/Items/Gear/Weapons/Sword/WoodenSword.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class WoodenSword : Sword
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Sword/WoodenSword";
-
 	public override float DropChance => 1f;
 	public override int ItemLevel => 1;
 

--- a/Content/Items/Gear/Weapons/Whip/Whip.cs
+++ b/Content/Items/Gear/Weapons/Whip/Whip.cs
@@ -22,8 +22,6 @@ internal abstract class Whip : Gear
 		public readonly bool DrawLine = drawLine;
 	}
 
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Gear/Weapons/Whip/{GetType().Name}";
-
 	public override float DropChance => 1f;
 
 	public abstract WhipDrawData DrawData { get; }

--- a/Content/Items/Pickups/HealingPotionPickup.cs
+++ b/Content/Items/Pickups/HealingPotionPickup.cs
@@ -7,8 +7,6 @@ namespace PathOfTerraria.Content.Items.Pickups;
 
 internal class HealingPotionPickup : ModItem
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Pickups/HealingPotionPickup";
-
 	public override void SetDefaults()
 	{
 		Item.width = 16;

--- a/Content/Items/Pickups/ManaPotionPickup.cs
+++ b/Content/Items/Pickups/ManaPotionPickup.cs
@@ -7,8 +7,6 @@ namespace PathOfTerraria.Content.Items.Pickups;
 
 internal class ManaPotionPickup : ModItem
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Pickups/ManaPotionPickup";
-
 	public override void SetDefaults()
 	{
 		Item.width = 16;

--- a/Content/Items/Placeable/MapDevice.cs
+++ b/Content/Items/Placeable/MapDevice.cs
@@ -4,8 +4,6 @@ namespace PathOfTerraria.Content.Items.Placeable;
 
 public class MapDevice : ModItem
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Items/Placeable/MapDevice";
-	
 	public override void SetDefaults() {
 		Item.DefaultToPlaceableTile(ModContent.TileType<MapDevicePlaceable>());
 		Item.width = 60;

--- a/Content/NPCs/Town/Barkeep.cs
+++ b/Content/NPCs/Town/Barkeep.cs
@@ -10,8 +10,6 @@ namespace PathOfTerraria.Content.NPCs.Town;
 [AutoloadHead]
 public class Barkeep : ModNPC
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/NPCs/Town/Barkeep";
-
 	public override void SetStaticDefaults()
 	{
 		Main.npcFrameCount[NPC.type] = 25;

--- a/Content/NPCs/Town/Blacksmith.cs
+++ b/Content/NPCs/Town/Blacksmith.cs
@@ -14,8 +14,6 @@ namespace PathOfTerraria.Content.NPCs.Town;
 [AutoloadHead]
 public class Blacksmith : ModNPC
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/NPCs/Town/Blacksmith";
-
 	public override void SetStaticDefaults()
 	{
 		Main.npcFrameCount[NPC.type] = 25;

--- a/Content/Projectiles/LifeStealProjectile.cs
+++ b/Content/Projectiles/LifeStealProjectile.cs
@@ -2,8 +2,6 @@
 
  public class LifeStealProjectile : ModProjectile
  {
-	 public override string Texture => $"{PathOfTerraria.ModName}/Assets/Projectiles/LifeStealProjectile";
-
 	 public override void SetStaticDefaults()
 	 {
 		 // Total count animation frames

--- a/Content/Projectiles/Summoner/GrimoireSummon.cs
+++ b/Content/Projectiles/Summoner/GrimoireSummon.cs
@@ -10,8 +10,6 @@ namespace PathOfTerraria.Content.Projectiles.Summoner;
 
 internal abstract class GrimoireSummon : ModProjectile
 {
-	public override string Texture => $"PathOfTerraria/Assets/Projectiles/Summoner/GrimoireSummons/{GetType().Name}";
-
 	public static Dictionary<int, Asset<Texture2D>> IconsById = [];
 
 	public abstract int BaseDamage { get; }

--- a/Content/Tiles/Town/BrokenAnvil.cs
+++ b/Content/Tiles/Town/BrokenAnvil.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Tiles.Town;
 
 internal class BrokenAnvil : ModTile
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Tiles/Town/BrokenAnvil";
-
 	public override void SetStaticDefaults()
 	{
 		Main.tileFrameImportant[Type] = true;

--- a/Content/Tiles/Town/BrokenFurnace.cs
+++ b/Content/Tiles/Town/BrokenFurnace.cs
@@ -5,8 +5,6 @@ namespace PathOfTerraria.Content.Tiles.Town;
 
 internal class BrokenFurnace : ModTile
 {
-	public override string Texture => $"{PathOfTerraria.ModName}/Assets/Tiles/Town/BrokenFurnace";
-
 	public override void SetStaticDefaults()
 	{
 		Main.tileFrameImportant[Type] = true;

--- a/Core/Sources/SmartContentSource.cs
+++ b/Core/Sources/SmartContentSource.cs
@@ -1,0 +1,78 @@
+﻿using ReLogic.Content;
+using ReLogic.Content.Sources;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PathOfTerraria.Core.Sources;
+
+/// <summary>
+///		A wrapper around an <see cref="IContentSource"/> instance which additional
+///		APIs for finer control.
+/// </summary>
+internal sealed class SmartContentSource(IContentSource source) : IContentSource
+{
+	IContentValidator IContentSource.ContentValidator
+	{
+		get => source.ContentValidator;
+		set => source.ContentValidator = value;
+	}
+
+	RejectedAssetCollection IContentSource.Rejections => source.Rejections;
+
+	/// <summary>
+	///		A map of directory redirects, with keys as the source directories
+	///		and values as the target directories.
+	/// </summary>
+	private readonly Dictionary<string, string> directoryRedirects = [];
+
+	/// <summary>
+	///		Adds a directory redirect from <paramref name="fromDir"/> to
+	///		<paramref name="toDir"/>.
+	/// </summary>
+	/// <param name="fromDir">The directory to redirect from.</param>
+	/// <param name="toDir">The directory to redirect to.</param>
+	public void AddDirectoryRedirect(string fromDir, string toDir)
+	{
+		directoryRedirects.Add(fromDir, toDir);
+	}
+
+	/// <summary>
+	///		Rewrites a path to account for modifications made by this content
+	///		source, such as directory redirections.
+	/// </summary>
+	/// <param name="path">The path to rewrite.</param>
+	/// <returns>The rewritten path.</returns>
+	private string RewritePath(string path)
+	{
+		// In the future, we may also use a hash map to reduce duplicate
+		// calculations if a notable performance degradation is observed, as
+		// this is used in frequently-called codepaths.
+
+		foreach ((string from, string to) in directoryRedirects)
+		{
+			if (path.StartsWith(from))
+			{
+				// Since we only rewrite directories now, we can return early
+				// here.
+				return path.Replace(from, to);
+			}
+		}
+
+		return path;
+	}
+
+	public IEnumerable<string> EnumerateAssets()
+	{
+		throw new NotImplementedException();
+	}
+
+	public string GetExtension(string assetName)
+	{
+		throw new NotImplementedException();
+	}
+
+	public Stream OpenStream(string fullAssetName)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/Core/Sources/SmartContentSource.cs
+++ b/Core/Sources/SmartContentSource.cs
@@ -2,6 +2,7 @@
 using ReLogic.Content.Sources;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace PathOfTerraria.Core.Sources;
 
@@ -61,18 +62,18 @@ internal sealed class SmartContentSource(IContentSource source) : IContentSource
 		return path;
 	}
 
-	public IEnumerable<string> EnumerateAssets()
+	IEnumerable<string> IContentSource.EnumerateAssets()
 	{
-		throw new NotImplementedException();
+		return source.EnumerateAssets().Select(RewritePath);
 	}
 
-	public string GetExtension(string assetName)
+	string IContentSource.GetExtension(string assetName)
 	{
-		throw new NotImplementedException();
+		return source.GetExtension(RewritePath(assetName));
 	}
 
-	public Stream OpenStream(string fullAssetName)
+	Stream IContentSource.OpenStream(string fullAssetName)
 	{
-		throw new NotImplementedException();
+		return source.OpenStream(RewritePath(fullAssetName));
 	}
 }

--- a/PathOfTerraria.cs
+++ b/PathOfTerraria.cs
@@ -5,7 +5,9 @@ global using Terraria;
 global using Terraria.ModLoader;
 using PathOfTerraria.API.GraphicsLib;
 using PathOfTerraria.Content.Items.Gear;
+using PathOfTerraria.Core.Sources;
 using PathOfTerraria.Core.Systems.Networking;
+using ReLogic.Content.Sources;
 using System.IO;
 using Terraria.ID;
 
@@ -34,5 +36,17 @@ public class PathOfTerraria : Mod
 	public override void HandlePacket(BinaryReader reader, int whoAmI)
 	{
 		Networking.HandlePacket(reader);
+	}
+
+	public override IContentSource CreateDefaultContentSource()
+	{
+		// Use our own SmartContentSource which wraps IContentSource with additional
+		// behavior.
+		var source = new SmartContentSource(base.CreateDefaultContentSource());
+
+		// Redirects requests for ModName/Content/... to ModName/Assets/...
+		source.AddDirectoryRedirect("Content", "Assets");
+
+		return source;
 	}
 }


### PR DESCRIPTION
﻿### Link Issues

Resolves: #286

### Description of Work

Implements `SmartContentSource` and removes redundant `Texture` overrides.

### Comments

The remaining overrides to `Texture` are all necessary; we should probably standardize those ones too.