### PR TITLE
Localize static data

### DIFF
--- a/Content/Items/Gear/Weapons/Battleaxe/Battleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/Battleaxe.cs
@@ -16,7 +16,7 @@ internal abstract class Battleaxe : Gear
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.Battleaxe.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.Battleaxe.AltUse");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
@@ -6,7 +6,6 @@ using PathOfTerraria.Content.Projectiles.Melee;
 using PathOfTerraria.Core.Items;
 using Terraria.DataStructures;
 using Terraria.ID;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 

--- a/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
@@ -19,8 +19,8 @@ internal class CorruptedBattleaxe : IronBattleaxe
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
 		staticData.IsUnique = true;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.CorruptedBattleaxe.AltUseDescription");
-		staticData.Description = Language.GetTextValue("Mods.PathOfTerraria.Items.CorruptedBattleaxe.Description");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
@@ -7,7 +7,6 @@ using PathOfTerraria.Content.Projectiles.Melee;
 using PathOfTerraria.Core.Items;
 using ReLogic.Content;
 using Terraria.ID;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 

--- a/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
@@ -21,8 +21,8 @@ internal class GuardianAngel : SteelBattleaxe
 		staticData.DropChance = 1f;
 		staticData.MinDropItemLevel = 25;
 		staticData.IsUnique = true;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.GuardianAngel.AltUseDescription");
-		staticData.Description = Language.GetTextValue("Mods.PathOfTerraria.Items.GuardianAngel.Description");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Boomerangs/Boomerang.cs
+++ b/Content/Items/Gear/Weapons/Boomerangs/Boomerang.cs
@@ -23,7 +23,7 @@ internal abstract class Boomerang : Gear, GetItemLevel.IItem
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.Boomerang.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.Boomerang.AltUse");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Bow/Bow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Bow.cs
@@ -36,7 +36,7 @@ internal abstract class Bow : Gear
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.Bow.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.Bow.AltUse");
 
 		if (ModContent.HasAsset(Texture + "Animated"))
 		{

--- a/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
+++ b/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
@@ -19,8 +19,8 @@ internal class GrimoireItem : Gear
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 0f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.GrimoireItem.AltUseDescription");
-		staticData.Description = Language.GetTextValue("Mods.PathOfTerraria.Items.GrimoireItem.Description");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
@@ -34,6 +34,7 @@ internal class Bloodclotter : PlatinumGlaive
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
 		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
@@ -33,7 +33,7 @@ internal class Bloodclotter : PlatinumGlaive
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.Bloodclotter.AltUseDescription");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Javelins/Javelin.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Javelin.cs
@@ -39,7 +39,7 @@ internal abstract class Javelin : Gear
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.Javelin.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.Javelin.AltUse");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
+++ b/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
@@ -24,7 +24,7 @@ internal class MoltenDangpa : LeadDangpa
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.MoltenDangpa.AltUseDescription");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
+++ b/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
@@ -25,6 +25,7 @@ internal class MoltenDangpa : LeadDangpa
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
 		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
@@ -23,7 +23,7 @@ internal class Rottenbone : PlatinumGlaive
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.Rottenbone.AltUseDescription");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
 	}
 
 	public override List<ItemAffix> GenerateImplicits()

--- a/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
@@ -24,6 +24,7 @@ internal class Rottenbone : PlatinumGlaive
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
 		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override List<ItemAffix> GenerateImplicits()

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -41,8 +41,8 @@ internal class BloodOath : Sword, GenerateName.IItem
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 5f;
 		staticData.IsUnique = true;
-		staticData.Description = Language.GetTextValue("Mods.PathOfTerraria.Items.BloodOath.Description");
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.BloodOath.AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Sword/FireStarter.cs
+++ b/Content/Items/Gear/Weapons/Sword/FireStarter.cs
@@ -26,8 +26,8 @@ internal class FireStarter : Sword, GenerateName.IItem
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 5f;
 		staticData.IsUnique = true;
-		staticData.Description = Language.GetTextValue("Mods.PathOfTerraria.Items.FireStarter.Description");
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Items.FireStarter.AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Sword/Sword.cs
+++ b/Content/Items/Gear/Weapons/Sword/Sword.cs
@@ -17,7 +17,7 @@ internal abstract class Sword : Gear
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.Sword.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.Sword.AltUse");
 
 	}
 

--- a/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
+++ b/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
@@ -31,6 +31,8 @@ internal class StarlightBulwark : LeadBattleBulwark
 		
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.IsUnique = true;
+		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
+		staticData.Description = this.GetLocalization("Description");
 	}
 
 	public override List<ItemAffix> GenerateImplicits()

