### PR TITLE
Sync every remaining domain

### DIFF
--- a/Common/Subworlds/BossDomainSystem.cs
+++ b/Common/Subworlds/BossDomainSystem.cs
@@ -6,10 +6,13 @@ internal class BossDomainSystem : ModSystem
 {
 	public override void PreUpdateGores()
 	{
-		if (SubworldSystem.Current is BossDomainSubworld domain && domain.ForceTime.time != -1)
+		if (SubworldSystem.Current is BossDomainSubworld domain)
 		{
-			Main.time = domain.ForceTime.time;
-			Main.dayTime = domain.ForceTime.isDay;
+			if (domain.ForceTime.time != -1)
+			{
+				Main.time = domain.ForceTime.time;
+				Main.dayTime = domain.ForceTime.isDay;
+			}
 		}
 	}
 }

--- a/Common/Subworlds/BossDomains/EaterDomain.cs
+++ b/Common/Subworlds/BossDomains/EaterDomain.cs
@@ -13,6 +13,7 @@ using Mono.Cecil.Cil;
 using PathOfTerraria.Content.Tiles.BossDomain;
 using Terraria.Localization;
 using SubworldLibrary;
+using Terraria;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains;
 
@@ -88,7 +89,7 @@ public class EaterDomain : BossDomainSubworld
 				{
 					boneSpikes.Add(item.Key);
 				}
-				else if (WorldGen.genRand.NextBool(900))
+				else if (WorldGen.genRand.NextBool(900) && item.Value != OpenFlags.None)
 				{
 					eggs.Add(item.Key);
 				}
@@ -124,7 +125,12 @@ public class EaterDomain : BossDomainSubworld
 
 		foreach (Point16 position in eggs)
 		{
-			StructureTools.PlaceByOrigin("Assets/Structures/EaterDomain/Egg" + WorldGen.genRand.Next(3), position, new Vector2(0.5f, 0.5f), null);
+			OpenFlags flags = OpenExtensions.GetOpenings(position.X, position.Y, false, false);
+			float angle = GetAngleFromFlags(flags);
+			Vector2 angleOffset = -new Vector2(0, -10).RotatedBy(angle);
+			var placePos = new Point16(position.X + (int)angleOffset.X, position.Y + (int)angleOffset.Y);
+
+			StructureTools.PlaceByOrigin("Assets/Structures/EaterDomain/Egg" + WorldGen.genRand.Next(3), placePos, new Vector2(0.5f, 0.5f), null);
 		}
 
 		HashSet<Point16> grasses = [];
@@ -166,6 +172,86 @@ public class EaterDomain : BossDomainSubworld
 				lastStrX = pos.X;
 			}
 		}
+
+		CheckForSigns(new Point16(10, 100), new Point16(Main.maxTilesX - 20, Main.maxTilesY - 120));
+	}
+
+	private static void CheckForSigns(Point16 pos, Point16 size)
+	{
+		for (int i = pos.X; i < pos.X + size.X; ++i)
+		{
+			for (int j = pos.Y; j < pos.Y + size.Y; ++j)
+			{
+				WorldGen.TileFrame(i, j);
+
+				int sign = Sign.ReadSign(i, j, true);
+
+				if (sign != -1)
+				{
+					Sign.TextSign(sign, Language.GetText("Mods.PathOfTerraria.Generation.EaterSign." + WorldGen.genRand.Next(4))
+						.WithFormatArgs(Language.GetText("Mods.PathOfTerraria.Generation.EaterSign.Names." + WorldGen.genRand.Next(9)).Value).Value);
+				}
+			}
+		}
+	}
+
+	private float GetAngleFromFlags(OpenFlags flags)
+	{
+		List<float> angles = [];
+
+		if (flags == OpenFlags.None)
+		{
+			return float.NaN;
+		}
+
+		if (flags.HasFlag(OpenFlags.Left))
+		{
+			angles.Add(-MathHelper.PiOver2);
+		}
+
+		if (flags.HasFlag(OpenFlags.Right))
+		{
+			angles.Add(MathHelper.PiOver2);
+		}
+
+		if (flags.HasFlag(OpenFlags.Above))
+		{
+			angles.Add(0);
+		}
+
+		if (flags.HasFlag(OpenFlags.Below))
+		{
+			angles.Add(MathHelper.Pi);
+		}
+
+		if (flags.HasFlag(OpenFlags.UpLeft))
+		{
+			angles.Add(-MathHelper.PiOver4);
+		}
+
+		if (flags.HasFlag(OpenFlags.DownLeft))
+		{
+			angles.Add(-(MathHelper.PiOver2 + MathHelper.PiOver4));
+		}
+
+		if (flags.HasFlag(OpenFlags.UpRight))
+		{
+			angles.Add(MathHelper.PiOver4);
+		}
+
+		if (flags.HasFlag(OpenFlags.DownRight))
+		{
+			angles.Add(MathHelper.PiOver2 + MathHelper.PiOver4);
+		}
+
+		float angle = 0;
+
+		foreach (float ang in angles)
+		{
+			angle += ang;
+		}
+
+		return angle / angles.Count;
 	}
 
 	private static void SpawnBoneSpikes(Point16 position)
