### PR TITLE
Add levels, add failure check, rename method

### DIFF
--- a/Common/Systems/ModPlayers/SkillCombatPlayer.cs
+++ b/Common/Systems/ModPlayers/SkillCombatPlayer.cs
@@ -158,9 +158,28 @@ internal class SkillCombatPlayer : ModPlayer
 
 		return false;
 	}
-	
+
+	public bool HasSkill(string name)
+	{
+		for (int i = 0; i < HotbarSkills.Length; i++)
+		{
+			if (HotbarSkills[i] is not null && HotbarSkills[i].Name == name)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public bool TryAddSkill(Skill skill)
 	{
+		if (!skill.CanEquipSkill(Player))
+		{
+			Main.NewText("Skill cannot be added.");
+			return false;
+		}
+
 		for (int i = 0; i < HotbarSkills.Length; ++i)
 		{
 			if (HotbarSkills[i] != null && HotbarSkills[i].Name == skill.Name)

--- a/Common/UI/SkillsTree/SkillSelectionElement.cs
+++ b/Common/UI/SkillsTree/SkillSelectionElement.cs
@@ -1,6 +1,8 @@
 ﻿using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers;
+using Terraria.GameContent;
 using Terraria.UI;
+using Terraria.UI.Chat;
 
 namespace PathOfTerraria.Common.UI.SkillsTree;
 
@@ -32,6 +34,14 @@ internal class SkillSelectionElement : UIElement
 
 		Vector2 position = GetDimensions().Position() + new Vector2(Width.Pixels / 2, Height.Pixels / 2);
 		spriteBatch.Draw(tex, position, null, _skill.CanEquipSkill(Main.LocalPlayer) ? Color.White : Color.Gray, 0f, tex.Size() / 2f, 1f, SpriteEffects.None, 0f);
+
+		if (Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>().HasSkill(_skill.Name))
+		{
+			Vector2 texPos = position - new Vector2(0, Height.Pixels / 2f) * 0.8f;
+			string text = $"{_skill.Level}/{_skill.MaxLevel}";
+			Vector2 textSize = FontAssets.ItemStack.Value.MeasureString(text);
+			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.ItemStack.Value, text, texPos, Color.White, 0f, textSize / 2f, Vector2.One);
+		}
 	}
 	
 	public override void LeftClick(UIMouseEvent evt)
@@ -40,7 +50,7 @@ internal class SkillSelectionElement : UIElement
 		Main.NewText("Clicked on " + _skill.Name);
 		skillCombatPlayer.TryAddSkill(_skill);
 		_parentPanel.SelectedSkill = _skill;
-		_parentPanel.DrawSkillTree();
+		_parentPanel.RebuildTree();
 	}
 
 	public override void RightClick(UIMouseEvent evt)

--- a/Common/UI/SkillsTree/SkillSelectionPanel.cs
+++ b/Common/UI/SkillsTree/SkillSelectionPanel.cs
@@ -39,7 +39,7 @@ internal class SkillSelectionPanel : SmartUiElement
 		}
 	}
 
-	public void DrawSkillTree()
+	public void RebuildTree()
 	{
 		if (SelectedSkill == null)
 		{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #356

### Description of Work
- Adds in "level/maxlevels" text over skills on the skill tree.
- Adds in "Skill cannot be added." message when applying a skill that cannot be equipped.
- Renames "DrawSkillTree" to "RebuildTree".

### Comments