--- a/Content/Items/Gear/Weapons/WarShields/WarShield.cs
+++ b/Content/Items/Gear/Weapons/WarShields/WarShield.cs
@@ -46,7 +46,7 @@ internal abstract class WarShield : Gear, IParryItem, GetItemLevel.IItem
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.WarShield.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.WarShield.AltUse");
 
 		AddValidShieldParryItems.AddParryItem(Type);
 	}

--- a/Content/Items/Gear/Weapons/Whip/Whip.cs
+++ b/Content/Items/Gear/Weapons/Whip/Whip.cs
@@ -38,7 +38,7 @@ internal abstract class Whip : Gear
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = 1f;
-		staticData.AltUseDescription = Language.GetTextValue("Mods.PathOfTerraria.Gear.Whip.AltUse");
+		staticData.AltUseDescription = Language.GetText("Mods.PathOfTerraria.Gear.Whip.AltUse");
 
 		if (ModContent.HasAsset(Texture + "_Projectile"))
 		{

--- a/Core/Items/PoTGlobalItem.Data.cs
+++ b/Core/Items/PoTGlobalItem.Data.cs
@@ -1,6 +1,7 @@
 ﻿using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Systems.Affixes;
 using System.Collections.Generic;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -87,12 +88,12 @@ public sealed class PoTStaticItemData
 	/// <summary>
 	///		The item's description.
 	/// </summary>
-	public string Description { get; set; } = string.Empty;
+	public LocalizedText Description { get; set; } = LocalizedText.Empty;
 
 	/// <summary>
 	///		The item's description for alternate use (right-clicking).
 	/// </summary>
-	public string AltUseDescription { get; set; } = string.Empty;
+	public LocalizedText AltUseDescription { get; set; } = LocalizedText.Empty;
 }
 
 partial class PoTGlobalItem

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -119,9 +119,9 @@ partial class PoTGlobalItem
 		};
 		tooltips.Add(itemLevelLine);
 
-		if (!string.IsNullOrWhiteSpace(staticData.AltUseDescription))
+		if (!string.IsNullOrWhiteSpace(staticData.AltUseDescription.Value))
 		{
-			tooltips.Add(new TooltipLine(Mod, "AltUseDescription", staticData.AltUseDescription));
+			tooltips.Add(new TooltipLine(Mod, "AltUseDescription", staticData.AltUseDescription.Value));
 		}
 
 		if (item.damage > 0)
@@ -147,9 +147,9 @@ partial class PoTGlobalItem
 		Main.LocalPlayer.GetModPlayer<UniversalBuffingPlayer>().PrepareComparisonTooltips(tooltips, item);
 		AffixTooltipsHandler.DefaultColor = Color.White; // Resets color
 
-		if (!string.IsNullOrWhiteSpace(staticData.Description))
+		if (!string.IsNullOrWhiteSpace(staticData.Description.Value))
 		{
-			tooltips.Add(new TooltipLine(Mod, "Description", staticData.Description));
+			tooltips.Add(new TooltipLine(Mod, "Description", staticData.Description.Value));
 		}
 	}
 

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -350,6 +350,7 @@ MoltenDangpa: {
 	DisplayName: Molten Dangpa
 	Tooltip: ""
 	AltUseDescription: Right click to melt your weapon and throw it, guaranteeing On Fire! on every enemy and splashing a few magma bubbles around.
+	Description: Hot to the touch, fuel to your power.
 }
 
 WoodPlank: {
@@ -391,15 +392,19 @@ Bloodclotter: {
 	DisplayName: Bloodclotter
 	Tooltip: ""
 	AltUseDescription: Right click to bleed, powering up your weapon's damage by 50%.
+	Description: Its form shifts and dances in place, hiding some power you can only barely see.
 }
 
 StarlightBulwark: {
 	DisplayName: Starlight Bulwark
 	Tooltip: ""
+	AltUseDescription: Right click to parry enemies and projectiles. Parrying projectiles will send out additional stars.
+	Description: Light but heavy, you can touch the sky.
 }
 
 Rottenbone: {
 	DisplayName: Rottenbone
 	Tooltip: ""
 	AltUseDescription: Right click to throw your weapon, which quickly splits into many pieces, each dealing additional damage or applying Poisoned.
+	Description: It's genuinely unpleasant to touch. More unpleasant for your opponents, though.
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
`PoTStaticItemData.Description` and `PoTStaticItemData.AltUseDescription` are now LocalizedTexts which update when language is changed.
All remaining uniques now have little flavor text descriptions.

### Comments