@@ -454,12 +540,10 @@ public class EaterDomain : BossDomainSubworld
 		Main.dayTime = true;
 		Main.time = Main.dayLength - 1800;
 
-		bool allInArena = true;
+		bool allInArena = Main.CurrentFrameFlags.ActivePlayersCount > 0;
 
 		foreach (Player player in Main.ActivePlayers)
 		{
-			player.GetModPlayer<StopBuildingPlayer>().ConstantStopBuilding = true;
-
 			if (allInArena && !Arena.Intersects(player.Hitbox))
 			{
 				allInArena = false;
@@ -473,8 +557,17 @@ public class EaterDomain : BossDomainSubworld
 				WorldGen.PlaceTile(Arena.X / 16 + i + 4, Arena.Y / 16 - 3, TileID.FleshBlock, true, true);
 			}
 
-			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X + 1400, Arena.Center.Y - 0, NPCID.EaterofWorldsHead, 1);
-			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X - 1400, Arena.Center.Y - 0, NPCID.EaterofWorldsHead, 1);
+			int headOne = NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X + 1400, Arena.Center.Y - 0, NPCID.EaterofWorldsHead, 1);
+			int headTwo = NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X - 1400, Arena.Center.Y - 0, NPCID.EaterofWorldsHead, 1);
+
+			if (Main.netMode == NetmodeID.Server)
+			{
+				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, headOne);
+				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, headTwo);
+				NetMessage.SendData(MessageID.WorldData);
+				NetMessage.SendTileSquare(-1, Arena.X / 16 + 4, Arena.Y - 3, 20, 1);
+			}
+
 			BossSpawned = true;
 		}
 

--- a/Common/Subworlds/BossDomains/EaterDomain.cs
+++ b/Common/Subworlds/BossDomains/EaterDomain.cs
@@ -6,14 +6,12 @@ using Terraria.ID;
 using Terraria.IO;
 using Terraria.WorldBuilding;
 using PathOfTerraria.Common.World.Generation;
-using PathOfTerraria.Common.Systems.DisableBuilding;
 using Terraria.DataStructures;
 using MonoMod.Cil;
 using Mono.Cecil.Cil;
 using PathOfTerraria.Content.Tiles.BossDomain;
 using Terraria.Localization;
 using SubworldLibrary;
-using Terraria;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains;
 
@@ -22,6 +20,7 @@ public class EaterDomain : BossDomainSubworld
 	public override int Width => 800;
 	public override int Height => 1000;
 	public override int[] WhitelistedMiningTiles => [ModContent.TileType<WeakMalaise>(), ModContent.TileType<TeethSpikes>()];
+	public override (int time, bool isDay) ForceTime => ((int)Main.dayLength - 1800, true);
 
 	public Rectangle Arena = Rectangle.Empty;
 	public bool BossSpawned = false;
@@ -89,7 +88,7 @@ public class EaterDomain : BossDomainSubworld
 				{
 					boneSpikes.Add(item.Key);
 				}
-				else if (WorldGen.genRand.NextBool(900) && item.Value != OpenFlags.None)
+				else if (WorldGen.genRand.NextBool(1200) && (item.Value == OpenFlags.Above || item.Value == OpenFlags.Below) && item.Value != (OpenFlags.Above | OpenFlags.Below))
 				{
 					eggs.Add(item.Key);
 				}
@@ -204,16 +203,6 @@ public class EaterDomain : BossDomainSubworld
 			return float.NaN;
 		}
 
