### PR TITLE
add skill tooltips, fix missing data on nova and rain of arrows

### DIFF
--- a/Content/GUI/NewHotbar.cs
+++ b/Content/GUI/NewHotbar.cs
@@ -143,35 +143,52 @@ internal class NewHotbar : SmartUIState
 			return;
 		}
 
-		if (skillPlayer.Skills[0] != null)
-		{
-			DrawSkill(spriteBatch, off, opacity, glow, 0);
-		}
-
-		if (skillPlayer.Skills[1] != null)
-		{
-			DrawSkill(spriteBatch, off, opacity, glow, 1);
-		}
-
-		if (skillPlayer.Skills[2] != null)
-		{
-			DrawSkill(spriteBatch, off, opacity, glow, 2);
-		}
+		DrawSkill(spriteBatch, off, opacity, glow, 0);
+		DrawSkill(spriteBatch, off, opacity, glow, 1);
+		DrawSkill(spriteBatch, off, opacity, glow, 2);
 	}
 
 	private static void DrawSkill(SpriteBatch spriteBatch, float off, float opacity, Texture2D glow, int skillIndex)
 	{
 		SkillPlayer skillPlayer = Main.LocalPlayer.GetModPlayer<SkillPlayer>();
+
+		if (skillPlayer.Skills[skillIndex] is null)
+		{
+			return;
+		}
+
 		Skill skill = skillPlayer.Skills[skillIndex];
 		Texture2D texture = ModContent.Request<Texture2D>(skill.Texture).Value;
+		var skillRect = new Rectangle(268 + 52 * skillIndex, (int)(8 + off) + texture.Height - 25, texture.Width, texture.Height);
 		spriteBatch.Draw(texture,
-			new Rectangle(268 + 52 * skillIndex, (int)(8 + off) + texture.Height - 25, texture.Width, texture.Height),
+			skillRect,
 			new Rectangle(1, 2, texture.Width, texture.Height), Color.White * opacity);
 
 		if (skill.Timer > 0)
 		{
 			spriteBatch.Draw(glow, new Vector2(291 + 52 * skillIndex, 55 + off), null, Color.Black, 0, glow.Size() / 2f, 1, 0, 0);
 			Utils.DrawBorderString(spriteBatch, $"{skill.Timer / 60 + 1}", new Vector2(291 + 52 * skillIndex, 55 + off), Color.LightGray * opacity, 1f * opacity, 0.5f, 0.5f);
+		}
+
+		if (skillRect.Contains(Main.MouseScreen.ToPoint()))
+		{
+			string level = Language.GetText("Mods.PathOfTerraria.Skills.LevelLine").WithFormatArgs(skill.Level, skill.MaxLevel).Value;
+			Tooltip.SetName(skill.DisplayName.Value + " " + level);
+
+			string manaCost = Language.GetText("Mods.PathOfTerraria.Skills.ManaLine").WithFormatArgs(skill.ManaCost).Value;
+			string weapon = Language.GetText("Mods.PathOfTerraria.Skills.WeaponLine").WithFormatArgs(skill.WeaponType).Value;
+			string tooltip = skill.Description.Value + $"\n{manaCost}\n{weapon}";
+
+			if (skill.Duration != 0)
+			{
+				string duration = Language.GetText("Mods.PathOfTerraria.Skills.DurationLine").WithFormatArgs($"{skill.Duration / 60f:#0.##}").Value;
+				tooltip += "\n" + duration;
+			}
+
+			string cooldown = Language.GetText("Mods.PathOfTerraria.Skills.CooldownLine").WithFormatArgs($"{skill.MaxCooldown / 60f:#0.##}").Value;
+			tooltip += "\n" + cooldown;
+
+			Tooltip.SetTooltip(tooltip);
 		}
 	}
 

--- a/Content/Skills/Magic/Nova.cs
+++ b/Content/Skills/Magic/Nova.cs
@@ -14,6 +14,7 @@ public class Nova : Skill
 		Cooldown = MaxCooldown = (15 - Level) * 60;
 		ManaCost = 20 + 5 * Level;
 		Duration = 0;
+		WeaponType = Core.ItemType.Magic;
 	}
 
 	public override void UseSkill(Player player)

--- a/Content/Skills/Ranged/RainOfArrows.cs
+++ b/Content/Skills/Ranged/RainOfArrows.cs
@@ -19,6 +19,7 @@ public class RainOfArrows : Skill
 		Cooldown = MaxCooldown = 10 * 60;
 		ManaCost = 20;
 		Duration = 0;
+		WeaponType = Core.ItemType.Ranged;
 	}
 
 	public override void UseSkill(Player player)

--- a/Core/Mechanics/Skill.cs
+++ b/Core/Mechanics/Skill.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Content.Skills.Melee;
 using PathOfTerraria.Helpers;
+using Terraria.Localization;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Core.Mechanics;
@@ -18,6 +19,9 @@ public abstract class Skill
 
 	public virtual string Name => GetType().Name;
 	public virtual string Texture => $"{PathOfTerraria.ModName}/Assets/Skills/" + GetType().Name;
+
+	public virtual LocalizedText DisplayName => Language.GetText("Mods.PathOfTerraria.Skills." + Name + ".Name");
+	public virtual LocalizedText Description => Language.GetText("Mods.PathOfTerraria.Skills." + Name + ".Description");
 
 	/// <summary>
 	/// Creates a default instance of the given <see cref="Skill"/> with 0 for all ctor parameters, aside from 1 for <see cref="Level"/>.

--- a/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
@@ -1,3 +1,11 @@
+# These are used for the hotbar hover in NewHotbar.cs.
+LevelLine: (Level {0}/{1})
+ManaLine: Costs {0} mana
+WeaponLine: Must use a {0} weapon
+DurationLine: Lasts {0} seconds
+CooldownLine: "{0} second cooldown"
+
+# These are the actual localization lines for skills.
 Nova: {
 	Name: Nova
 	Description: Create a shockwave around you based on your held magic weapon's damage


### PR DESCRIPTION
﻿### Link Issues
Resolves: #262

### Description of Work
Adds in hover tooltips for each skill.
Fixes most skills not setting their needed weapon type (though that seems to do nothing?)

### Comments
