### PR TITLE
Fix Affixes & Many More

### DIFF
--- a/Common/Enums/ItemType.cs
+++ b/Common/Enums/ItemType.cs
@@ -22,15 +22,20 @@ public enum ItemType : long
 	MeleeFlail = 1 << 15,
 	RangedFlail = 1 << 16,
 	Launcher = 1 << 17,
+	Javelin = 1 << 18,
+	Whip = 1 << 19,
+	WarShield = 1 << 20,
+	Grimoire = 1 << 21,
 
 	Armor = Helmet | Chestplate | Leggings,
 	Accessories = Ring | Charm,
 	Equipment = Armor | Accessories,
 
-	Melee = Sword | Spear | MeleeFlail,
+	Melee = Sword | Spear | MeleeFlail | WarShield,
 	Magic = Staff | Tome | Wand,
-	Ranged = Bow | Gun | Boomerang | RangedFlail | Launcher,
-	Weapon = Melee | Magic | Ranged,
+	Ranged = Bow | Gun | Boomerang | RangedFlail | Launcher | Javelin,
+	Summoner = Whip | Grimoire,
+	Weapon = Melee | Magic | Ranged | Whip,
 
 	AllGear = Equipment | Weapon,
 

--- a/Common/Systems/Affixes/AffixTooltipsHandler.cs
+++ b/Common/Systems/Affixes/AffixTooltipsHandler.cs
@@ -86,6 +86,12 @@ public class AffixTooltipsHandler
 	{
 		if (Tooltips.TryGetValue(type, out AffixTooltip tooltip))
 		{
+			if (!tooltip.ValueBySource.ContainsKey(source))
+			{
+				tooltip.OriginalValueBySource.Add(source, value);
+				tooltip.ValueBySource.Add(source, 0);
+			}
+
 			tooltip.ValueBySource[source] = value;
 
 			if (tooltip.ValueBySource[source] == tooltip.OriginalValueBySource[source])

--- a/Common/Systems/Affixes/ItemTypes/ModifyHitAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ModifyHitAffixes.cs
@@ -78,7 +78,7 @@ internal class BuffPoisonedHitsAffix : ItemAffix
 			
 			if (target.HasBuff(BuffID.Poisoned))
 			{
-				modifiers.FinalDamage += Player.GetModPlayer<AffixPlayer>().StrengthOf<BuffPoisonedHitsAffix>();
+				modifiers.FinalDamage += Player.GetModPlayer<AffixPlayer>().StrengthOf<BuffPoisonedHitsAffix>() * 0.01f;
 			}
 		}
 	}

--- a/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
@@ -11,7 +11,7 @@ internal class IncreasedAttackSpeedAffix : ItemAffix
 
 	public override void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
 	{
-		handler.AddOrModify(GetType(), item,Value * 100, this.GetLocalization("Description"), null);
+		handler.AddOrModify(GetType(), item, Value, this.GetLocalization("Description"), null);
 	}
 }
 
@@ -35,11 +35,11 @@ internal class IncreasedDamageAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Damage += Value / 100;
+		modifier.Damage += Value / 500;
 	}
 
 	public override void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
 	{
-		handler.AddOrModify(GetType(), item,Value / 100, this.GetLocalization("Description"), null);
+		handler.AddOrModify(GetType(), item, Value / 5, this.GetLocalization("Description"), null);
 	}
 }

--- a/Common/Systems/MobSystem/MobAPRGSystem.cs
+++ b/Common/Systems/MobSystem/MobAPRGSystem.cs
@@ -6,6 +6,7 @@ using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Core.Items;
 using SubworldLibrary;
 using Terraria.ID;
 using Terraria.ModLoader.IO;
@@ -187,8 +188,8 @@ internal class MobAprgSystem : GlobalNPC
 		List<MobAffix> possible = AffixHandler.GetAffixes(Rarity);
 		_affixes = Rarity switch
 		{
-			ItemRarity.Magic => Affix.GenerateAffixes(possible, Main.rand.Next(1, 3)),
-			ItemRarity.Rare => Affix.GenerateAffixes(possible, Main.rand.Next(2, 5)),
+			ItemRarity.Magic => Affix.GenerateAffixes(possible, PoTItemHelper.GetAffixCount(Rarity)),
+			ItemRarity.Rare => Affix.GenerateAffixes(possible, PoTItemHelper.GetAffixCount(Rarity)),
 			_ => []
 		};
 