-		if (flags.HasFlag(OpenFlags.Left))
-		{
-			angles.Add(-MathHelper.PiOver2);
-		}
-
-		if (flags.HasFlag(OpenFlags.Right))
-		{
-			angles.Add(MathHelper.PiOver2);
-		}
-
 		if (flags.HasFlag(OpenFlags.Above))
 		{
 			angles.Add(0);
@@ -222,26 +211,6 @@ public class EaterDomain : BossDomainSubworld
 		if (flags.HasFlag(OpenFlags.Below))
 		{
 			angles.Add(MathHelper.Pi);
-		}
-
-		if (flags.HasFlag(OpenFlags.UpLeft))
-		{
-			angles.Add(-MathHelper.PiOver4);
-		}
-
-		if (flags.HasFlag(OpenFlags.DownLeft))
-		{
-			angles.Add(-(MathHelper.PiOver2 + MathHelper.PiOver4));
-		}
-
-		if (flags.HasFlag(OpenFlags.UpRight))
-		{
-			angles.Add(MathHelper.PiOver4);
-		}
-
-		if (flags.HasFlag(OpenFlags.DownRight))
-		{
-			angles.Add(MathHelper.PiOver2 + MathHelper.PiOver4);
 		}
 
 		float angle = 0;
@@ -560,12 +529,13 @@ public class EaterDomain : BossDomainSubworld
 			int headOne = NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X + 1400, Arena.Center.Y - 0, NPCID.EaterofWorldsHead, 1);
 			int headTwo = NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X - 1400, Arena.Center.Y - 0, NPCID.EaterofWorldsHead, 1);
 
+			Main.spawnTileX = Arena.Center.X / 16;
+			Main.spawnTileY = Arena.Center.Y / 16;
+
 			if (Main.netMode == NetmodeID.Server)
 			{
-				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, headOne);
-				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, headTwo);
 				NetMessage.SendData(MessageID.WorldData);
-				NetMessage.SendTileSquare(-1, Arena.X / 16 + 4, Arena.Y - 3, 20, 1);
+				NetMessage.SendTileSquare(-1, Arena.X / 16 + 4, Arena.Y / 16 - 3, 20, 1);
 			}
 
 			BossSpawned = true;

--- a/Common/Subworlds/BossDomains/EyeDomain.cs
+++ b/Common/Subworlds/BossDomains/EyeDomain.cs
@@ -263,8 +263,6 @@ public class EyeDomain : BossDomainSubworld
 
 		foreach (Player player in Main.ActivePlayers)
 		{
-			player.GetModPlayer<StopBuildingPlayer>().ConstantStopBuilding = true;
-
 			if (allInArena && !Arena.Intersects(player.Hitbox))
 			{
 				allInArena = false;

--- a/Common/Subworlds/BossDomains/QueenBeeDomain.cs
+++ b/Common/Subworlds/BossDomains/QueenBeeDomain.cs
@@ -21,6 +21,7 @@ public class QueenBeeDomain : BossDomainSubworld
 	public override int Height => 800;
 	public override int[] WhitelistedCutTiles => [TileID.BeeHive, TileID.JungleVines, ModContent.TileType<RoyalHoneyClumpTile>()];
 	public override int[] WhitelistedMiningTiles => [ModContent.TileType<RoyalHoneyClumpTile>()];
+	public override (int time, bool isDay) ForceTime => ((int)Main.dayLength / 2, true);
 
 	public bool BossSpawned = false;
 	public bool ReadyToExit = false;
@@ -164,7 +165,7 @@ public class QueenBeeDomain : BossDomainSubworld
 			}
 		}
 
-		StructureTools.PlaceByOrigin($"Assets/Structures/BeeDomain/Mini_{(left ? "" : "R_")}{3}", original, new(left ? 1 : 0, 0.5f));
+		StructureTools.PlaceByOrigin($"Assets/Structures/BeeDomain/Mini_{(left ? "" : "R_")}{WorldGen.genRand.Next(4)}", original, new(left ? 1 : 0, 0.5f));
 	}
 
 	public override void OnEnter()
@@ -185,15 +186,7 @@ public class QueenBeeDomain : BossDomainSubworld
 		}
 
 		TileEntity.UpdateEnd();
-
-		Main.dayTime = true;
-		Main.time = Main.dayLength / 2;
 		Main.moonPhase = (int)MoonPhase.Full;
