### PR TITLE
fix(#293): properly handle quest ui when zero quests are available

### DIFF
--- a/Content/GUI/Quests/QuestDetailsPanel.cs
+++ b/Content/GUI/Quests/QuestDetailsPanel.cs
@@ -20,7 +20,7 @@ internal class QuestDetailsPanel : SmartUIElement
 	public override void Draw(SpriteBatch spriteBatch)
 	{
 		DrawBack(spriteBatch);
-		if (Main.LocalPlayer.GetModPlayer<QuestModPlayer>().GetQuestCount() != 0)
+		if (Main.LocalPlayer.GetModPlayer<QuestModPlayer>().GetQuestCount() != 0 && ViewedQuest is not null)
 		{
 			Utils.DrawBorderStringBig(spriteBatch, ViewedQuest.Name, GetRectangle().Center() + new Vector2(175, -320), Color.White, 0.5f, 0.5f, 0.35f);
 		}
@@ -38,6 +38,11 @@ internal class QuestDetailsPanel : SmartUIElement
 
 	public void PopulateQuestSteps()
 	{
+		if (ViewedQuest is null)
+		{
+			return;
+		}
+
 		int index = 0;
 
 		foreach (QuestStep step in ViewedQuest.GetSteps())

--- a/Content/GUI/Quests/QuestsUIState.cs
+++ b/Content/GUI/Quests/QuestsUIState.cs
@@ -54,11 +54,8 @@ public class QuestsUIState : CloseableSmartUi
 			Height = StyleDimension.FromPercent(1),
 			ViewedQuest = quests.FirstOrDefault()
 		};
-		if (_questDetails.ViewedQuest != null)
-		{
-			Panel.Append(_questDetails);
-			_questDetails.PopulateQuestSteps();
-		}
+		Panel.Append(_questDetails);
+		_questDetails.PopulateQuestSteps();
 
 		_closeButton = new UIImageButton(ModContent.Request<Texture2D>($"{PathOfTerraria.ModName}/Assets/GUI/CloseButton"));
 		_closeButton.Left.Set(0, 0.83f);

--- a/Content/GUI/Quests/QuestsUIState.cs
+++ b/Content/GUI/Quests/QuestsUIState.cs
@@ -48,19 +48,16 @@ public class QuestsUIState : CloseableSmartUi
 		RemoveAllChildren();
 		base.CreateMainPanel(false, new Point(970, 715), false, true);
 		List<Quest> quests = Main.LocalPlayer.GetModPlayer<QuestModPlayer>().GetAllQuests();
-		if (quests.Count > 0)
+		_questDetails = new QuestDetailsPanel
 		{
-			_questDetails = new QuestDetailsPanel
-			{
-				Width = StyleDimension.FromPercent(1),
-				Height = StyleDimension.FromPercent(1),
-				ViewedQuest = quests.First()
-			};
-			if (_questDetails.ViewedQuest != null)
-			{
-				Panel.Append(_questDetails);
-				_questDetails.PopulateQuestSteps();
-			}    
+			Width = StyleDimension.FromPercent(1),
+			Height = StyleDimension.FromPercent(1),
+			ViewedQuest = quests.FirstOrDefault()
+		};
+		if (_questDetails.ViewedQuest != null)
+		{
+			Panel.Append(_questDetails);
+			_questDetails.PopulateQuestSteps();
 		}
 
 		_closeButton = new UIImageButton(ModContent.Request<Texture2D>($"{PathOfTerraria.ModName}/Assets/GUI/CloseButton"));


### PR DESCRIPTION
﻿### Link Issues

Resolves: #293 

### Description of Work

Properly initializes the quest UI when zero quests are available, allowing it to render and close properly. Also handles cases where `ViewedQuest` is null to prevent subsequent errors.