### PR TITLE
feature: user interface hot reloading

### DIFF
--- a/Common/UI/Armor/UIGearInventoryManager.cs
+++ b/Common/UI/Armor/UIGearInventoryManager.cs
@@ -9,9 +9,9 @@ namespace PathOfTerraria.Common.UI.Armor;
 public sealed class UIGearInventoryManager : ModSystem
 {
 	public const string Identifier = $"{PoTMod.ModName}:Inventory";
-	
+
 	public override void OnWorldLoad()
 	{
-		UIManager.Enable(Identifier, "Vanilla: Inventory", new UIGearInventory(), 1);
+		UIManager.TryEnableOrRegister(Identifier, "Vanilla: Inventory", new UIGearInventory(), 1);
 	}
 }

--- a/Core/UI/UIHotReloadUpdateHandler.cs
+++ b/Core/UI/UIHotReloadUpdateHandler.cs
@@ -22,8 +22,8 @@ internal static class UIHotReloadUpdateHandler
 						continue;
 					}
 					
-					var methodInfo = typeof(UIManager).GetMethod("RefreshStates", BindingFlags.NonPublic | BindingFlags.Static);
-					var generatedMethodInfo = methodInfo?.MakeGenericMethod(type);
+					MethodInfo? methodInfo = typeof(UIManager).GetMethod("RefreshStates", BindingFlags.NonPublic | BindingFlags.Static);
+					MethodInfo? generatedMethodInfo = methodInfo?.MakeGenericMethod(type);
 					
 					generatedMethodInfo?.Invoke(null, null);
 				}

--- a/Core/UI/UIHotReloadUpdateHandler.cs
+++ b/Core/UI/UIHotReloadUpdateHandler.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using JetBrains.Annotations;
+using PathOfTerraria.Core.UI;
+using Terraria.UI;
+
+[assembly: MetadataUpdateHandler(typeof(UIHotReloadUpdateHandler))]
+
+namespace PathOfTerraria.Core.UI;
+
+internal static class UIHotReloadUpdateHandler
+{        
+	internal static void UpdateApplication(Type[]? updatedTypes)
+	{	
+		Main.QueueMainThreadAction(
+			() =>
+			{
+				foreach (Type type in updatedTypes)
+				{
+					if (!typeof(UIState).IsAssignableFrom(type))
+					{
+						continue;
+					}
+					
+					var methodInfo = typeof(UIManager).GetMethod("RefreshStates", BindingFlags.NonPublic | BindingFlags.Static);
+					var generatedMethodInfo = methodInfo?.MakeGenericMethod(type);
+					
+					generatedMethodInfo?.Invoke(null, null);
+				}
+			}
+		);
+	}
+}

--- a/Core/UI/UIManager.Reload.cs
+++ b/Core/UI/UIManager.Reload.cs
@@ -1,0 +1,32 @@
+using Terraria.UI;
+
+namespace PathOfTerraria.Core.UI;
+
+[Autoload(Side = ModSide.Client)]
+public sealed partial class UIManager : ModSystem
+{
+	/// <summary>
+	///		Reloads all registered <see cref="UIState"/> instances by its type.
+	/// </summary>
+	/// <typeparam name="T">The type of the <see cref="UIState"/> instances.</typeparam>
+	internal static void RefreshStates<T>() where T : UIState
+	{
+		for (int i = 0; i < UITypeData<T>.Data.Count; i++)
+		{
+			UIStateData<T> data = UITypeData<T>.Data[i];
+
+			if (data.Value == null)
+			{
+				continue;
+			}
+			
+			data.Value.RemoveAllChildren();
+			
+			data.Value.OnActivate();
+			data.Value.OnInitialize();
+			
+			data.UserInterface?.SetState(null);
+			data.UserInterface?.SetState(data.Value);
+		}	
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: No issue linked.

### Description of Work
* Adds `UIState` IDE hot reload support.

This significantly boosts development since now you don't have to do manual workarounds or restart the mod every time you change something in a `UIState` regarding initialization, or generally speaking logic that only runs once upon activation.

### Comments
Hot reloading will reset `UserInterface.CurrentState` and call `UIState::OnInitialize`.