--- a/Content/Items/Currency/GlimmeringShard.cs
+++ b/Content/Items/Currency/GlimmeringShard.cs
@@ -30,7 +30,6 @@ internal class GlimmeringShard : CurrencyShard
 
 	public override void RightClick(Player player)
 	{
-		player.HeldItem.GetInstanceData().Affixes.Clear();
 		PoTItemHelper.Roll(player.HeldItem, player.HeldItem.GetInstanceData().RealLevel);
 	}
 }

--- a/Content/Items/Gear/Weapons/Boomerangs/Boomerang.cs
+++ b/Content/Items/Gear/Weapons/Boomerangs/Boomerang.cs
@@ -37,6 +37,9 @@ internal abstract class Boomerang : Gear, GetItemLevel.IItem
 		Item.useAnimation = 10;
 		Item.useStyle = ItemUseStyleID.Shoot;
 		Item.channel = true;
+
+		PoTInstanceItemData data = this.GetInstanceData();
+		data.ItemType = Common.Enums.ItemType.Boomerang;
 	}
 
 	public override bool CanUseItem(Player player)

--- a/Content/Items/Gear/Weapons/Bow/Bow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Bow.cs
@@ -56,11 +56,15 @@ internal abstract class Bow : Gear
 		Item.useStyle = ItemUseStyleID.Shoot;
 		Item.channel = true;
 		Item.UseSound = null;
+
+		PoTInstanceItemData data = this.GetInstanceData();
+		data.ItemType = Common.Enums.ItemType.Bow;
 	}
 
 	public override void HoldItem(Player player)
 	{
 		base.HoldItem(player);
+
 		if (player.altFunctionUse != 2 || !player.channel)
 		{
 			_isChanneling = false;

--- a/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
+++ b/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
@@ -43,7 +43,7 @@ internal class GrimoireItem : Gear
 		Item.noMelee = true;
 
 		PoTInstanceItemData data = this.GetInstanceData();
-		data.ItemType = ItemType.Magic;
+		data.ItemType = ItemType.Grimoire;
 	}
 
 	public override bool AltFunctionUse(Player player)

--- a/Content/Items/Gear/Weapons/Javelins/Javelin.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Javelin.cs
@@ -57,6 +57,9 @@ internal abstract class Javelin : Gear
 		Item.noUseGraphic = true;
 		Item.Size = new(12);
 		Item.useAmmo = AmmoID.None;
+
+		PoTInstanceItemData data = this.GetInstanceData();
+		data.ItemType = Common.Enums.ItemType.Javelin;
 	}
 
 	public override bool CanUseItem(Player player)

--- a/Content/Items/Gear/Weapons/Staff/Staff.cs
+++ b/Content/Items/Gear/Weapons/Staff/Staff.cs
@@ -41,6 +41,9 @@ internal abstract class Staff : Gear
 		Item.channel = true;
 		Item.autoReuse = true;
 		Item.mana = 12;
