### PR TITLE
feat(#264): implement hoverable tooltips for health and mana potions

### DIFF
--- a/Content/GUI/NewHotbar.cs
+++ b/Content/GUI/NewHotbar.cs
@@ -290,6 +290,7 @@ public class HijackHotbarClick : ModSystem
 		if (Main.LocalPlayer.selectedItem == 0) // If we're on the combat hotbar, don't do any of the following
 		{
 			DrawMainItemHover(hbLocked);
+			DrawPotionHotbarTooltips(hbLocked);
 
 			return;
 		}
@@ -322,6 +323,40 @@ public class HijackHotbarClick : ModSystem
 					Main.hoverItemName = Main.hoverItemName + " (" + Main.LocalPlayer.inventory[FirstSlot].stack + ")";
 				}
 			}
+		}
+	}
+
+	private static void DrawPotionHotbarTooltips(bool hbLocked)
+	{
+		if (hbLocked)
+		{
+			return;
+		}
+
+		const int HotbarOffX = 20;
+		const int HotbarOffY = 20;
+		const int InnerHotbarOffX = 436;
+		const int InnerHotbarOffY = 12;
+		const int RealHotbarOffX = HotbarOffX + InnerHotbarOffX;
+		const int RealHotbarOffY = HotbarOffY + InnerHotbarOffY;
+		const int SlotSize = 48;
+		const int SeparatorWidth = 4;
+
+		int offX = RealHotbarOffX;
+		int offY = RealHotbarOffY;
+
+		for (int i = 0; i < 2; i++)
+		{
+			var pos = new Rectangle(offX, offY, SlotSize, SlotSize);
+
+			if (pos.Contains(Main.MouseScreen.ToPoint()))
+			{
+				Main.LocalPlayer.mouseInterface = true;
+				Main.LocalPlayer.cursorItemIconEnabled = false;
+				Main.hoverItemName = i == 0 ? "Healing Potion" : "Mana Potion";
+			}
+
+			offX += SlotSize + SeparatorWidth;
 		}
 	}
 

--- a/Content/GUI/NewHotbar.cs
+++ b/Content/GUI/NewHotbar.cs
@@ -11,6 +11,7 @@ using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.UI;
 using Terraria.UI.Chat;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.GUI;
 
@@ -353,11 +354,21 @@ public class HijackHotbarClick : ModSystem
 			{
 				Main.LocalPlayer.mouseInterface = true;
 				Main.LocalPlayer.cursorItemIconEnabled = false;
-				Main.hoverItemName = i == 0 ? "Healing Potion" : "Mana Potion";
+				Main.hoverItemName = GetHealthOrManaTooltip(i == 0);
 			}
 
 			offX += SlotSize + SeparatorWidth;
 		}
+	}
+
+	private static string GetHealthOrManaTooltip(bool health)
+	{
+		string type = health ? "Health" : "Mana";
+		PotionSystem potions = Main.LocalPlayer.GetModPlayer<PotionSystem>();
+
+		return Language.GetTextValue($"Mods.PathOfTerraria.Misc.{type}PotionTooltip")
+			+ "\n" + Language.GetTextValue($"Mods.PathOfTerraria.Misc.Restores{type}Tooltip", health ? potions.HealPower : potions.ManaPower)
+			+ "\n" + Language.GetTextValue($"Mods.PathOfTerraria.Misc.CooldownTooltip", MathF.Round((health ? potions.HealDelay : potions.ManaDelay) / 60f, 2).ToString("0.00"));
 	}
 
 	private static void DrawBuildingHotbarTooltips(bool hbLocked, Texture2D back)

--- a/Localization/en-US/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Misc.hjson
@@ -8,3 +8,8 @@ GrimoireMaterial: Used for the Grimoire's Menagerie.
 GrimoireBoon: Traded {0} for coin!
 # This is used for disabling EoW/BoC spawns, instead of spawning the boss it fails and says this.
 EvilBossFailedToSummon: The distant screams fade.
+HealthPotionTooltip: Health Potion
+ManaPotionTooltip: Mana Potion
+RestoresHealthTooltip: Restores {0} health
+RestoresManaTooltip: Restores {0} mana
+CooldownTooltip: "{0} second cooldown"


### PR DESCRIPTION
﻿### Link Issues

Resolves: #264 

### Description of Work

![image](https://github.com/user-attachments/assets/1dba4ff9-67bd-40c1-becd-5363c043a1b5)
![image](https://github.com/user-attachments/assets/1eb1d89f-2b5f-43da-996d-283ff83c0c6d)


### Comments

Colors can be added to the tooltips later per anyone's request.