### PR TITLE
Changed default AnchorPassive value 1->0

### DIFF
--- a/Common/Systems/PassiveTreeSystem/PassiveTreeSystem.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreeSystem.cs
@@ -86,7 +86,7 @@ internal class PassiveTreePlayer : ModPlayer
 				}
 			}
 
-			if (passive.InternalIdentifier != "Anchor" && passive.Level > 0)
+			if (passive.InternalIdentifier != "AnchorPassive" && passive.Level > 0)
 			{
 				Points -= passive.Level;
 			}

--- a/Common/UI/PassiveTree/PassiveElement.cs
+++ b/Common/UI/PassiveTree/PassiveElement.cs
@@ -52,7 +52,7 @@ internal class PassiveElement : SmartUiElement
 		// Anchor passive should always be "unlocked", thus this hardcoding
 		if (_passive is AnchorPassive)
 		{
-			_passive.Level = 0;
+			_passive.Level = 1;
 		}
 	}
 

--- a/Common/UI/PassiveTree/PassiveElement.cs
+++ b/Common/UI/PassiveTree/PassiveElement.cs
@@ -52,7 +52,7 @@ internal class PassiveElement : SmartUiElement
 		// Anchor passive should always be "unlocked", thus this hardcoding
 		if (_passive is AnchorPassive)
 		{
-			_passive.Level = 1;
+			_passive.Level = 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes interface showing -1 in the skill tree when player saves as new character and re-enters world.

﻿### Link Issues
Resolves: [#389](https://github.com/Path-of-Terraria/PathOfTerraria/issues/389)

### Description of Work
Changes hard-coded value of 1->0 for AnchorPassive

### Comments
Characters already affected by this issue will need to save and quit for fix to take place.