### PR TITLE
Max health affix fix

### DIFF
--- a/Common/Systems/Affixes/ItemTypes/LifeAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/LifeAffixes.cs
@@ -18,7 +18,7 @@ internal class MultipliedLifeAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaximumLife *= Value / 100;
+		modifier.MaximumLife *= 1 + Value / 100;
 	}
 }
 internal class FlatLifeAffix : ItemAffix

--- a/Content/Items/Gear/Armor/Helmet/Helmet.cs
+++ b/Content/Items/Gear/Armor/Helmet/Helmet.cs
@@ -1,5 +1,8 @@
 using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.Systems.Affixes;
+using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Core.Items;
+using System.Collections.Generic;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 
@@ -15,7 +18,7 @@ internal class Helmet : Gear
 		base.SetStaticDefaults();
 
 		PoTStaticItemData staticData = this.GetStaticData();
-		staticData.DropChance = 1f;
+		staticData.DropChance = 1232f;
 	}
 
 	public override void SetDefaults()
@@ -28,6 +31,7 @@ internal class Helmet : Gear
 
 	public override void PostRoll()
 	{
+		this.GetInstanceData().Affixes.Add(Affix.CreateAffix<MultipliedLifeAffix>(30) as ItemAffix);
 		Item.defense = GetItemLevel.Invoke(Item) / 10 + 1;
 	}
 }

--- a/Content/Items/Gear/Armor/Helmet/Helmet.cs
+++ b/Content/Items/Gear/Armor/Helmet/Helmet.cs
@@ -1,8 +1,5 @@
 using PathOfTerraria.Common.Enums;
-using PathOfTerraria.Common.Systems.Affixes;
-using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Core.Items;
-using System.Collections.Generic;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 
@@ -18,7 +15,7 @@ internal class Helmet : Gear
 		base.SetStaticDefaults();
 
 		PoTStaticItemData staticData = this.GetStaticData();
-		staticData.DropChance = 1232f;
+		staticData.DropChance = 1f;
 	}
 
 	public override void SetDefaults()
@@ -31,7 +28,6 @@ internal class Helmet : Gear
 
 	public override void PostRoll()
 	{
-		this.GetInstanceData().Affixes.Add(Affix.CreateAffix<MultipliedLifeAffix>(30) as ItemAffix);
 		Item.defense = GetItemLevel.Invoke(Item) / 10 + 1;
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #473 

### Description of Work
Fixes bad multiplication in MultipliedLifeAffix affix (multiplying by x% instead of (1 + x)%).