### PR TITLE
fix some Gear not being given a PoTGlobalItem, fix implicits

### DIFF
--- a/Content/Items/Gear/Gear.cs
+++ b/Content/Items/Gear/Gear.cs
@@ -7,7 +7,7 @@ using TooltipUI = PathOfTerraria.Common.UI.Tooltip;
 
 namespace PathOfTerraria.Content.Items.Gear;
 
-public abstract class Gear : ModItem, GenerateAffixes.IItem, GenerateImplicits.IItem, PostRoll.IItem, GearLocalizationCategory.IItem
+public abstract class Gear : ModItem, GenerateAffixes.IItem, GenerateImplicits.IItem, PostRoll.IItem, GearLocalizationCategory.IItem, IPoTGlobalItem
 {
 	protected virtual string GearLocalizationCategory => GetType().Name;
 

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -26,12 +26,6 @@ partial class PoTGlobalItem
 	}
 
 	#region Modify tooltips and rendering
-	// TODO: Our scaling causes the tooltip box to be drawn with extra empty
-	// space, this is not something we can remedy on our side without hacky IL
-	// edits and similar.  Pending: TML-2449, TML-3546; it's been years with no
-	// resolution so I'm not holding my breath on this being implemented
-	// anytime some.  If we get close to release, I (Tomat) can write an IL
-	// edit to fix behavior for our lines.
 
 	public override bool PreDrawTooltipLine(Item item, DrawableTooltipLine line, ref int yOffset)
 	{

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -7,6 +7,7 @@ using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Data;
 using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -105,17 +106,14 @@ public static class PoTItemHelper
 			AddNewAffix(item, data);
 		}
 
-		if (staticData.IsUnique)
+		List<ItemAffix> uniqueItemAffixes = GenerateImplicits.Invoke(item);
+
+		foreach (ItemAffix affix in uniqueItemAffixes)
 		{
-			List<ItemAffix> uniqueItemAffixes = GenerateImplicits.Invoke(item);
-
-			foreach (ItemAffix affix in uniqueItemAffixes)
-			{
-				affix.Roll();
-			}
-
-			data.Affixes.AddRange(uniqueItemAffixes);
+			affix.Roll();
 		}
+
+		data.Affixes.AddRange(uniqueItemAffixes);
 	}
 	
 	/// <summary>


### PR DESCRIPTION
﻿### Link Issues
Resolves: #510

### Description of Work
- Makes GenerateImplicits always run.
- Applies `IPoTGlobalItem` to `Gear` to guarantee all child classes have the associated data.