### PR TITLE
fix minera, hide grimoire button until grimoire is obtained

### DIFF
--- a/Common/NPCs/Effects/NPCHitEffects.cs
+++ b/Common/NPCs/Effects/NPCHitEffects.cs
@@ -116,6 +116,11 @@ public sealed class NPCHitEffects : NPCComponent
 		) { }
 	}
 
+	public static bool OnDeath(NPC npc)
+	{
+		return npc.life <= 0;
+	}
+
 	/// <summary>
 	///     Whether to spawn the party hat gore for town NPCs during a party or not. Defaults to <c>true</c>.
 	/// </summary>

--- a/Common/Systems/ModPlayers/GrimoireSummonPlayer.cs
+++ b/Common/Systems/ModPlayers/GrimoireSummonPlayer.cs
@@ -14,6 +14,7 @@ internal class GrimoireSummonPlayer : ModPlayer
 	internal readonly HashSet<string> UnlockedSummons = [];
 
 	public int CurrentSummonId = -1;
+	public bool HasObtainedGrimoire = false;
 
 	public bool HasSummon<T>() where T : ModProjectile
 	{
@@ -37,6 +38,7 @@ internal class GrimoireSummonPlayer : ModPlayer
 
 	public override void SaveData(TagCompound tag)
 	{
+		tag.Add("hasGrimoire", HasObtainedGrimoire);
 		tag.Add("count", UnlockedSummons.Count);
 
 		for (int i = 0; i < UnlockedSummons.Count; i++)
@@ -52,6 +54,7 @@ internal class GrimoireSummonPlayer : ModPlayer
 
 	public override void LoadData(TagCompound tag)
 	{
+		HasObtainedGrimoire = tag.TryGet("hasGrimoire", out bool hasGrimoire) && hasGrimoire;
 		int count = tag.GetInt("count");
 
 		for (int i = 0; i < count; i++)

--- a/Common/UI/GrimoireSelection/GrimoireInvButton.cs
+++ b/Common/UI/GrimoireSelection/GrimoireInvButton.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Content.Items.Gear.Weapons.Grimoire;
 using PathOfTerraria.Core.UI.SmartUI;
 using Terraria.Audio;
@@ -9,7 +10,7 @@ namespace PathOfTerraria.Common.UI.GrimoireSelection;
 
 public class GrimoireInvButton : SmartUiState
 {
-	public override bool Visible => Main.playerInventory;
+	public override bool Visible => Main.playerInventory && Main.LocalPlayer.GetModPlayer<GrimoireSummonPlayer>().HasObtainedGrimoire;
 
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{

--- a/Common/UI/Utilities/UiStateRefresher.cs
+++ b/Common/UI/Utilities/UiStateRefresher.cs
@@ -23,12 +23,11 @@ internal class UiStateRefresher : ModSystem
 	/// <summary>
 	/// Forces the refresh a single time for when the world is loaded and the UI needs refreshing
 	/// </summary>
-	public override void OnWorldLoad(){
+	public override void OnWorldLoad()
+	{
 		if (Main.netMode != NetmodeID.Server)
 		{
-			SmartUiLoader.GetUiState<QuestPanelButton>().Refresh();
-			SmartUiLoader.GetUiState<PlayerStatButton>().Refresh();
-			SmartUiLoader.GetUiState<GrimoireInvButton>().Refresh();
+			RefreshUi(Vector2.Zero);
 		}
 	}
 	

--- a/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
+++ b/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
@@ -67,4 +67,10 @@ internal class GrimoireItem : Gear
 		type = player.GetModPlayer<GrimoireSummonPlayer>().CurrentSummonId;
 		damage = (ContentSamples.ProjectilesByType[type].ModProjectile as GrimoireSummon).BaseDamage;
 	}
+
+	public override bool OnPickup(Player player)
+	{
+		player.GetModPlayer<GrimoireSummonPlayer>().HasObtainedGrimoire = true;
+		return true;
+	}
 }

--- a/Content/NPCs/BossDomain/BrainDomain/Minera.cs
+++ b/Content/NPCs/BossDomain/BrainDomain/Minera.cs
@@ -20,6 +20,6 @@ public sealed class Minera : ModNPC
 		AnimationType = NPCID.Crimera;
 		AIType = NPCID.Crimera;
 
-		NPC.TryEnableComponent<NPCDeathEffects>(c => c.AddDust(DustID.Blood, 12));
+		//NPC.TryEnableComponent<NPCDeathEffects>(c => c.AddDust(DustID.Blood, 12));
 	}
 }

--- a/Content/NPCs/BossDomain/BrainDomain/Minera.cs
+++ b/Content/NPCs/BossDomain/BrainDomain/Minera.cs
@@ -20,6 +20,10 @@ public sealed class Minera : ModNPC
 		AnimationType = NPCID.Crimera;
 		AIType = NPCID.Crimera;
 
-		//NPC.TryEnableComponent<NPCDeathEffects>(c => c.AddDust(DustID.Blood, 12));
+		NPC.TryEnableComponent<NPCHitEffects>(c => 
+		{
+			c.AddDust(new(DustID.Blood, 4));
+			c.AddDust(new(DustID.Blood, 15, NPCHitEffects.OnDeath));
+		});
 	}
 }

