### PR TITLE
feat(#357): Add ability to allocate skill passives

### DIFF
--- a/Common/Mechanics/Skill.cs
+++ b/Common/Mechanics/Skill.cs
@@ -175,7 +175,7 @@ public abstract class Skill
 		Edges = [];
 		ActiveNodes =
 		[
-			new SkillPassiveAnchor()
+			new SkillPassiveAnchor(this)
 		];
 
 		foreach (SkillPassive passive in Passives)

--- a/Common/Mechanics/SkillPassive.cs
+++ b/Common/Mechanics/SkillPassive.cs
@@ -6,9 +6,9 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Mechanics;
 
-public abstract class SkillPassive
+public abstract class SkillPassive(Skill skill)
 {
-	public abstract Skill Skill { get; }
+	public Skill Skill { get; set; } = skill;
 	public virtual List<SkillPassive> Connections { get; set; }
 	public abstract int ReferenceId { get; }
 	public int Level;
@@ -18,6 +18,8 @@ public abstract class SkillPassive
 
 	public virtual string Name => GetType().Name;
 	public virtual string Texture => $"{PoTMod.ModName}/Assets/SkillPassives/" + Name;
+	
+	// New constructor
 
 	public virtual string DisplayName => Language.GetTextValue("Mods.PathOfTerraria.SkillPassives." + Name + ".Name");
 	public virtual string Description => Language.GetTextValue("Mods.PathOfTerraria.SkillPassives." + Name + ".Description");

--- a/Common/Systems/ModPlayers/SkilPassivePlayer.cs
+++ b/Common/Systems/ModPlayers/SkilPassivePlayer.cs
@@ -32,28 +32,36 @@ public class SkillPassivePlayer : ModPlayer
 
 	public bool AllocatePassivePoint(Skill skill, SkillPassive passive)
 	{
-		if (AllocatedPassivePoints.ContainsKey(skill) && AllocatedPassivePoints[skill] < AcquiredPassivePoints[skill])
+		if (passive.Level > passive.MaxLevel)
 		{
-			if (!AllocatedPassives.ContainsKey(skill))
-			{
-				AllocatedPassives[skill] = new List<SkillPassive>();
-			}
-
-			if (AllocatedPassives[skill].Contains(passive))
-			{
-				return false; // Already allocated this passive
-			}
-
-			AllocatedPassives[skill].Add(passive);
-			AllocatedPassivePoints[skill]++;
-			return true;
+			return false; // Passive is not leveled or already maxed
+		}
+		
+		AllocatedPassivePoints.TryAdd(skill, 0);
+		AcquiredPassivePoints.TryAdd(skill, 0);
+		
+		if (AllocatedPassivePoints[skill] >= AcquiredPassivePoints[skill])
+		{
+			return false; // Not enough points or already allocated
 		}
 
-		return false; // Not enough points or already allocated
+		if (!AllocatedPassives.ContainsKey(skill))
+		{
+			AllocatedPassives[skill] = [];
+		}
+
+		AllocatedPassives[skill].Add(passive);
+		AllocatedPassivePoints[skill]++;
+		return true;
 	}
 
 	public void DeallocatePassivePoint(Skill skill, SkillPassive passive)
 	{
+		if (passive.Name == "Anchor")
+		{
+			return; // Anchor passive cannot be unallocated
+		}
+		
 		if (AllocatedPassives.ContainsKey(skill) && AllocatedPassives[skill].Contains(passive))
 		{
 			AllocatedPassives[skill].Remove(passive);

--- a/Common/UI/SkillsTree/SkillPassiveElement.cs
+++ b/Common/UI/SkillsTree/SkillPassiveElement.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Mechanics;
+using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Common.Systems.TreeSystem;
 using PathOfTerraria.Core.Sounds;
@@ -118,11 +119,14 @@ internal class SkillPassiveElement : SmartUiElement
 			return;
 		}
 
+
+		if (!Main.LocalPlayer.GetModPlayer<SkillPassivePlayer>().AllocatePassivePoint(_passive.Skill, _passive))
+		{
+			return;
+		}
+
 		_passive.Level++;
-		Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().Points--;
-
 		_flashTimer = 20;
-
 		TreeSoundEngine.PlaySoundForTreeAllocation(_passive.MaxLevel, _passive.Level);
 	}
 
@@ -134,7 +138,7 @@ internal class SkillPassiveElement : SmartUiElement
 		}
 
 		_passive.Level--;
-		Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().Points++;
+		Main.LocalPlayer.GetModPlayer<SkillPassivePlayer>().DeallocatePassivePoint(_passive.Skill, _passive);
 
 		_redFlashTimer = 20;
 

--- a/Common/UI/SkillsTree/SkillPassiveElement.cs
+++ b/Common/UI/SkillsTree/SkillPassiveElement.cs
@@ -119,7 +119,6 @@ internal class SkillPassiveElement : SmartUiElement
 			return;
 		}
 
