### PR TITLE
Add use counts to portals

### DIFF
--- a/Common/Projectiles/ISaveProjectile.cs
+++ b/Common/Projectiles/ISaveProjectile.cs
@@ -1,0 +1,9 @@
+﻿using Terraria.ModLoader.IO;
+
+namespace PathOfTerraria.Common.Projectiles;
+
+internal interface ISaveProjectile
+{
+	public void SaveData(TagCompound tag) { }
+	public void LoadData(TagCompound tag, Projectile projectile) { }
+}

--- a/Common/Projectiles/SaveProjectileSystem.cs
+++ b/Common/Projectiles/SaveProjectileSystem.cs
@@ -1,0 +1,46 @@
+﻿using Terraria.ModLoader.IO;
+
+namespace PathOfTerraria.Common.Projectiles;
+
+internal class SaveProjectileSystem : ModSystem
+{
+	public override void SaveWorldData(TagCompound tag)
+	{
+		int saveCount = 0;
+		TagCompound saveProjs = [];
+
+		foreach (Projectile projectile in Main.ActiveProjectiles)
+		{
+			if (projectile.ModProjectile is not ISaveProjectile saveProj)
+			{
+				continue;
+			}
+
+			TagCompound proj = [];
+			proj.Add("name", projectile.ModProjectile.FullName);
+			proj.Add("pos", projectile.position);
+			saveProj.SaveData(proj);
+			saveProjs.Add("projectile" + saveCount++, proj);
+		}
+
+		saveProjs.Add("count", saveCount);
+		tag.Add("saveProjectiles", saveProjs);
+	}
+
+	public override void LoadWorldData(TagCompound tag)
+	{
+		TagCompound projCompound = tag.GetCompound("saveProjectiles");
+		int count = projCompound.GetInt("count");
+
+		for (int i = 0; i < count; ++i)
+		{
+			TagCompound proj = projCompound.GetCompound("projectile" + i);
+			int type = ModContent.Find<ModProjectile>(proj.GetString("name")).Type;
+			Vector2 pos = proj.Get<Vector2>("pos");
+
+			int index = Projectile.NewProjectile(Entity.GetSource_NaturalSpawn(), pos, Vector2.Zero, type, 0, 0, -1);
+			var savedProj = Main.projectile[index].ModProjectile as ISaveProjectile;
+			savedProj.LoadData(proj, Main.projectile[index]);
+		}
+	}
+}

--- a/Content/Projectiles/Summoner/GrimoireSummons/HornetSummon.cs
+++ b/Content/Projectiles/Summoner/GrimoireSummons/HornetSummon.cs
@@ -71,7 +71,7 @@ internal class HornetSummon : GrimoireSummon
 				Timer = 0;
 			}
 
