### PR TITLE
Pvp icon adjustment

### DIFF
--- a/Common/UI/Armor/UIGearInventory.cs
+++ b/Common/UI/Armor/UIGearInventory.cs
@@ -178,11 +178,11 @@ public sealed class UIGearInventory : UIState
 	private int currentPage;
 	private readonly UIElement[] pages = { BuildDefaultInventory(), BuildVanityInventory(), BuildDyeInventory() };
 
-	internal UIElement root;
+	internal UIElement Root;
 
 	public override void OnInitialize()
 	{
-		root = new UIElement
+		Root = new UIElement
 		{
 			Width = StyleDimension.FromPixels(ArmorPageWidth + LoadoutPadding + FirstLoadoutIconTexture.Width() + RootPadding),
 			Height = StyleDimension.FromPixels(ArmorPageHeight + LeftButtonTexture.Height() + DefenseCounterTexture.Height() + RootPadding * 2f),
@@ -190,12 +190,12 @@ public sealed class UIGearInventory : UIState
 			Top = StyleDimension.FromPixels(Main.mapStyle == 1 ? 436f : 180f)
 		};
 
-		Append(root);
+		Append(Root);
 
-		root.Append(BuildGearPages());
-		root.Append(BuildPageButtons());
-		root.Append(BuildDefenseCounter());
-		root.Append(BuildLoadouts());
+		Root.Append(BuildGearPages());
+		Root.Append(BuildPageButtons());
+		Root.Append(BuildDefenseCounter());
+		Root.Append(BuildLoadouts());
 	}
 
 	public override void Update(GameTime gameTime)
@@ -233,8 +233,8 @@ public sealed class UIGearInventory : UIState
 
 		float top = Main.mapStyle == 1 ? 446f : 190f;
 
-		root.Left.Set(MathHelper.SmoothStep(root.Left.Pixels, left, Smoothness), 0f);
-		root.Top.Set(MathHelper.SmoothStep(root.Top.Pixels, top, Smoothness), 0f);
+		Root.Left.Set(MathHelper.SmoothStep(Root.Left.Pixels, left, Smoothness), 0f);
+		Root.Top.Set(MathHelper.SmoothStep(Root.Top.Pixels, top, Smoothness), 0f);
 	}
 
 	private void HandleLeftPageClick(UIMouseEvent @event, UIElement element)
@@ -715,7 +715,7 @@ public sealed class UIGearInventory : UIState
 			Left = StyleDimension.FromPixels(FirstLoadoutIconTexture.Width() + RootPadding)
 		};
 
-		root.Append(gearRoot);
+		Root.Append(gearRoot);
 
 		for (int i = 0; i < pages.Length; i++)
 		{

--- a/Common/UI/Armor/UIGearInventory.cs
+++ b/Common/UI/Armor/UIGearInventory.cs
@@ -178,7 +178,7 @@ public sealed class UIGearInventory : UIState
 	private int currentPage;
 	private readonly UIElement[] pages = { BuildDefaultInventory(), BuildVanityInventory(), BuildDyeInventory() };
 
-	private UIElement root;
+	internal UIElement root;
 
 	public override void OnInitialize()
 	{

--- a/Common/UI/Armor/UIGearInventoryManager.cs
+++ b/Common/UI/Armor/UIGearInventoryManager.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
-using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Core.UI;
-using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.Armor;
 

--- a/Common/UI/Armor/VanillaUIEdits.cs
+++ b/Common/UI/Armor/VanillaUIEdits.cs
@@ -1,0 +1,45 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using PathOfTerraria.Core.UI;
+using System.Linq;
+using System.Reflection;
+
+namespace PathOfTerraria.Common.UI.Armor;
+
+internal class VanillaUIEdits : ModSystem
+{
+	public override void Load()
+	{
+		IL_Main.DrawPVPIcons += ModifyPvpIconLocations;
+	}
+
+	private void ModifyPvpIconLocations(ILContext il)
+	{
+		ILCursor c = new(il);
+
+		MethodInfo method = typeof(SpriteBatch).GetMethod(nameof(SpriteBatch.Draw), BindingFlags.Public | BindingFlags.Instance,
+			[typeof(Texture2D), typeof(Vector2), typeof(Rectangle?), typeof(Color), typeof(float), typeof(Vector2), typeof(Vector2), typeof(SpriteEffects), typeof(float)]);
+
+		if (!c.TryGotoNext(x => x.MatchCallvirt(method)))
+		{
+			return;
+		}
+
+		if (!c.TryGotoPrev(x => x.MatchLdsfld<Main>(nameof(Main.spriteBatch))))
+		{
+			return;
+		}
+
+		c.Emit(OpCodes.Ldloca_S, (byte)1);
+		c.Emit(OpCodes.Ldloca_S, (byte)2);
+		c.EmitDelegate(ModifyToggleLocation);
+	}
+
+	private static void ModifyToggleLocation(ref int x, ref int y)
+	{
+		int pixels = (int)(UIManager.Data.First(x => x.Identifier == $"{PoTMod.ModName}:Inventory").Value as UIGearInventory).root.Left.Pixels;
+		float off = pixels - Main.screenWidth + UIGearInventory.ArmorPageWidth + UIGearInventory.Margin;
+		x += (int)off + 20;
+		y += 140;
+	}
+}

--- a/Common/UI/Armor/VanillaUIEdits.cs
+++ b/Common/UI/Armor/VanillaUIEdits.cs
@@ -37,7 +37,7 @@ internal class VanillaUIEdits : ModSystem
 
 	private static void ModifyToggleLocation(ref int x, ref int y)
 	{
-		int pixels = (int)(UIManager.Data.First(x => x.Identifier == $"{PoTMod.ModName}:Inventory").Value as UIGearInventory).root.Left.Pixels;
+		int pixels = (int)(UIManager.Data.First(x => x.Identifier == $"{PoTMod.ModName}:Inventory").Value as UIGearInventory).Root.Left.Pixels;
 		float off = pixels - Main.screenWidth + UIGearInventory.ArmorPageWidth + UIGearInventory.Margin;
 		x += (int)off + 20;
 		y += 140;

--- a/Core/UI/UIManager.cs
+++ b/Core/UI/UIManager.cs
@@ -69,7 +69,7 @@ public sealed partial class UIManager : ModSystem
 	/// <summary>
 	///		The list of data from registered <see cref="UIState"/> instances.
 	/// </summary>
-	public static List<UIStateData> Data { get; set; } = new();
+	public static List<UIStateData> Data { get; set; } = [];
 
 	public override void Unload()
 	{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #459

### Description of Work
Adjusts position of PvP elements next to the armor slots to remove overlap. Also makes it slide in alongside the armor UI.
Random cleanup.