### PR TITLE
fix(#288): serialize a list of `TagCompound`s instead of an array

### DIFF
--- a/Core/Systems/ModPlayers/GearSwapManager.cs
+++ b/Core/Systems/ModPlayers/GearSwapManager.cs
@@ -47,7 +47,7 @@ public sealed class GearSwapManager : ModPlayer
 
 	public override void SaveData(TagCompound tag)
 	{
-		tag["inventory"] = Inventory.Select(ItemIO.Save).ToArray();
+		tag["inventory"] = Inventory.Select(ItemIO.Save).ToList();
 	}
 
 	public override void LoadData(TagCompound tag)


### PR DESCRIPTION
﻿### Link Issues

Resolves: #288

### Description of Work

Serializes a list of `TagCompound`s instead of an array due to poor handling of collection serialization on tModLoader's end.

### Comments

I will be writing a ticket in the tML repo to address this oversight. Edit: [Done](https://github.com/tModLoader/tModLoader/issues/4316).