### PR TITLE
fix ravencrest subworld removing all spawns lol

### DIFF
--- a/Common/Subworlds/RavencrestSubworld.cs
+++ b/Common/Subworlds/RavencrestSubworld.cs
@@ -82,6 +82,11 @@ internal class RavencrestSubworld : MappingWorld
 	{
 		public override void EditSpawnPool(IDictionary<int, float> pool, NPCSpawnInfo spawnInfo)
 		{
+			if (SubworldSystem.Current is not RavencrestSubworld)
+			{
+				return;
+			}
+
 			if (Main.invasionType == InvasionID.GoblinArmy && Main.invasionSize > 0)
 			{
 				return;

--- a/Common/Systems/MappingSystem.cs
+++ b/Common/Systems/MappingSystem.cs
@@ -50,15 +50,3 @@ internal class MappingPlayer : ModPlayer
 		}
 	}
 }
-
-internal class MappingGlobalNPC : GlobalNPC
-{
-	// apply map affixes here
-	public override void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns)
-	{
-		if (MappingSystem.InMap)
-		{
-			// maxSpawns = 0; if we onlt want custom spawn-ins...
-		}
-	}
-}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #502

### Description of Work
Fixes code intended to stop spawns in Ravencrest from running everywhere.