-
-		foreach (Player player in Main.ActivePlayers)
-		{
-			player.GetModPlayer<StopBuildingPlayer>().ConstantStopBuilding = true;
-		}
 
 		if (!BossSpawned && NPC.AnyNPCs(NPCID.QueenBee))
 		{

--- a/Common/Subworlds/BossDomains/SkeleDomain/RoomData.cs
+++ b/Common/Subworlds/BossDomains/SkeleDomain/RoomData.cs
@@ -3,6 +3,7 @@ using PathOfTerraria.Content.NPCs.BossDomain.SkeletronDomain;
 using StructureHelper;
 using System.Collections.Generic;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.SkeleDomain;
 
@@ -65,7 +66,12 @@ public readonly struct RoomData(WireColor color, OpeningType opening, Point open
 			IEntitySource source = Entity.GetSource_NaturalSpawn();
 			int type = ModContent.NPCType<ControllableSpikeball>();
 			int dir = info.SpinClockwise is null ? Main.rand.NextBool(2) ? -1 : 1 : (info.SpinClockwise.Value ? -1 : 1);
-			int whoAmI = NPC.NewNPC(source, (x + info.Position.X) * 16 + 6, (y + info.Position.Y) * 16 - 8, type, 0, info.SpinSpeed * dir, 0, 0, info.Length);
+			int whoAmI = NPC.NewNPC(source, (x + info.Position.X) * 16 + 6, (y + info.Position.Y) * 16 - 8, type, 1, info.SpinSpeed * dir, 0, 0, info.Length);
+
+			if (Main.netMode == NetmodeID.Server)
+			{
+				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, whoAmI);
+			}
 		}
 
 		if (Timers.Count > 0)