--- a/Content/NPCs/Town/BarkeepNPC.cs
+++ b/Content/NPCs/Town/BarkeepNPC.cs
@@ -42,9 +42,9 @@ public sealed class BarkeepNPC : ModNPC
 		NPC.TryEnableComponent<NPCHitEffects>(
 			c =>
 			{
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_0", 1, static npc => npc.life <= 0));
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_1", 1, static npc => npc.life <= 0));
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_2", 2, static npc => npc.life <= 0));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_0", 1, NPCHitEffects.OnDeath));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_1", 1, NPCHitEffects.OnDeath));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_2", 2, NPCHitEffects.OnDeath));
 				
 				c.AddDust(new NPCHitEffects.DustSpawnParameters(DustID.Blood, 20));
 			}

--- a/Content/NPCs/Town/BlacksmithNPC.cs
+++ b/Content/NPCs/Town/BlacksmithNPC.cs
@@ -45,9 +45,9 @@ public class BlacksmithNPC : ModNPC
 		NPC.TryEnableComponent<NPCHitEffects>(
 			c =>
 			{
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_0", 1, static npc => npc.life <= 0));
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_1", 1, static npc => npc.life <= 0));
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_2", 2, static npc => npc.life <= 0));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_0", 1, NPCHitEffects.OnDeath));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_1", 1, NPCHitEffects.OnDeath));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_2", 2, NPCHitEffects.OnDeath));
 				
 				c.AddDust(new NPCHitEffects.DustSpawnParameters(DustID.Blood, 20));
 			}

--- a/Content/NPCs/Town/HunterNPC.cs
+++ b/Content/NPCs/Town/HunterNPC.cs
@@ -45,9 +45,9 @@ public class HunterNPC : ModNPC
 		NPC.TryEnableComponent<NPCHitEffects>(
 			c =>
 			{
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_0", 1, static npc => npc.life <= 0));
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_1", 1, static npc => npc.life <= 0));
-				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_2", 2, static npc => npc.life <= 0));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_0", 1, NPCHitEffects.OnDeath));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_1", 1, NPCHitEffects.OnDeath));
+				c.AddGore(new NPCHitEffects.GoreSpawnParameters($"{PoTMod.ModName}/{Name}_2", 2, NPCHitEffects.OnDeath));
 				
 				c.AddDust(new NPCHitEffects.DustSpawnParameters(DustID.Blood, 20));
 			}

--- a/Localization/en-US/Mods.PathOfTerraria.Affixes.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Affixes.hjson
@@ -44,3 +44,8 @@ NoFallDamageAffix: {
 	Description: Immunity to fall damage
 	Removed: Vulnerable to fall damage
 }
+
+PercentageIncreasedCriticalStrikeChanceAffix.Description: "{1}{0} to stat"
+PercentageCriticalStrikeMultiplierAffix.Description: "{1}{0} to stat"
+FlatCriticalStrikeChanceAffix.Description: "{1}{0} to stat"
+PercentageIncreasedCriticalStrikeDamageAffix.Description: "{1}{0} to stat"


### PR DESCRIPTION
﻿### Link Issues
Resolves: #387

### Description of Work
Adds in flag for if the player has obtained a Grimoire.
Hides the Grimoire UI if the above flag is false.
Fixed Minera's reference to an nonexistent NPC component.
Added NPCHitEffects.OnDeath for ease-of-use on death effects.

### Comments
