### PR TITLE
make passives use internal name instead of old internal identifier

### DIFF
--- a/Common/Data/Passives.json
+++ b/Common/Data/Passives.json
@@ -14,7 +14,7 @@
 		}
 	},
 	{
-		"internalIdentifier": "Anchor",
+		"internalIdentifier": "AnchorPassive",
 		"referenceId": 1,
 		"maxLevel": 1,
 		"connections": [
@@ -24,7 +24,7 @@
 		]
 	},
 	{
-		"internalIdentifier": "AddedLife",
+		"internalIdentifier": "LifePassive",
 		"referenceId": 2,
 		"maxLevel": 5,
 		"connections": [
@@ -44,7 +44,7 @@
 		}
 	},
 	{
-		"internalIdentifier": "AddedLife",
+		"internalIdentifier": "LifePassive",
 		"referenceId": 3,
 		"maxLevel": 5,
 		"connections": [
@@ -61,7 +61,7 @@
 		}
 	},
 	{
-		"internalIdentifier": "AddedLife",
+		"internalIdentifier": "LifePassive",
 		"referenceId": 4,
 		"maxLevel": 5,
 		"connections": [
@@ -78,7 +78,7 @@
 		}
 	},
 	{
-		"internalIdentifier": "DecreasedManaCost",
+		"internalIdentifier": "DecreasedManaCostPassive",
 		"referenceId": 5,
 		"maxLevel": 5,
 		"position": {
@@ -96,7 +96,7 @@
 		}
 	},
 	{
-		"internalIdentifier": "IncreasedMinionDamage",
+		"internalIdentifier": "MinionPassive",
 		"referenceId": 7,
 		"maxLevel": 10,
 		"connections": [

--- a/Common/Systems/TreeSystem/TreeSystem.cs
+++ b/Common/Systems/TreeSystem/TreeSystem.cs
@@ -54,14 +54,17 @@ internal class TreePlayer : ModPlayer
 		Edges = [];
 
 		Dictionary<int, Passive> passives = [];
-
 		List<PassiveData> data = PassiveRegistry.GetPassiveData();
 
-		data.ForEach(n => { passives.Add(n.ReferenceId, Passive.GetPassiveFromData(n)); ActiveNodes.Add(passives[n.ReferenceId]); });
+		data.ForEach(n => 
+		{
+			passives.Add(n.ReferenceId, Passive.GetPassiveFromData(n)); 
+			ActiveNodes.Add(passives[n.ReferenceId]); 
+		});
+
 		data.ForEach(n => n.Connections.ForEach(connection => Edges.Add(new PassiveEdge(passives[n.ReferenceId], passives[connection.ReferenceId]))));
 
 		ExpModPlayer expPlayer = Main.LocalPlayer.GetModPlayer<ExpModPlayer>();
-
 		Points = expPlayer.EffectiveLevel + ExtraPoints;
 
 		foreach (Passive passive in ActiveNodes)

--- a/Content/Passives/ClassPassives.cs
+++ b/Content/Passives/ClassPassives.cs
@@ -2,6 +2,10 @@
 
 namespace PathOfTerraria.Content.Passives;
 
+internal class AnchorPassive : Passive
+{
+}
+
 internal class MartialMasteryPassive : Passive
 {
 	public override void BuffPlayer(Player player)

--- a/Content/Passives/SummonPassives.cs
+++ b/Content/Passives/SummonPassives.cs
@@ -6,6 +6,9 @@ namespace PathOfTerraria.Content.Passives;
 
 internal class MinionPassive : Passive
 {
+	public override void BuffPlayer(Player player)
+	{
+	}
 }
 
 internal class SentryPassive : Passive

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -112,3 +112,8 @@ ArmorPenetrationPassive: {
 	Name: Increased Armor Penetration (Melee)
 	Tooltip: Adds 15% more armor penetration per level
 }
+
+AnchorPassive: {
+	Name: AnchorPassive
+	Tooltip: ""
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #328 

### Description of Work
Fixes Passives.json using outdated internal identifiers instead of internal class names for data, which fixes the NullRef.

### Comments