--- a/Common/Subworlds/BossDomains/SkeleDomain/RoomDatabase.cs
+++ b/Common/Subworlds/BossDomains/SkeleDomain/RoomDatabase.cs
@@ -70,29 +70,29 @@ internal class RoomDatabase : ModSystem
 		DataByRoomIndex.Add(0, new RoomData(WireColor.Yellow, OpeningType.Right, new Point(44, 29), new Point(23, 39), null, [new EngageTimerInfo(new Point16(41, 5), 0)]));
 
 		DataByRoomIndex.Add(1, new RoomData(WireColor.Blue, OpeningType.Left, new Point(0, 11), new Point(89, 56), 
-			[new SpikeballInfo(new Point16(21, 47), 80, true, 0.05f), new(new Point16(36, 47), 80, true, 0.05f), new(new Point16(49, 47), 80, true, 0.05f), 
-				new SpikeballInfo(new Point16(64, 47), 80, true, 0.05f)],
+			[new SpikeballInfo(new Point16(23, 49), 80, true, 0.05f), new(new Point16(38, 49), 80, true, 0.05f), new(new Point16(51, 49), 80, true, 0.05f), 
+				new SpikeballInfo(new Point16(66, 49), 80, true, 0.05f)],
 			[new EngageTimerInfo(new Point16(87, 5), 0), new EngageTimerInfo(new Point16(90, 11), 60)]));
 
 		DataByRoomIndex.Add(2, new RoomData(WireColor.Green, OpeningType.Above, new Point(33, 0), new Point(33, 85),
-			[new SpikeballInfo(new Point16(15, 59), 110, false), new(new Point16(49, 59), 110, false)],
+			[new SpikeballInfo(new Point16(17, 61), 110, false), new(new Point16(51, 61), 110, false)],
 			[new EngageTimerInfo(new Point16(18, 27), 0), new EngageTimerInfo(new Point16(20, 27), 45), new EngageTimerInfo(new Point16(22, 27), 90),
 				new EngageTimerInfo(new Point16(24, 27), 135), 
 				new EngageTimerInfo(new Point16(39, 34), 0), new EngageTimerInfo(new Point16(40, 34), 60), new EngageTimerInfo(new Point16(41, 34), 120)]));
 
 		DataByRoomIndex.Add(3, new RoomData(WireColor.Red, OpeningType.Right, new Point(97, 13), new Point(93, 54),
-			[new SpikeballInfo(new(30, 33), 90), new(new(53, 33), 90), new(new(76, 33), 90), new(new(30, 45), 90), new(new(53, 45), 90), new(new(76, 45), 90),
-				new SpikeballInfo(new(74, 14), 90)],
+			[new SpikeballInfo(new(32, 35), 90), new(new(55, 35), 90), new(new(78, 35), 90), new(new(32, 47), 90), new(new(55, 47), 90), new(new(78, 47), 90),
+				new SpikeballInfo(new(76, 16), 90)],
 			[new EngageTimerInfo(new(5, 7), 0), new(new(7, 9), 60), new(new(12, 49), 0)]));
 
 		// This room's entrance is offset by 10 tiles to make sure it doesn't overlap the chasms by offsetting origin.
 		DataByRoomIndex.Add(4, new RoomData(WireColor.Yellow, OpeningType.Above, new Point(24, 0), new Point(73, 72),
-			[new SpikeballInfo(new(53, 37), 90, true, 0.04f), new(new(36, 37), 90), new(new(12, 37), 90)],
+			[new SpikeballInfo(new(55, 39), 90, true, 0.04f), new(new(38, 39), 90), new(new(14, 39), 90)],
 			[new EngageTimerInfo(new(68, 25), 0), new(new(69, 25), 90), new(new(65, 67), 0), new(new(66, 67), 60), new(new(67, 67), 120), 
 				new EngageTimerInfo(new(68, 67), 180)]));
 
 		DataByRoomIndex.Add(5, new RoomData(WireColor.Blue, OpeningType.Left, new Point(1, 8), new Point(14, 78),
-			[new SpikeballInfo(new(26, 48), 90, true, 0.04f), new(new(26, 48), 180, false), new(new(26, 48), 270, true)], null));
+			[new SpikeballInfo(new(27, 50), 90, true, 0.04f), new(new(27, 50), 180, false), new(new(27, 50), 270, true)], null));
 
 		DataByRoomIndex.Add(6, new RoomData(WireColor.Green, OpeningType.Left, new Point(1, 44), new Point(6, 51), null,
 			[new EngageTimerInfo(new(61, 33), 0), new(new(63, 35), 120), new(new(60, 23), 0), new(new(61, 23), 60), new(new(62, 23), 120), new(new(63, 23), 180),

--- a/Common/Subworlds/BossDomains/SkeletronDomain.cs
+++ b/Common/Subworlds/BossDomains/SkeletronDomain.cs
@@ -38,6 +38,7 @@ public class SkeletronDomain : BossDomainSubworld
 
 	public override int Width => 900;
 	public override int Height => 1000;
+	public override (int time, bool isDay) ForceTime => ((int)Main.nightLength / 2, false);
 
 	const int BaseTunnelDepth = 90;
 
@@ -662,8 +663,6 @@ public class SkeletronDomain : BossDomainSubworld
 
 	public override void Update()
 	{
-		Main.dayTime = false;
-		Main.time = Main.nightLength / 2;
 		Wiring.UpdateMech();
 
 		bool hasProj = false;
@@ -683,12 +682,10 @@ public class SkeletronDomain : BossDomainSubworld
 			Projectile.NewProjectile(Entity.GetSource_NaturalSpawn(), position, Vector2.Zero, type, 0, 0, -1, Width / 2 * 16, (Height - 140) * 16);
 		}
 
-		bool allInArena = true;
+		bool allInArena = Main.CurrentFrameFlags.ActivePlayersCount > 0;
 
 		foreach (Player player in Main.ActivePlayers)
 		{
-			player.GetModPlayer<StopBuildingPlayer>().ConstantStopBuilding = true;
-
 			if (allInArena && !Arena.Intersects(player.Hitbox))
 			{
 				allInArena = false;
@@ -699,6 +696,14 @@ public class SkeletronDomain : BossDomainSubworld
 		{
 			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X, Arena.Center.Y, NPCID.SkeletronHead, 1);
 			BossSpawned = true;
+
+			Main.spawnTileX = Arena.Center.X / 16;
+			Main.spawnTileY = Arena.Center.Y / 16;
+
+			if (Main.netMode != NetmodeID.SinglePlayer)
+			{
+				NetMessage.SendData(MessageID.WorldData);
+			}
 		}
 
 		if (BossSpawned && !NPC.AnyNPCs(NPCID.SkeletronHead) && !ReadyToExit)

--- a/Common/Subworlds/BossDomains/WallOfFleshDomain.cs
+++ b/Common/Subworlds/BossDomains/WallOfFleshDomain.cs
@@ -601,11 +601,6 @@ public class WallOfFleshDomain : BossDomainSubworld
 		Main.time = Main.nightLength / 2;
 		Main.moonPhase = (int)MoonPhase.Full;
 
-		foreach (Player player in Main.ActivePlayers)
-		{
-			player.GetModPlayer<StopBuildingPlayer>().ConstantStopBuilding = true;
-		}
-
 		if (NPC.AnyNPCs(NPCID.WallofFlesh))
 		{
 			if (!BossSpawned) // Remove all flesh blocks
@@ -642,33 +637,6 @@ public class WallOfFleshDomain : BossDomainSubworld
 
 			BossTracker.CachedBossesDowned.Add(NPCID.WallofFlesh);
 			ReadyToExit = true;
-		}
-	}
-
-	/// <summary>
-	/// Used to clamp camera to hide the other side of the domain for a "wow" factor.
-	/// </summary>
-	public class WoFDomainSystem : ModSystem
-	{
-		public override void ModifyScreenPosition()
-		{
-			if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
-			{
-				if (domain.LeftBlocked)
-				{
-					if (Main.screenPosition.X / 16f < Main.spawnTileX - 70)
-					{
-						Main.screenPosition.X = (Main.spawnTileX - 70) * 16;
-					}
-				}
-				else
-				{
-					if ((Main.screenPosition.X + Main.screenWidth) / 16f > Main.spawnTileX + 70)
-					{
-						Main.screenPosition.X = (Main.spawnTileX + 70) * 16 - Main.screenWidth;
-					}
-				}
-			}
 		}
 	}
 }

--- a/Common/Subworlds/BossDomains/WoFDomain/ArenaEnemyNPC.cs
+++ b/Common/Subworlds/BossDomains/WoFDomain/ArenaEnemyNPC.cs
@@ -1,8 +1,29 @@
-﻿namespace PathOfTerraria.Common.Subworlds.BossDomains.WoFDomain;
+﻿using System.IO;
+using Terraria.ModLoader.IO;
+
+namespace PathOfTerraria.Common.Subworlds.BossDomains.WoFDomain;
 
 internal class ArenaEnemyNPC : GlobalNPC
 {
 	public override bool InstancePerEntity => true;
+	protected override bool CloneNewInstances => true;
 
 	public bool Arena = false;
+
+	public override GlobalNPC Clone(NPC from, NPC to)
+	{
+		GlobalNPC clone = base.Clone(from, to);
+		(clone as ArenaEnemyNPC).Arena = Arena;
+		return clone;
+	}
+
+	public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
+	{
+		bitWriter.WriteBit(Arena);
+	}
+
+	public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
+	{
+		Arena = bitReader.ReadBit();
+	}
 }

--- a/Common/Subworlds/BossDomains/WoFDomain/WoFDomainSystem.cs
+++ b/Common/Subworlds/BossDomains/WoFDomain/WoFDomainSystem.cs
@@ -1,0 +1,47 @@
+﻿using SubworldLibrary;
+using System.IO;
+
+namespace PathOfTerraria.Common.Subworlds.BossDomains;
+
+/// <summary>
+/// Used to clamp camera to hide the other side of the domain for a "wow" factor.
+/// </summary>
+public class WoFDomainSystem : ModSystem
+{
+	public override void ModifyScreenPosition()
+	{
+		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
+		{
+			if (domain.LeftBlocked)
+			{
+				if (Main.screenPosition.X / 16f < Main.spawnTileX - 70)
+				{
+					Main.screenPosition.X = (Main.spawnTileX - 70) * 16;
+				}
+			}
+			else
+			{
+				if ((Main.screenPosition.X + Main.screenWidth) / 16f > Main.spawnTileX + 70)
+				{
+					Main.screenPosition.X = (Main.spawnTileX + 70) * 16 - Main.screenWidth;
+				}
+			}
+		}
+	}
+
+	public override void NetSend(BinaryWriter writer)
+	{
+		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
+		{
+			writer.Write(domain.LeftBlocked);
+		}
+	}
+
+	public override void NetReceive(BinaryReader reader)
+	{
+		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
+		{
+			domain.LeftBlocked = reader.ReadBoolean();
+		}
+	}
+}

--- a/Common/Systems/MiscUtilities/BlockerSystem.cs
+++ b/Common/Systems/MiscUtilities/BlockerSystem.cs
@@ -8,13 +8,13 @@ public class BlockerSystem : ModSystem
 	internal static float FadeOut = 0;
 	internal static bool HasArenaEnemies = false;
 
-	public override void PreUpdateWorld()
+	public override void PreUpdatePlayers()
 	{
 		HasArenaEnemies = false;
 
 		foreach (NPC npc in Main.ActiveNPCs)
 		{
-			if (npc.GetGlobalNPC<ArenaEnemyNPC>().Arena)
+			if (npc.TryGetGlobalNPC(out ArenaEnemyNPC enemy) && enemy.Arena)
 			{
 				HasArenaEnemies = true;
 				break;

--- a/Content/NPCs/BossDomain/SkeletronDomain/ControllableSpikeball.cs
+++ b/Content/NPCs/BossDomain/SkeletronDomain/ControllableSpikeball.cs
@@ -35,13 +35,14 @@ public sealed class ControllableSpikeball : ModNPC
 		NPC.Size = new Vector2(46);
 		NPC.scale = 1f;
 		NPC.ShowNameOnHover = false;
+		NPC.netAlways = true;
 	}
 
 	public override void AI()
 	{
-		if (!IsInitialized)
+		if (!IsInitialized && Main.netMode != NetmodeID.MultiplayerClient)
 		{
-			Anchor = NPC.Center;
+			Anchor = NPC.position - new Vector2(8, 2);
 
 			if (Length == 0f)
 			{

--- a/Content/Projectiles/Teleportal.cs
+++ b/Content/Projectiles/Teleportal.cs
@@ -16,6 +16,7 @@ internal class Teleportal : ModProjectile
 		Projectile.tileCollide = false;
 		Projectile.Size = new Vector2(80, 80);
 		Projectile.Opacity = 0f;
+		Projectile.netImportant = true;
 	}
 
 	public override bool? CanDamage()

--- a/Content/Tiles/BossDomain/CorruptSacks.cs
+++ b/Content/Tiles/BossDomain/CorruptSacks.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.DataStructures;
+﻿using PathOfTerraria.Common.Systems.Networking.Handlers;
+using Terraria.DataStructures;
 using Terraria.Enums;
 using Terraria.GameContent;
 using Terraria.ID;
@@ -36,9 +37,18 @@ internal class CorruptSacks : ModTile
 
 	public override void KillMultiTile(int i, int j, int frameX, int frameY)
 	{
-		int npc = NPC.NewNPC(new EntitySource_TileBreak(i, j), (i + 1) * 16, (j + 1) * 16, Main.rand.NextBool(6) ? NPCID.DevourerHead : NPCID.EaterofSouls, 1);
-		Main.npc[npc].velocity = AwayFromNearestPlayer(i, j) * Main.rand.NextFloat(5, 8);
-		Main.npc[npc].netUpdate = true;
+		int type = Main.rand.NextBool(6) ? NPCID.DevourerHead : NPCID.EaterofSouls;
+
+		if (Main.netMode != NetmodeID.MultiplayerClient)
+		{
+			int npc = NPC.NewNPC(new EntitySource_TileBreak(i, j), (i + 1) * 16, (j + 1) * 16, type, 1);
+			Main.npc[npc].velocity = AwayFromNearestPlayer(i, j) * Main.rand.NextFloat(5, 8);
+			Main.npc[npc].netUpdate = true;
+		}
+		else
+		{
+			SpawnNPCOnServerHandler.Send((short)type, new((i + 1) * 16, (j + 1) * 16));
+		}
 
 		for (int k = 0; k < 16; k++)
 		{

--- a/Content/Tiles/BossDomain/CorruptSacks.cs
+++ b/Content/Tiles/BossDomain/CorruptSacks.cs
@@ -38,16 +38,17 @@ internal class CorruptSacks : ModTile
 	public override void KillMultiTile(int i, int j, int frameX, int frameY)
 	{
 		int type = Main.rand.NextBool(6) ? NPCID.DevourerHead : NPCID.EaterofSouls;
+		Vector2 velocity = AwayFromNearestPlayer(i, j) * Main.rand.NextFloat(5, 8);
 
 		if (Main.netMode != NetmodeID.MultiplayerClient)
 		{
 			int npc = NPC.NewNPC(new EntitySource_TileBreak(i, j), (i + 1) * 16, (j + 1) * 16, type, 1);
-			Main.npc[npc].velocity = AwayFromNearestPlayer(i, j) * Main.rand.NextFloat(5, 8);
+			Main.npc[npc].velocity = velocity;
 			Main.npc[npc].netUpdate = true;
 		}
 		else
 		{
-			SpawnNPCOnServerHandler.Send((short)type, new((i + 1) * 16, (j + 1) * 16));
+			SpawnNPCOnServerHandler.Send((short)type, new((i + 1) * 16, (j + 1) * 16), velocity);
 		}
 
 		for (int k = 0; k < 16; k++)

--- a/Content/Tiles/BossDomain/HiveSpawner.cs
+++ b/Content/Tiles/BossDomain/HiveSpawner.cs
@@ -1,4 +1,7 @@
 ﻿using PathOfTerraria.Common.Subworlds.BossDomains.WoFDomain;
+using PathOfTerraria.Common.Systems.Networking.Handlers;
+using PathOfTerraria.Content.NPCs.BossDomain.BrainDomain;
+using Terraria;
 using Terraria.DataStructures;
 using Terraria.Enums;
 using Terraria.ID;
@@ -32,6 +35,11 @@ internal class HiveSpawner : ModTile
 
 		WorldGen.KillTile(i, j);
 		Wiring.SkipWire(i, j);
+
+		if (Main.netMode == NetmodeID.Server)
+		{
+			NetMessage.SendTileSquare(-1, i, j);
+		}
 	}
 
 	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem)
@@ -53,8 +61,8 @@ internal class HiveSpawner : ModTile
 		for (int k = 0; k < repeats; ++k)
 		{
 			int npc = NPC.NewNPC(new EntitySource_TileBreak(i, j), (i + 1) * 16, (j + 1) * 16, type, 1);
-			Main.npc[npc].netUpdate = true;
 			Main.npc[npc].GetGlobalNPC<ArenaEnemyNPC>().Arena = true;
+			Main.npc[npc].netUpdate = true;
 
 			if (type == NPCID.Bee)
 			{

--- a/Content/Tiles/BossDomain/Pustule.cs
+++ b/Content/Tiles/BossDomain/Pustule.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Content.NPCs.BossDomain.BrainDomain;
+﻿using PathOfTerraria.Common.Systems.Networking.Handlers;
+using PathOfTerraria.Content.NPCs.BossDomain.BrainDomain;
 using PathOfTerraria.Content.Projectiles.Hostile;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -41,9 +42,17 @@ internal class Pustule : ModTile
 
 			for (int k = 0; k < length; ++k)
 			{
-				int npc = NPC.NewNPC(new EntitySource_TileBreak(i, j), (i + 1) * 16, (j + 1) * 16, ModContent.NPCType<Minera>(), 1);
-				Main.npc[npc].velocity = new Vector2(0, -Main.rand.NextFloat(5, 8)).RotatedByRandom(0.9f);
-				Main.npc[npc].netUpdate = true;
+				if (Main.netMode != NetmodeID.MultiplayerClient)
+				{
+					int npc = NPC.NewNPC(new EntitySource_TileBreak(i, j), (i + 1) * 16, (j + 1) * 16, ModContent.NPCType<Minera>(), 1);
+					Main.npc[npc].velocity = new Vector2(0, -Main.rand.NextFloat(5, 8)).RotatedByRandom(0.9f);
+					Main.npc[npc].netUpdate = true;
+				}
+				else
+				{
+					Vector2 vel = new Vector2(0, -Main.rand.NextFloat(5, 8)).RotatedByRandom(0.9f);
+					SpawnNPCOnServerHandler.Send((short)ModContent.NPCType<Minera>(), new Vector2((i + 1) * 16, (j + 1) * 16), vel);
+				}
 			}
 		}
 		else 

--- a/Content/Tiles/BossDomain/UnderworldSpawnerTile.cs
+++ b/Content/Tiles/BossDomain/UnderworldSpawnerTile.cs
@@ -32,6 +32,11 @@ internal class UnderworldSpawnerTile : ModTile
 
 		WorldGen.KillTile(i, j);
 		Wiring.SkipWire(i, j);
+
+		if (Main.netMode == NetmodeID.Server)
+		{
+			NetMessage.SendTileSquare(-1, i, j);
+		}
 	}
 
 	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem)

--- a/Localization/en-US/Mods.PathOfTerraria.Generation.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Generation.hjson
@@ -6,7 +6,7 @@ Arenas: Building arenas
 Pathway: Discovering pathway
 RavenPass: Nevermore
 
-EaterSigns: {
+EaterSign: {
 	0: "{0} was instantly devoured."
 	1: "{0} fell into an Eater's jaws."
 	2: The Eater found {0}'s flesh very tasty.

--- a/Localization/en-US/Mods.PathOfTerraria.Generation.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Generation.hjson
@@ -5,3 +5,22 @@ Steps: Building steps
 Arenas: Building arenas
 Pathway: Discovering pathway
 RavenPass: Nevermore
+
+EaterSigns: {
+	0: "{0} was instantly devoured."
+	1: "{0} fell into an Eater's jaws."
+	2: The Eater found {0}'s flesh very tasty.
+	3: "{0} was digested."
+
+	Names: {
+		0: Ronny
+		1: Jameson
+		2: Evan
+		3: Polly
+		4: Sylvia
+		5: Liara
+		6: Svetlana
+		7: Obie
+		8: Jane-Ashley
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: n/a

### Description of Work
Syncs and improves every single domain. Specifically,
Eater: Fixes arena check, spawn change, egg prefab placement (shouldn't block passages now), corrupt sack spawning in mp. updates time, adds in sign text
Brain of Cthulhu: Fixes time, arena & spawn check, 
Queen Bee: Fixes lack of randomization on rooms, updates time
Deerclops: Fixes time, spawn check, poor structure placement,
Skeletron: Fixes spikeball placement, syncing, arena check
Wall of Flesh: Fixes camera restriction

### Comments
This was originally going to be just EoW, but it was so quick I just did the rest. Sorry for the larger PR!