### PR TITLE
fix every item having PoTGlobalItem, add IPoTGlobalItem for manually …

### DIFF
--- a/Core/Items/IPoTGlobalItem.cs
+++ b/Core/Items/IPoTGlobalItem.cs
@@ -1,0 +1,8 @@
+﻿namespace PathOfTerraria.Core.Items;
+
+/// <summary>
+/// Defines an item as something that uses <see cref="PoTGlobalItem"/>. Weapons, armor and accessories automatically apply <see cref="PoTGlobalItem"/>.
+/// </summary>
+internal interface IPoTGlobalItem
+{
+}

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -7,6 +7,7 @@ using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.ModPlayers;
+using System.Linq;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -34,6 +35,14 @@ partial class PoTGlobalItem
 
 	public override bool PreDrawTooltipLine(Item item, DrawableTooltipLine line, ref int yOffset)
 	{
+		// Reduce size of tooltips to fit the "Description"s we add in
+		if (line.Name.StartsWith("Tooltip"))
+		{
+			yOffset = -2;
+			line.BaseScale = new Vector2(0.8f);
+			return true;
+		}
+
 		// Don't mess with tooltip lines that we aren't responsible for.
 		if (line.Mod != Mod.Name)
 		{
@@ -91,6 +100,8 @@ partial class PoTGlobalItem
 	public override void ModifyTooltips(Item item, List<TooltipLine> tooltips)
 	{
 		base.ModifyTooltips(item, tooltips);
+
+		List<TooltipLine> oldTooltips = tooltips.Where(x => x.Name.StartsWith("Tooltip")).ToList();
 
 		tooltips.Clear();
 
@@ -151,6 +162,8 @@ partial class PoTGlobalItem
 		{
 			tooltips.Add(new TooltipLine(Mod, "Description", staticData.Description.Value));
 		}
+
+		tooltips.AddRange(oldTooltips);
 	}
 
 	private static string HighlightNumbers(string input, string numColor = "CCCCFF", string baseColor = "A0A0A0")

--- a/Core/Items/PoTGlobalItem.cs
+++ b/Core/Items/PoTGlobalItem.cs
@@ -19,4 +19,9 @@ internal sealed partial class PoTGlobalItem : GlobalItem
 
 		PoTItemHelper.ApplyAffixes(item, player.GetModPlayer<UniversalBuffingPlayer>().UniversalModifier, player);
 	}
+
+	public override bool AppliesToEntity(Item entity, bool lateInstantiation)
+	{
+		return entity.damage > 0 || entity.defense > 0 || entity.accessory || entity.ModItem is IPoTGlobalItem;
+	}
 }


### PR DESCRIPTION
…defining them

﻿### Link Issues
Resolves: #403 

### Description of Work
Makes weapons, armor and accessories the only things that automatically have a PoTGlobalItem instance applied to them.
Added IPoTGlobalItem interface for defining something that doesn't fit the above criteria but needs to have a PoTGlobalItem.
Restores vanilla tooltips to items with a PoTGlobalItem instance by moving them to the bottom and reducing their size to fit our "Description" tooltip lines.

### Comments
