### PR TITLE
fix(#291): render player in stat panel with white light

### DIFF
--- a/Content/GUI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Content/GUI/PlayerStats/PlayerStatInnerPanel.cs
@@ -1,6 +1,7 @@
 ﻿using PathOfTerraria.Core.Loaders.UILoading;
 using PathOfTerraria.Core.Systems;
 using PathOfTerraria.Core.Systems.ModPlayers;
+using Terraria.DataStructures;
 using Terraria.GameContent.UI.Elements;
 using Terraria.UI;
 
@@ -8,6 +9,23 @@ namespace PathOfTerraria.Content.GUI.PlayerStats;
 
 internal class PlayerStatInnerPanel : SmartUIElement
 {
+	private sealed class StatPanelRendererPlayer : ModPlayer
+	{
+		public override void DrawEffects(PlayerDrawSet drawInfo, ref float r, ref float g, ref float b, ref float a, ref bool fullBright)
+		{
+			base.DrawEffects(drawInfo, ref r, ref g, ref b, ref a, ref fullBright);
+
+			// Force fullBright if rendering the player so hair draws
+			// correctly.
+			if (drawingPlayer)
+			{
+				fullBright = true;
+			}
+		}
+	}
+
+	private static bool drawingPlayer;
+
 	private UIElement Panel => Parent;
 
 	public override string TabName => "PlayerStats";
@@ -87,7 +105,9 @@ internal class PlayerStatInnerPanel : SmartUIElement
 			Recalculate();
 		}
 
+		drawingPlayer = true;
 		_drawDummy.Draw(spriteBatch);
+		drawingPlayer = false;
 	}
 
 	private void DrawSingleStat(SpriteBatch spriteBatch, string text)

--- a/Content/GUI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Content/GUI/PlayerStats/PlayerStatInnerPanel.cs
@@ -9,8 +9,10 @@ namespace PathOfTerraria.Content.GUI.PlayerStats;
 
 internal class PlayerStatInnerPanel : SmartUIElement
 {
-	// This is a "less dangerous" (and arguably More Correct) fix to hair being
-	// rendered as black, but it's bugged (see: TML-4317). 
+	// This is the correct approach at correctly rendering the player in the stat
+	// panel, since it's in-game and needs lighting.  This is bugged (see:
+	// TML-4317), so we use a temporary patch (GetHairColorPatch) to fix the most
+	// immediately obvious issue.
 	/*private sealed class StatPanelRendererPlayer : ModPlayer
 	{
 		public override void DrawEffects(PlayerDrawSet drawInfo, ref float r, ref float g, ref float b, ref float a, ref bool fullBright)
@@ -26,7 +28,6 @@ internal class PlayerStatInnerPanel : SmartUIElement
 		}
 	}*/
 
-	// Instead, we'll settle for a detour...
 	private sealed class GetHairColorPatch : ModSystem
 	{
 		public override void Load()

--- a/Content/GUI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Content/GUI/PlayerStats/PlayerStatInnerPanel.cs
@@ -9,18 +9,36 @@ namespace PathOfTerraria.Content.GUI.PlayerStats;
 
 internal class PlayerStatInnerPanel : SmartUIElement
 {
-	private sealed class StatPanelRendererPlayer : ModPlayer
+	// This is a "less dangerous" (and arguably More Correct) fix to hair being
+	// rendered as black, but it's bugged (see: TML-4317). 
+	/*private sealed class StatPanelRendererPlayer : ModPlayer
 	{
 		public override void DrawEffects(PlayerDrawSet drawInfo, ref float r, ref float g, ref float b, ref float a, ref bool fullBright)
 		{
 			base.DrawEffects(drawInfo, ref r, ref g, ref b, ref a, ref fullBright);
-
+	
 			// Force fullBright if rendering the player so hair draws
 			// correctly.
 			if (drawingPlayer)
 			{
 				fullBright = true;
 			}
+		}
+	}*/
+
+	// Instead, we'll settle for a detour...
+	private sealed class GetHairColorPatch : ModSystem
+	{
+		public override void Load()
+		{
+			base.Load();
+
+			On_Player.GetHairColor += GetHairColorWithoutLighting;
+		}
+
+		private static Color GetHairColorWithoutLighting(On_Player.orig_GetHairColor orig, Player self, bool useLighting)
+		{
+			return orig(self, useLighting && !drawingPlayer);
 		}
 	}
 


### PR DESCRIPTION
﻿### Link Issues

Resolves: #291 

### Description of Work

Tricks the game into correctly rendering the player in the stat panel by setting `Main::gameMenu` to true, includes a better approach in comments that is waiting on a tML bug to be fixed to be implemented.

### Comments

https://github.com/tModLoader/tModLoader/issues/4317