-			if (Projectile.honeyWet && NPC.downedQueenBee)
+			if (Projectile.honeyWet && !NPC.downedQueenBee)
 			{
 				HoneyTimer++;
 

--- a/Content/Projectiles/Utility/EoWPortal.cs
+++ b/Content/Projectiles/Utility/EoWPortal.cs
@@ -1,12 +1,18 @@
-﻿using PathOfTerraria.Common.Subworlds.BossDomains;
+﻿using PathOfTerraria.Common.Projectiles;
+using PathOfTerraria.Common.Subworlds.BossDomains;
+using PathOfTerraria.Content.Items.Consumables.Maps;
 using SubworldLibrary;
 using System.IO;
 using Terraria.ID;
+using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class EoWPortal : ModProjectile
+internal class EoWPortal : ModProjectile, ISaveProjectile
 {
+	private ref float Uses => ref Projectile.ai[1];
+	private ref float MaxUses => ref Projectile.ai[2];
+
 	public override void SetDefaults()
 	{
 		Projectile.friendly = false;
@@ -25,9 +31,27 @@ internal class EoWPortal : ModProjectile
 
 	public override void AI()
 	{
+		//if (NPC.downedBoss1)
+		//{
+		//	Projectile.Kill();
+
+		//	for (int i = 0; i < 20; ++i)
+		//	{
+		//		Vector2 vel = new Vector2(-Main.rand.NextFloat(4, 8), 0).RotatedBy(Projectile.rotation);
+		//		Dust.NewDustPerfect(Projectile.Center + new Vector2(8, Main.rand.NextFloat(-16, 16)), DustID.PurpleTorch, vel);
+		//	}
+
+		//	return;
+		//}
+
 		Projectile.timeLeft++;
 		Projectile.Opacity = MathHelper.Lerp(Projectile.Opacity, 1f, 0.05f);
 		Projectile.velocity *= 0.96f;
+
+		if (MaxUses == 0)
+		{
+			MaxUses = Map.GetBossUseCount();
+		}
 
 		if (Main.rand.NextBool(14))
 		{
@@ -42,6 +66,14 @@ internal class EoWPortal : ModProjectile
 			if (player.Hitbox.Intersects(Projectile.Hitbox) && Main.myPlayer == player.whoAmI)
 			{
 				SubworldSystem.Enter<EaterDomain>();
+
+				Projectile.ai[1]++;
+				Projectile.netUpdate = true;
+
+				if (Projectile.ai[1] > Projectile.ai[2])
+				{
+					Projectile.Kill();
+				}
 			}
 		}
 	}
@@ -59,5 +91,17 @@ internal class EoWPortal : ModProjectile
 	public override void ReceiveExtraAI(BinaryReader reader)
 	{
 		Projectile.rotation = reader.ReadSingle();
+	}
+
+	public void SaveData(TagCompound tag)
+	{
+		tag.Add("uses", Uses);
+		tag.Add("rotation", Projectile.rotation);
+	}
+
+	public void LoadData(TagCompound tag, Projectile projectile)
+	{
+		projectile.ai[1] = tag.GetFloat("uses");
+		projectile.rotation = tag.GetFloat("rotation");
 	}
 }

--- a/Content/Projectiles/Utility/EoWPortal.cs
+++ b/Content/Projectiles/Utility/EoWPortal.cs
@@ -31,18 +31,18 @@ internal class EoWPortal : ModProjectile, ISaveProjectile
 
 	public override void AI()
 	{
-		//if (NPC.downedBoss1)
-		//{
-		//	Projectile.Kill();
+		if (NPC.downedBoss1)
+		{
+			Projectile.Kill();
 
-		//	for (int i = 0; i < 20; ++i)
-		//	{
-		//		Vector2 vel = new Vector2(-Main.rand.NextFloat(4, 8), 0).RotatedBy(Projectile.rotation);
-		//		Dust.NewDustPerfect(Projectile.Center + new Vector2(8, Main.rand.NextFloat(-16, 16)), DustID.PurpleTorch, vel);
-		//	}
+			for (int i = 0; i < 20; ++i)
+			{
+				Vector2 vel = new Vector2(-Main.rand.NextFloat(4, 8), 0).RotatedBy(Projectile.rotation);
+				Dust.NewDustPerfect(Projectile.Center + new Vector2(8, Main.rand.NextFloat(-16, 16)), DustID.PurpleTorch, vel);
+			}
 
-		//	return;
-		//}
+			return;
+		}
 
 		Projectile.timeLeft++;
 		Projectile.Opacity = MathHelper.Lerp(Projectile.Opacity, 1f, 0.05f);

--- a/Content/Projectiles/Utility/QueenBeePortal.cs
+++ b/Content/Projectiles/Utility/QueenBeePortal.cs
@@ -63,6 +63,18 @@ internal class QueenBeePortal : ModProjectile
 		Projectile.velocity *= 0.96f;
 		Projectile.frame = (int)Math.Abs(Timer-- * 0.15f % 3);
 
+		if (NPC.downedQueenBee)
+		{
+			Projectile.Kill();
+
+			for (int i = 0; i < 20; ++i)
+			{
+				Dust.NewDust(Projectile.position + new Vector2(8), Projectile.width - 16, Projectile.height - 16, DustID.Honey);
+			}
+
+			return;
+		}
+
 		if (Projectile.honeyWet)
 		{
 			Projectile.velocity.Y -= 0.05f;

--- a/Content/Projectiles/Utility/QueenBeePortal.cs
+++ b/Content/Projectiles/Utility/QueenBeePortal.cs
@@ -1,26 +1,38 @@
 ﻿using PathOfTerraria.Common.Projectiles;
 using PathOfTerraria.Common.Subworlds.BossDomains;
 using PathOfTerraria.Common.UI;
+using PathOfTerraria.Content.Items.Consumables.Maps;
 using SubworldLibrary;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
 internal class QueenBeePortal : ModProjectile
 {
 	private ref float Timer => ref Projectile.ai[0];
+	private ref float Uses => ref Projectile.ai[1];
+	private ref float MaxUses => ref Projectile.ai[2];
 
 	public override void SetStaticDefaults()
 	{
 		Main.projFrames[Type] = 3;
 
-		ClickableProjectilePlayer.RegisterProjectile(Type, (_, _) =>
+		ClickableProjectilePlayer.RegisterProjectile(Type, static (proj, _) =>
 		{
 			if (Main.mouseRight && Main.mouseRightRelease)
 			{
 				SubworldSystem.Enter<QueenBeeDomain>();
+
+				proj.ai[1]++;
+				proj.netUpdate = true;
+
+				if (proj.ai[1] > proj.ai[2])
+				{
+					proj.Kill();
+				}
 			}
 
 			Tooltip.SetName(Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"));
@@ -56,6 +68,11 @@ internal class QueenBeePortal : ModProjectile
 			Projectile.velocity.Y -= 0.05f;
 		}
 
+		if (MaxUses == 0)
+		{
+			MaxUses = Map.GetBossUseCount();
+		}
+
 		if (Main.rand.NextBool(14))
 		{
 			Dust.NewDust(Projectile.position + new Vector2(8), Projectile.width - 16, Projectile.height - 16, DustID.Honey);
@@ -78,5 +95,16 @@ internal class QueenBeePortal : ModProjectile
 		}
 
 		return false;
+	}
+
+	public void SaveData(TagCompound tag)
+	{
+		tag.Add("uses", Uses);
+	}
+
+	public void LoadData(TagCompound tag, Projectile projectile)
+	{
+		projectile.ai[0] = 49;
+		projectile.ai[1] = tag.GetFloat("uses");
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #476

### Description of Work
Adds in ISaveProjectile interface for keeping projectiles active between saves (including entering & exiting subworlds).
Uses the above to save use count for each existing portal (EoW, EoC, Queen Bee).
Fixes the Queen Bee portal only spawning post-queen bee (aka it's impossible to spawn).
Made all portals despawn on their boss being killed, such that they're only accessible before beating the boss.