-
 		if (!Main.LocalPlayer.GetModPlayer<SkillPassivePlayer>().AllocatePassivePoint(_passive.Skill, _passive))
 		{
 			return;

--- a/Content/SkillPassives/Magic/FireNovaSkillPassive.cs
+++ b/Content/SkillPassives/Magic/FireNovaSkillPassive.cs
@@ -4,17 +4,16 @@ using PathOfTerraria.Content.Skills.Magic;
 
 namespace PathOfTerraria.Content.SkillPassives.Magic;
 
-public class FireNovaSkillPassive : SkillPassive
+public sealed class FireNovaSkillPassive : SkillPassive
 {
-	public override Skill Skill => new Nova();
 	public override int ReferenceId => 1;
 	public override int MaxLevel => 1;
 	public override Vector2 TreePos => new(100, 0);
-
-	public override List<SkillPassive> Connections =>
-	[
-		new SkillPassiveAnchor()
-	];
+	
+	public FireNovaSkillPassive(Skill skill) : base(skill)
+	{
+		Connections = [new SkillPassiveAnchor(skill)];
+	}
 
 	public override void LevelTo(byte level)
 	{

--- a/Content/SkillPassives/Magic/IceNovaSkillPassive.cs
+++ b/Content/SkillPassives/Magic/IceNovaSkillPassive.cs
@@ -5,17 +5,16 @@ using PathOfTerraria.Content.Skills.Magic;
 
 namespace PathOfTerraria.Content.SkillPassives.Magic;
 
-public class IceNovaSkillPassive : SkillPassive
+public sealed class IceNovaSkillPassive : SkillPassive
 {
-	public override Skill Skill => new Nova();
 	public override int ReferenceId => 2;
 	public override int MaxLevel => 1;
 	public override Vector2 TreePos => new(0, 100);
 	
-	public override List<SkillPassive> Connections =>
-	[
-		new SkillPassiveAnchor()
-	];
+	public IceNovaSkillPassive(Skill skill) : base(skill)
+	{
+		Connections = [new SkillPassiveAnchor(skill)];
+	}
 	
 	public override void LevelTo(byte level)
 	{

--- a/Content/SkillPassives/Magic/LightningNovaSkillPassive.cs
+++ b/Content/SkillPassives/Magic/LightningNovaSkillPassive.cs
@@ -1,20 +1,17 @@
-﻿using System.Collections.Generic;
-using PathOfTerraria.Common.Mechanics;
-using PathOfTerraria.Content.Skills.Magic;
+﻿using PathOfTerraria.Common.Mechanics;
 
 namespace PathOfTerraria.Content.SkillPassives.Magic;
 
-public class LightningNovaSkillPassive : SkillPassive
+public sealed class LightningNovaSkillPassive : SkillPassive
 {
-	public override Skill Skill => new Nova();
 	public override int ReferenceId => 3;
 	public override int MaxLevel => 1;
 	public override Vector2 TreePos => new(0, -100);
 	
-	public override List<SkillPassive> Connections =>
-	[
-		new SkillPassiveAnchor()
-	];
+	public LightningNovaSkillPassive(Skill skill) : base(skill)
+	{
+		Connections = [new SkillPassiveAnchor(skill)];
+	}
 	
 	public override void LevelTo(byte level)
 	{

--- a/Content/SkillPassives/SkillPassiveAnchor.cs
+++ b/Content/SkillPassives/SkillPassiveAnchor.cs
@@ -4,11 +4,15 @@ namespace PathOfTerraria.Content.SkillPassives;
 
 public class SkillPassiveAnchor : SkillPassive
 {
-	public override Skill Skill => null;
 	public override int ReferenceId => 0;
 	public override int MaxLevel => 0;
 	public override string Name => "Anchor";
 	public override Vector2 TreePos => new(0, 0);
+
+	public SkillPassiveAnchor(Skill skill) : base(skill)
+	{
+		Level = 1;
+	}
 
 	public override void LevelTo(byte level) { }
 }

--- a/Content/Skills/Magic/Nova.cs
+++ b/Content/Skills/Magic/Nova.cs
@@ -14,10 +14,10 @@ public class Nova : Skill
 	
 	public override List<SkillPassive> Passives =>
 	[
-		new SkillPassiveAnchor(),
-		new LightningNovaSkillPassive(),
-		new FireNovaSkillPassive(),
-		new IceNovaSkillPassive()
+		new SkillPassiveAnchor(this),
+		new LightningNovaSkillPassive(this),
+		new FireNovaSkillPassive(this),
+		new IceNovaSkillPassive(this)
 	];
 
 	public override void LevelTo(byte level)

--- a/Localization/en-US/Mods.PathOfTerraria.SkillPassives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.SkillPassives.hjson
@@ -8,17 +8,17 @@ Anchor: {
 	Tooltip: Your journey starts here
 }
 
-LightningNova: {
+LightningNovaSkillPassive: {
 	Name: Lightning Nova
 	Tooltip: Turns your Nova into the Lightning Nova skill
 }
 
-FireNova: {
+FireNovaSkillPassive: {
 	Name: Fire Nova
 	Tooltip: Turns your Nova into the Fire Nova skill
 }
 
-IceNova: {
+IceNovaSkillPassive: {
 	Name: Ice Nova
 	Tooltip: Turns your Nova into the Ice Nova skill
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #357 

### Description of Work
* Adds the ability for SkillPassives to be used across multiple skills - For things like the anchor or maybe generic damage in the future
* Fixes some localization things
* Fixes the AllocatePassivePoint method

### Comments
