### PR TITLE
replaced goblin scout check with a blanket wipe for Ravencrest's spaw…

### DIFF
--- a/Common/Subworlds/RavencrestSubworld.cs
+++ b/Common/Subworlds/RavencrestSubworld.cs
@@ -2,6 +2,7 @@
 using PathOfTerraria.Common.Subworlds.Passes;
 using PathOfTerraria.Common.Systems.DisableBuilding;
 using PathOfTerraria.Common.World.Generation;
+using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
 using System.Collections.Generic;
 using Terraria.DataStructures;
@@ -47,12 +48,15 @@ internal class RavencrestSubworld : MappingWorld
 
 	public class RavencrestNPC : GlobalNPC 
 	{
-		public override void OnSpawn(NPC npc, IEntitySource source)
+		public override void EditSpawnPool(IDictionary<int, float> pool, NPCSpawnInfo spawnInfo)
 		{
-			if (SubworldSystem.Current is RavencrestSubworld && npc.type == NPCID.GoblinScout)
+			if (Main.invasionType == InvasionID.GoblinArmy && Main.invasionSize > 0)
 			{
-				npc.active = false;
+				return;
 			}
+
+			pool.Clear();
+			pool.Add(ModContent.NPCType<TownScoutNPC>(), ModContent.GetInstance<TownScoutNPC>().SpawnChance(spawnInfo));
 		}
 	}
 }

--- a/Content/NPCs/Town/TownScoutNPC.cs
+++ b/Content/NPCs/Town/TownScoutNPC.cs
@@ -47,9 +47,18 @@ public sealed class TownScoutNPC : ModNPC
 				}
 			}
 
-			if (Math.Abs(NPC.Center.X / 16 - Main.maxTilesX / 2) > 250)
+			if (NPC.life < NPC.lifeMax)
 			{
-				NPC.velocity.X = NPC.Center.X >= Main.maxTilesX * 8 ? -3 : 3;
+				HasPlayerBeenNear = true;
+			}
+
+			if (Math.Abs(NPC.Center.X / 16 - Main.maxTilesX / 2) > 220)
+			{
+				NPC.velocity.X = NPC.Center.X / 16 >= Main.maxTilesX / 2 ? -2 : 2;
+			}
+			else
+			{
+				NPC.velocity.X = 0;
 			}
 		}
 		else
@@ -57,6 +66,7 @@ public sealed class TownScoutNPC : ModNPC
 			NPC.velocity.X = NPC.Center.X < Main.maxTilesX * 8 ? -3 : 3;
 		}
 
+		NPC.direction = NPC.spriteDirection = Math.Sign(NPC.velocity.X);
 		ModContent.GetInstance<RavencrestSystem>().SpawnedScout = true;
 		return false;
 	}
@@ -69,7 +79,7 @@ public sealed class TownScoutNPC : ModNPC
 
 	public override float SpawnChance(NPCSpawnInfo spawnInfo)
 	{
-		bool anyHealthyPlayer = false;
+		bool anyHealthyPlayer = true;
 
 		foreach (Player plr in Main.ActivePlayers)
 		{


### PR DESCRIPTION
…ns, aside from the town scout NPC

﻿### Link Issues
Resolves: #399

### Description of Work
Makes only the custom Goblin Scout NPC spawn in Ravencrest, unless the Goblin Army is active.
Fixes up custom Goblin Scout AI, which had a few issues.

### Comments
