### PR TITLE
fix some inconsistencies

### DIFF
--- a/Common/NPCs/QuestMarkers/Vanilla/OldManMarkerNPC.cs
+++ b/Common/NPCs/QuestMarkers/Vanilla/OldManMarkerNPC.cs
@@ -28,6 +28,7 @@ internal class OldManModifiers : GlobalNPC
 	{
 		int slot = Mod.AddNPCHeadTexture(NPCID.OldMan, $"{PoTMod.ModName}/Assets/NPCs/Town/OldMan_Head");
 
+		// Properly add a NPC head to the Old Man
 		FieldInfo internalDictInfo = typeof(TownNPCProfiles).GetField("_townNPCProfiles", BindingFlags.Instance | BindingFlags.NonPublic);
 		var dict = internalDictInfo.GetValue(TownNPCProfiles.Instance) as Dictionary<int, ITownNPCProfile>;
 		dict[NPCID.OldMan] = TownNPCProfiles.LegacyWithSimpleShimmer("OldMan", slot, -1, uniquePartyTexture: false, uniquePartyTextureShimmered: false);

--- a/Common/NPCs/SyncedCustomDrops.cs
+++ b/Common/NPCs/SyncedCustomDrops.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Content.Items.Quest;
+using PathOfTerraria.Content.NPCs.Town;
 using System.Collections.Generic;
 using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
@@ -57,11 +58,12 @@ internal class SyncedCustomDrops : GlobalNPC
 
 	public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
 	{
-		if (npc.type is NPCID.GoblinArcher or NPCID.GoblinPeon or NPCID.GoblinScout or NPCID.GoblinSorcerer or NPCID.GoblinThief or NPCID.GoblinWarrior)
+		if (npc.type is NPCID.GoblinArcher or NPCID.GoblinPeon or NPCID.GoblinScout or NPCID.GoblinSorcerer or NPCID.GoblinThief or NPCID.GoblinWarrior
+			|| npc.type == ModContent.NPCType<TownScoutNPC>())
 		{
 			AddCountCondition(npcLoot, LocalizedText.Empty, ModContent.ItemType<TomeOfTheElders>(), 10);
 		}
-		else if (npc.type is NPCID.Zombie)
+		else if (npc.type is NPCID.Zombie or NPCID.DemonEye)
 		{
 			AddCountCondition(npcLoot, LocalizedText.Empty, ModContent.ItemType<LunarShard>(), 5);
 		}

--- a/Common/Systems/Questing/Quests/MainPath/SkeletronQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/SkeletronQuest.cs
@@ -18,7 +18,7 @@ internal class SkeletronQuest : Quest
 
 	public override List<QuestReward> QuestRewards =>
 	[
-		new ActionRewards((p, v) => p.GetModPlayer<ExpModPlayer>().Exp += 5000, ""),
+		new ActionRewards((p, v) => p.GetModPlayer<ExpModPlayer>().Exp += 10000, ""),
 	];
 
 	public override List<QuestStep> SetSteps()


### PR DESCRIPTION
### Description of Work
- Adds a little documentation
- Adds in missing IDs to Lunar Shard and Tome of the Elders drop rules
- Adjusts Skeletron quest exp reward from 5,000 to 10,000

### Comments
Made while I wrote the corresponding wiki, so it's very small.