+
+		PoTInstanceItemData data = this.GetInstanceData();
+		data.ItemType = Common.Enums.ItemType.Staff;
 	}
 
 	public override bool? CanAutoReuseItem(Player player)

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -99,6 +99,8 @@ internal class BloodOath : Sword, GenerateName.IItem
 
 	public override void HoldItem(Player player)
 	{
+		base.HoldItem(player);
+
 		if (_specialOn && Main.rand.NextBool(12))
 		{ 
 			Dust.NewDust(player.GetFrontHandPosition(Player.CompositeArmStretchAmount.None, 4f) + new Vector2(0, 4), 1, 1, DustID.Firework_Red);

--- a/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
+++ b/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
@@ -63,6 +63,8 @@ internal class StarlightBulwark : LeadBattleBulwark
 
 	public override void HoldItem(Player player)
 	{
+		base.HoldItem(player);
+
 		if (player.GetModPlayer<WarShieldPlayer>().Bashing)
 		{
 			if (_projTimer++ % (_specialAlt ? 6 : 3) == 0)

--- a/Content/Items/Gear/Weapons/WarShields/WarShield.cs
+++ b/Content/Items/Gear/Weapons/WarShields/WarShield.cs
@@ -67,6 +67,9 @@ internal abstract class WarShield : Gear, IParryItem, GetItemLevel.IItem
 		Item.noUseGraphic = true;
 		Item.crit = 6;
 		Item.knockBack = 8;
+
+		PoTInstanceItemData data = this.GetInstanceData();
+		data.ItemType = Common.Enums.ItemType.WarShield;
 	}
 
 	public override bool CanUseItem(Player player)

--- a/Content/Items/Gear/Weapons/Whip/Whip.cs
+++ b/Content/Items/Gear/Weapons/Whip/Whip.cs
@@ -52,6 +52,9 @@ internal abstract class Whip : Gear
 
 		Item.DefaultToWhip(ModContent.ProjectileType<WhipBaseProjectile>(), 5, 2, 4);
 		Item.channel = true;
+
+		PoTInstanceItemData data = this.GetInstanceData();
+		data.ItemType = Common.Enums.ItemType.Whip;
 	}
 
 	public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Core/Items/PoTGlobalItem.Data.cs
+++ b/Core/Items/PoTGlobalItem.Data.cs
@@ -53,7 +53,7 @@ public sealed class PoTInstanceItemData : GlobalItem
 	/// <summary>
 	///		The affixes of the item.
 	/// </summary>
-	public List<ItemAffix> Affixes { get; private set; } = [];
+	public List<ItemAffix> Affixes { get; internal set; } = [];
 
 	/// <summary>
 	///		The amount of implicit affixes preceding rolled ones.

--- a/Core/Items/PoTGlobalItem.cs
+++ b/Core/Items/PoTGlobalItem.cs
@@ -10,7 +10,8 @@ internal sealed partial class PoTGlobalItem : GlobalItem
 	{
 		base.SetDefaults(entity);
 
-		PoTItemHelper.Roll(entity, PoTItemHelper.PickItemLevel());
+		// Makes Affixes use a new reference so that rerolling or updating Affixes in another instance doesn't share the reference
+		entity.GetInstanceData().Affixes = [];
 	}
 
 	public override void UpdateEquip(Item item, Player player)
@@ -22,6 +23,9 @@ internal sealed partial class PoTGlobalItem : GlobalItem
 
 	public override bool AppliesToEntity(Item entity, bool lateInstantiation)
 	{
-		return entity.damage > 0 || entity.defense > 0 || entity.accessory || entity.ModItem is IPoTGlobalItem;
+		bool anyValidTrait = entity.damage > 0 || entity.defense > 0 || entity.accessory || entity.headSlot > 0 || entity.bodySlot > 0 || 
+			entity.legSlot > 0 || entity.ModItem is IPoTGlobalItem;
+
+		return anyValidTrait && !entity.vanity;
 	}
 }

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -160,9 +160,14 @@ public static class PoTItemHelper
 
 	public static int GetAffixCount(Item item)
 	{
-		return item.GetInstanceData().Rarity switch
+		return GetAffixCount(item.GetInstanceData().Rarity);
+	}
+
+	public static int GetAffixCount(ItemRarity rarity)
+	{
+		return rarity switch
 		{
-			ItemRarity.Magic => 2,
+			ItemRarity.Magic => Main.rand.Next(1, 3),
 			ItemRarity.Rare => Main.rand.Next(3, 5),
 			_ => 0
 		};

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -1,4 +1,19 @@
+Rarity: {
+	Normal: ""
+	Magic: "Magic "
+	Rare: "Rare "
+	Unique: "Unique "
+}
+
+Influence: {
+	None: ""
+	Lunar: "Lunar "
+	Solar: "Solar "
+}
+
 Chestplate: {
+	Name: Chestplate
+
 	Prefixes: {
 		0: Enduring
 		1: Dreadknight's
@@ -18,6 +33,8 @@ Chestplate: {
 }
 
 Helmet: {
+	Name: Helmet
+
 	Prefixes: {
 		0: Adept
 		1: Tattered
@@ -36,6 +53,8 @@ Helmet: {
 }
 
 Leggings: {
+	Name: Leggings
+
 	Prefixes: {
 		0: Eagle
 		1: Swift
@@ -54,6 +73,7 @@ Leggings: {
 }
 
 Battleaxe: {
+	Name: Battle Axe
 	AltUse: Sacrifice 5 life to increase damage temporarily. Take more damage during the effect.
 
 	Prefixes: {
@@ -74,6 +94,7 @@ Battleaxe: {
 }
 
 Boomerang: {
+	Name: Boomerang
 	AltUse: Send the boomerang in a quick spiral around you.
 
 	Prefixes: {
@@ -94,6 +115,7 @@ Boomerang: {
 }
 
 Bow: {
+	Name: Bow
 	AltUse: Charge and fire a significantly stronger and faster shot.
 
 	Prefixes: {
@@ -114,6 +136,7 @@ Bow: {
 }
 
 Staff: {
+	Name: Staff
 	AltUse: Overcharge your mana for a short time, summoning projectiles four times faster and automatically firing them
 
 	Prefixes: {
@@ -134,6 +157,7 @@ Staff: {
 }
 
 Sword: {
+	Name: Sword
 	AltUse: Summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
 
 	Prefixes: {
@@ -153,8 +177,10 @@ Sword: {
 	}
 }
 
-# Spellbook and Wand are the same as Staff at the moment.
+# Spellbook is the same as Staff at the moment.
 Spellbook: {
+	Name: Spellbook
+
 	Prefixes: {
 		0: Arcane
 		1: Mystic
@@ -173,26 +199,28 @@ Spellbook: {
 }
 
 Wand: {
+	Name: Wand
 	AltUse: Summon 4x the normal mana cost to send a flurry of projectiles forward
 
 	Prefixes: {
-		0: Arcane
-		1: Mystic
-		2: Eldritch
-		3: Luminous
+		0: Forbidden
+		1: Ancient
+		2: Holy
+		3: Ominous
 		4: Sacred
 	}
 
 	Suffixes: {
-		0: Wrath
-		1: Whisper
-		2: Beacon
-		3: Veil
-		4: Echo
+		0: of Fury
+		1: of Creation
+		2: of Destruction
+		3: of Memories
+		4: of Death
 	}
 }
 
 Whip: {
+	Name: Whip
 	AltUse: Whip once in front of and once behind you in quick succession.
 
 	Prefixes: {
@@ -213,6 +241,7 @@ Whip: {
 }
 
 Javelin: {
+	Name: Javelin
 	AltUse: Dash towards the cursor, stabbing the first enemy you hit for high damage.
 
 	Prefixes: {
@@ -233,6 +262,7 @@ Javelin: {
 }
 
 Grimoire: {
+	Name: Grimoire
 	AltUse: Command your conjurations to go towards your cursor.
 
 	Prefixes: {
@@ -253,6 +283,7 @@ Grimoire: {
 }
 
 WarShield: {
+	Name: War Shield
 	AltUse: Block or reflect projectiles and incoming hits, dealing damage in return.
 
 	Prefixes: {
@@ -263,12 +294,11 @@ WarShield: {
 		4: Great
 	}
 
-	# TBD
 	Suffixes: {
-		0: of Sin
-		1: of Death
-		2: of Fury
-		3: of Limbo
-		4: of Hell
+		0: of Bashing
+		1: of Power
+		2: of Strength
+		3: of Resilience
+		4: of Conquery
 	}
 }

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -541,7 +541,7 @@ GemWand: {
 
 CopperStaff: {
 	DisplayName: Copper Staff
-	Tooltip: Uses
+	Tooltip: ""
 }
 
 IronStaff: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #436

### Description of Work
- Makes Magic rarity items roll either 1 or 2 affixes, not just always 2
- Adds in ItemTypes for Javelins, Grimoires, WarShields, Whips, and updates the class entries to have the new flags
- Fixes crash in AffixTooltipsHandler caused by having 2 sources for the same value
- Fixed BuffPoisonedHitsAffix being 100x stronger than it should be
- Adjusted IncreasedDamageAffix to be balanced and display the proper value
- Fixed IncreasedDamageAffix displaying the wrong value in tooltips
- Fix all Gear items which override HoldItem not calling base, thus breaking the tooltipping functionality Gear runs
- Fix PoTInstanceItemData.SpecialName not being set for vanilla items that are crafted
- Fix PoTItem names lack of localization
- Stop PoTGlobalItem from rolling affixes in SetDefaults, breaking tooltips - replaced with creating a new Affixes list to avoid instancing issues
- Added all non-vanity armor pieces to the list of valid items to get a PoTGlobalItem
- Tons of localization polish

### Comments
This is much larger of a PR than I'd like for it to be, but I couldn't stop finding issues. Hopefully there's no silent error that escaped from me.