### PR TITLE
fix: inconsistent loadout buttons

### DIFF
--- a/Common/UI/Armor/UIGearInventory.cs
+++ b/Common/UI/Armor/UIGearInventory.cs
@@ -265,6 +265,11 @@ public sealed class UIGearInventory : UIState
 
 	private static void UpdateLoadoutIcon(UIImage image, int index)
 	{
+		if (image.ContainsPoint(Main.MouseScreen))
+		{
+			Main.LocalPlayer.mouseInterface = true;
+		}
+		
 		if (Player.CurrentLoadoutIndex == index)
 		{
 			image.Color = Color.White;


### PR DESCRIPTION
﻿### Link Issues
Resolves: #342 

### Description of Work
Fixes inconsistent hovering in the inventory loadout buttons by setting `Player.mouseInterface` to true during hover.

### Comments
Apparently UI elements don't automatically account for setting that field during collisions, we might want to keep an eye out.
