### PR TITLE
make affixes imodlocalizable for affixes, use utils, add unloading & …

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -103,7 +103,7 @@ public class AffixRegistry : ILoadable
 	/// <returns>Instance of ItemAffix corresponding to the affix data.</returns>
 	internal static ItemAffix ConvertToItemAffix(ItemAffixData affixData)
 	{
-		string typeName = $"PathOfTerraria.Common.Systems.Affixes.ItemTypes.{affixData.AffixType}";
+		string typeName = $"{PoTMod.ModName}.Common.Systems.Affixes.ItemTypes.{affixData.AffixType}";
 		var affixType = Type.GetType(typeName);
 
 		if (affixType == null || !typeof(ItemAffix).IsAssignableFrom(affixType))

--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -5,16 +5,20 @@ using System.Linq;
 using PathOfTerraria.Common.Enums;
 using Terraria.ModLoader.IO;
 using Terraria.ModLoader.Core;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Common.Systems.Affixes;
 
-public abstract class Affix
+public abstract class Affix : ILocalizedModType
 {
 	public float MinValue;
 	public float MaxValue = 1f;
 	public float Value = 0;
 	public int Duration = 180; //3 Seconds by default
+
+	public string LocalizationCategory => "Affixes";
+	public Mod Mod => PoTMod.Instance; // TODO: Cross mod compat?
+	public string Name => GetType().Name;
+	public string FullName => Mod.Name + "/" + Name;
 
 	// to a certain degree, none of the above is useable by the MobAffix...
 
@@ -64,7 +68,7 @@ public abstract class Affix
 		writer.Write(AffixHandler.IndexFromItemAffix(this));
 
 		writer.Write(Value);
-		writer.Write(MaxValue);			  // it seems that min and max get swapped here...
+		writer.Write(MaxValue); // it seems that min and max get swapped here...
 		writer.Write(MinValue);
 	}
 

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -16,7 +16,7 @@ public abstract class ItemAffix : Affix
 
 	public virtual void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
 	{
-		handler.AddOrModify(GetType(), item, Value, Language.GetText($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Description"), null);
+		handler.AddOrModify(GetType(), item, Value, this.GetLocalization("Description"), null);
 	}
 
 	/// <summary>
@@ -47,6 +47,6 @@ public abstract class ItemAffix : Affix
 
 	internal override void CreateLocalization()
 	{
-		Language.GetOrRegister($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Description", () => "{1}{0} to stat");
+		Language.GetOrRegister(this.GetLocalizationKey("Description"), () => "{1}{0} to stat");
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
@@ -11,7 +11,7 @@ internal class IncreasedAttackSpeedAffix : ItemAffix
 
 	public override void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
 	{
-		handler.AddOrModify(GetType(), item,Value * 100, Language.GetText($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Description"), null);
+		handler.AddOrModify(GetType(), item,Value * 100, this.GetLocalization("Description"), null);
 	}
 }
 
@@ -40,6 +40,6 @@ internal class IncreasedDamageAffix : ItemAffix
 
 	public override void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
 	{
-		handler.AddOrModify(GetType(), item,Value / 100, Language.GetText($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Description"), null);
+		handler.AddOrModify(GetType(), item,Value / 100, this.GetLocalization("Description"), null);
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/UniqueAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/UniqueAffixes.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Terraria.Localization;
+using Terraria.ModLoader;
 
 namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
@@ -15,15 +16,13 @@ internal class NoFallDamageAffix : ItemAffix
 
 	public override void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
 	{
-		handler.AddOrModify(GetType(), item, 1, Language.GetText($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Description"), ModifyTooltip);
+		handler.AddOrModify(GetType(), item, 1, this.GetLocalization("Description"), ModifyTooltip);
 	}
 
 	private string ModifyTooltip(AffixTooltip self, float value, float difference, float originalValue, LocalizedText text)
 	{
 		bool hasBuff = value > 0;
-		string baseString = hasBuff
-			? Language.GetTextValue($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Description")
-			: Language.GetTextValue($"Mods.PathOfTerraria.Affixes.{GetType().Name}.Removed");
+		string baseString = this.GetLocalizedValue(hasBuff ? "Description" : "Removed");
 
 		if (!hasBuff && originalValue != value && value == 0)
 		{

--- a/Common/Systems/ModPlayers/UniversalBuffingPlayer.cs
+++ b/Common/Systems/ModPlayers/UniversalBuffingPlayer.cs
@@ -77,4 +77,11 @@ internal class UniversalBuffingPlayer : ModPlayer
 
 		AffixTooltipHandler.ModifyTooltips(tooltips);
 	}
+
+	public override void Unload()
+	{
+		AffixTooltipHandler.Reset();
+		AffixTooltipHandler = null;
+		UniversalModifier = null;
+	}
 }


### PR DESCRIPTION
…use PoTMod.ModName

﻿### Link Issues
Resolves:

### Description of Work
Makes Affixes implement IModLocalizable.
Affixes now use `this.GetLocalizedValue()` or similar IModLocalizable utils instead of manually using Languag.GetText/Value.
UniversalBuffingPlayer now nulls out the modifier and affix tooltip handler.

### Comments
