### PR TITLE
Fix grimoire

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -87,11 +87,6 @@ public class AffixRegistry : ILoadable
 			{
 				Type type = types.FirstOrDefault(x => x.Name == data.AffixType);
 
-				if (type == typeof(ChanceToApplyPoisonItemAffix))
-				{
-					int i = 0;
-				}
-
 				if (type is null || !jsonDataMap.TryAdd(type, data))
 				{
 					Console.WriteLine($"Affix of type {data.AffixType} not found.");

--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Systems.Affixes;
+using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using Terraria.ModLoader.Core;
 
 namespace PathOfTerraria.Common.Data;
@@ -85,6 +86,11 @@ public class AffixRegistry : ILoadable
 			foreach (ItemAffixData data in datas)
 			{
 				Type type = types.FirstOrDefault(x => x.Name == data.AffixType);
+
+				if (type == typeof(ChanceToApplyPoisonItemAffix))
+				{
+					int i = 0;
+				}
 
 				if (type is null || !jsonDataMap.TryAdd(type, data))
 				{

--- a/Common/Data/Affixes/ModifyHitAffixes.json
+++ b/Common/Data/Affixes/ModifyHitAffixes.json
@@ -212,7 +212,7 @@
 	},
 	{
 		"affixType": "ChanceToApplyPoisonItemAffix",
-		"equipTypes": "Weapon",
+		"equipTypes": "Weapon Grimoire",
 		"influences": "None",
 		"tiers": [
 			{

--- a/Common/Data/Affixes/OnKillAffixes.json
+++ b/Common/Data/Affixes/OnKillAffixes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"affixType": "HealOnKillingBurningEnemiesAffix",
-		"equipTypes": "Weapon",
+		"equipTypes": "Weapon Grimoire",
 		"tiers": [
 			{
 				"minValue": 1,

--- a/Common/Data/Affixes/PassiveAffixes.json
+++ b/Common/Data/Affixes/PassiveAffixes.json
@@ -61,7 +61,7 @@
 	},
 	{
 		"affixType": "AddedDamageAffix",
-		"equipTypes": "Melee",
+		"equipTypes": "Melee Grimoire",
 		"tiers": [
 			{
 				"minValue": 1,
@@ -91,7 +91,7 @@
 	},
 	{
 		"affixType": "IncreasedDamageAffix",
-		"equipTypes": "Weapon",
+		"equipTypes": "Weapon Grimoire",
 		"tiers": [
 			{
 				"minValue": 1,

--- a/Common/Systems/ModPlayers/GrimoireStoragePlayer.cs
+++ b/Common/Systems/ModPlayers/GrimoireStoragePlayer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Systems.ModPlayers;
@@ -9,6 +10,8 @@ internal class GrimoireStoragePlayer : ModPlayer
 
 	public override void SaveData(TagCompound tag)
 	{
+		Storage.RemoveAll(x => x.IsAir || x.type == ItemID.None || x.stack == 0);
+
 		tag.Add("count", Storage.Count);
 
 		for (int i = 0; i < Storage.Count; i++)

--- a/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
+++ b/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
@@ -1,16 +1,21 @@
 ﻿using System.Collections.Generic;
+using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.UI.Utilities;
 using PathOfTerraria.Content.Items.Gear.Weapons.Grimoire;
 using PathOfTerraria.Content.Projectiles.Summoner;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
+using Steamworks;
+using StructureHelper.GUI;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
 using Terraria.UI;
+using Terraria.UI.Chat;
 
 namespace PathOfTerraria.Common.UI.GrimoireSelection;
 
@@ -453,35 +458,39 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 			return;
 		}
 
-		Tooltip.DrawWidth = 500;
-		Tooltip.SetName(item.Name);
+		float width = 0;
 		string tooltip = string.Empty;
+		List<DrawableTooltipLine> tooltips = ItemTooltipBuilder.BuildTooltips(item, Main.LocalPlayer);
 
-		List<TooltipLine> moddedTooltips = [];
-		item.ModItem.ModifyTooltips(moddedTooltips);
+		Tooltip.DrawWidth = (int)width;
+		Tooltip.SetFancyTooltip(tooltips[1..]);
+		Tooltip.SetName(tooltips[0].Text);
 
-		foreach (TooltipLine line in moddedTooltips)
-		{
-			if (line.Text.Trim() == string.Empty || line.FullName == "PathOfTerraria/Name")
-			{
-				continue;
-			}
+		//List<TooltipLine> moddedTooltips = [];
+		//item.ModItem.ModifyTooltips(moddedTooltips);
 
-			tooltip += line.Text + "\n";
-		}
+		//foreach (TooltipLine line in moddedTooltips)
+		//{
+		//	if (line.Text.Trim() == string.Empty || line.FullName == "PathOfTerraria/Name")
+		//	{
+		//		continue;
+		//	}
 
-		for (int i = 0; i < item.ToolTip.Lines; ++i)
-		{
-			string line = item.ToolTip.GetLine(i);
+		//	tooltip += line.Text + "\n";
+		//}
 
-			if (line.Trim() == string.Empty)
-			{
-				continue;
-			}
+		//for (int i = 0; i < item.ToolTip.Lines; ++i)
+		//{
+		//	string line = item.ToolTip.GetLine(i);
 
-			tooltip += line + "\n";
-		}
+		//	if (line.Trim() == string.Empty)
+		//	{
+		//		continue;
+		//	}
 
-		Tooltip.SetTooltip(tooltip);
+		//	tooltip += line + "\n";
+		//}
+
+		//Tooltip.SetTooltip(tooltip);
 	}
 }

--- a/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
+++ b/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
@@ -6,16 +6,12 @@ using PathOfTerraria.Content.Items.Gear.Weapons.Grimoire;
 using PathOfTerraria.Content.Projectiles.Summoner;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
-using Steamworks;
-using StructureHelper.GUI;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
 using Terraria.Localization;
-using Terraria.ModLoader;
 using Terraria.ModLoader.UI.Elements;
 using Terraria.UI;
-using Terraria.UI.Chat;
 
 namespace PathOfTerraria.Common.UI.GrimoireSelection;
 
@@ -50,7 +46,6 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 	private static UIImage _currentSummon = null;
 	private static Item _trashItem = null;
 	private static UIItemIcon _trashSlot = null;
-	private static UIPanel _storagePanel = null;
 
 	public override void SafeUpdate(GameTime gameTime)
 	{
@@ -301,14 +296,14 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 
 	private static void BuildStorage(UICloseablePanel panel)
 	{
-		_storagePanel = new UIPanel()
+		var mainPanel = new UIPanel()
 		{
 			Width = StyleDimension.FromPixels(398),
 			Height = StyleDimension.Fill,
 		};
-		panel.Append(_storagePanel);
+		panel.Append(mainPanel);
 
-		_storagePanel.Append(new UIText("Storage", 1, true)
+		mainPanel.Append(new UIText("Storage", 1, true)
 		{
 			HAlign = 0.5f,
 		});
@@ -319,7 +314,7 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 			Width = StyleDimension.FromPixelsAndPercent(-24, 1),
 			VAlign = 1f
 		};
-		_storagePanel.Append(storagePanel);
+		mainPanel.Append(storagePanel);
 
 		_storageGrid = new UIGrid()
 		{
@@ -337,7 +332,7 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 		};
 		_storageGrid.SetScrollbar(scrollBar);
 		_storageGrid.OnUpdate += SpamRecalculate;
-		_storagePanel.Append(scrollBar);
+		mainPanel.Append(scrollBar);
 
 		RefreshStorage();
 
@@ -458,39 +453,8 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 			return;
 		}
 
-		float width = 0;
-		string tooltip = string.Empty;
 		List<DrawableTooltipLine> tooltips = ItemTooltipBuilder.BuildTooltips(item, Main.LocalPlayer);
-
-		Tooltip.DrawWidth = (int)width;
 		Tooltip.SetFancyTooltip(tooltips[1..]);
 		Tooltip.SetName(tooltips[0].Text);
-
-		//List<TooltipLine> moddedTooltips = [];
-		//item.ModItem.ModifyTooltips(moddedTooltips);
-
-		//foreach (TooltipLine line in moddedTooltips)
-		//{
-		//	if (line.Text.Trim() == string.Empty || line.FullName == "PathOfTerraria/Name")
-		//	{
-		//		continue;
-		//	}
-
-		//	tooltip += line.Text + "\n";
-		//}
-
-		//for (int i = 0; i < item.ToolTip.Lines; ++i)
-		//{
-		//	string line = item.ToolTip.GetLine(i);
-
-		//	if (line.Trim() == string.Empty)
-		//	{
-		//		continue;
-		//	}
-
-		//	tooltip += line + "\n";
-		//}
-
-		//Tooltip.SetTooltip(tooltip);
 	}
 }

--- a/Content/Items/Gear/Gear.cs
+++ b/Content/Items/Gear/Gear.cs
@@ -35,25 +35,7 @@ public abstract class Gear : ModItem, GenerateAffixes.IItem, GenerateImplicits.I
 		{
 			string tooltip = string.Empty;
 			List<DrawableTooltipLine> tooltipLines = ItemTooltipBuilder.BuildTooltips(Item, player);
-			float width = 0;
-			
-			// Skip the first line as that's the name.
-			// Add the name in later.
-
-			for (int i = 1; i < tooltipLines.Count; ++i)
-			{
-				DrawableTooltipLine line = tooltipLines[i];
-				tooltip += line.Text + (i != tooltipLines.Count - 1 ? "\n" : "");
-				Vector2 size = ChatManager.GetStringSize(line.Font, line.Text, Vector2.One);
-
-				if (size.X > width)
-				{
-					width = size.X;
-				}
-			}
-
-			TooltipUI.DrawWidth = (int)width;
-			TooltipUI.SetTooltip(tooltip);
+			TooltipUI.SetFancyTooltip(tooltipLines[1..]);
 			TooltipUI.SetName($"[c/{tooltipLines[0].Color.Hex3()}:{tooltipLines[0].Text}]");
 		}
 	}

--- a/Content/Items/Pickups/GrimoirePickup.cs
+++ b/Content/Items/Pickups/GrimoirePickup.cs
@@ -9,6 +9,8 @@ using PathOfTerraria.Common.UI.GrimoireSelection;
 using Terraria.ID;
 using Terraria.Localization;
 using PathOfTerraria.Core.UI.SmartUI;
+using Terraria.DataStructures;
+using Terraria;
 
 namespace PathOfTerraria.Content.Items.Pickups;
 
@@ -36,7 +38,22 @@ internal abstract class GrimoirePickup : ModItem, IPoTGlobalItem
 		Item.maxStack = 1;
 
 		PoTInstanceItemData data = this.GetInstanceData();
-		data.ItemType = ItemType.Weapon;
+		data.ItemType = ItemType.Grimoire;
+	}
+
+	public override void OnSpawn(IEntitySource source)
+	{
+		base.OnSpawn(source);
+
+		Item.GetInstanceData().Rarity = Main.rand.NextFloat() switch
+		{
+			> 0.3f => ItemRarity.Normal,
+			> 0.05f => ItemRarity.Magic,
+			_ => ItemRarity.Rare
+		};
+
+		// TODO: Make sure this works in Multiplayer
+		PoTItemHelper.Roll(Item, PoTItemHelper.PickItemLevel());
 	}
 
 	public override bool ItemSpace(Player player)
@@ -49,16 +66,6 @@ internal abstract class GrimoirePickup : ModItem, IPoTGlobalItem
 		List<Item> storage = player.GetModPlayer<GrimoireStoragePlayer>().Storage;
 		string spawnText = Language.GetText("Mods.PathOfTerraria.Misc.GrimoireConsume").WithFormatArgs(Item.Name).Value;
 		Color textColor = Color.IndianRed;
-
-		if (storage.Count(x => x.type == Type) >= 5)
-		{
-			spawnText = Language.GetText("Mods.PathOfTerraria.Misc.GrimoireBoon").WithFormatArgs(Item.Name).Value;
-			textColor = Color.Silver;
-
-			Item.SetDefaults(ItemID.SilverCoin);
-			Item.stack = 20;
-		}
-
 		storage.Add(Item);
 		int projType = ModContent.ProjectileType<GrimoireVisageEffect>();
 		

--- a/Content/Items/Pickups/GrimoirePickups/OwlFeather.cs
+++ b/Content/Items/Pickups/GrimoirePickups/OwlFeather.cs
@@ -11,7 +11,7 @@ internal class OwlFeather : GrimoirePickup
 	{
 		if (npc.type == NPCID.Owl)
 		{
-			loot.AddCommon<OwlFeather>(1);
+			loot.AddCommon<OwlFeather>(18);
 		}
 	}
 }

--- a/Content/Items/Pickups/GrimoirePickups/OwlFeather.cs
+++ b/Content/Items/Pickups/GrimoirePickups/OwlFeather.cs
@@ -11,7 +11,7 @@ internal class OwlFeather : GrimoirePickup
 	{
 		if (npc.type == NPCID.Owl)
 		{
-			loot.AddCommon<OwlFeather>(20);
+			loot.AddCommon<OwlFeather>(1);
 		}
 	}
 }

--- a/Content/Projectiles/Summoner/GrimoireSummon.cs
+++ b/Content/Projectiles/Summoner/GrimoireSummon.cs
@@ -73,7 +73,7 @@ internal abstract class GrimoireSummon : ModProjectile
 			}	
 
 			var pickup = part.ModItem as GrimoirePickup;
-			PoTItemHelper.ApplyAffixes(pickup.Item, modifier, null);
+			PoTItemHelper.ApplyAffixes(pickup.Item, modifier, Owner);
 
 		}
 


### PR DESCRIPTION
### Description of Work
- Adds in a trash slot & trash functionality to Grimoire storage, so you can remove unwanted Grimoire material
- Fixes Grimoire summons not having any affixes, nor being able to roll them
- Improves tooltip functionality for Grimoire storage hover, Gear holding
- Fixes issue where you could fill up your Grimoire storage with empty items

### Comments
I was just looking to make sure Grimoire worked before writing the wiki page...good thing I did!