### PR TITLE
Fix: Wrong search path for Ravencrest world files

### DIFF
--- a/Common/Systems/WorldNavigation/WorldNavigation.cs
+++ b/Common/Systems/WorldNavigation/WorldNavigation.cs
@@ -13,8 +13,8 @@ public abstract class WorldNavigation : ModSystem
 	{
 		if (!File.Exists(Path.Combine(ModLoader.ModPath, $"{WorldFileName}.wld")) || !File.Exists(Path.Combine(ModLoader.ModPath, $"{WorldFileName}.twld")))
 		{
-			File.WriteAllBytes(Path.Combine(ModLoader.ModPath, $"{WorldFileName}.wld"), Mod.GetFileBytes($"Worlds/{WorldFileName}.wld"));
-			File.WriteAllBytes(Path.Combine(ModLoader.ModPath, $"{WorldFileName}.twld"), Mod.GetFileBytes($"Worlds/{WorldFileName}.twld"));
+			File.WriteAllBytes(Path.Combine(ModLoader.ModPath, $"{WorldFileName}.wld"), Mod.GetFileBytes($"Assets/Worlds/{WorldFileName}.wld"));
+			File.WriteAllBytes(Path.Combine(ModLoader.ModPath, $"{WorldFileName}.twld"), Mod.GetFileBytes($"Assets/Worlds/{WorldFileName}.twld"));
 		}
 	}
 


### PR DESCRIPTION
### Link Issues
Resolves: issue not made

### Description of Work
Changed the path to include the `Assets` directory in front.

### Comments
