### PR TITLE
hide quest button before first quest; flip FirstQuest saving pattern

### DIFF
--- a/Common/Systems/Questing/QuestModPlayer.cs
+++ b/Common/Systems/Questing/QuestModPlayer.cs
@@ -16,7 +16,7 @@ public class QuestModPlayer : ModPlayer
 
 	public Dictionary<string, Quest> QuestsByName = [];
 	
-	private bool _firstQuest = true;
+	internal bool FirstQuest = true;
 
 	public void StartQuest(string name, int step = -1, bool fromLoad = false)
 	{
@@ -27,11 +27,11 @@ public class QuestModPlayer : ModPlayer
 			UIQuestPopupState.NewQuest = new UIQuestPopupState.PopupText(QuestsByName[name].DisplayName, 300, 1f, 1.2f);
 			SoundEngine.PlaySound(new SoundStyle($"{PoTMod.ModName}/Assets/Sounds/QuestStart") { Volume = 0.5f });
 
-			if (_firstQuest) // Only display first quest popup on first quest (wow!)
+			if (FirstQuest) // Only display first quest popup on first quest (wow!)
 			{
 				UIQuestPopupState.FlashQuestButton = 600;
 
-				_firstQuest = false;
+				FirstQuest = false;
 			}
 		}
 	}
@@ -67,7 +67,7 @@ public class QuestModPlayer : ModPlayer
 
 		tag.Add("questTags", questTags);
 
-		if (!_firstQuest)
+		if (FirstQuest)
 		{
 			tag.Add("firstQuest", false);
 		}
@@ -75,7 +75,7 @@ public class QuestModPlayer : ModPlayer
 	
 	public override void LoadData(TagCompound tag)
 	{
-		_firstQuest = !tag.ContainsKey("firstQuest"); // If we have the tag, the first quest is false
+		FirstQuest = tag.ContainsKey("firstQuest"); // If we have the tag, the first quest is true
 		List<TagCompound> questTags = tag.Get<List<TagCompound>>("questTags");
 
 		QuestsByName.Clear();

--- a/Common/UI/QuestPanelButton.cs
+++ b/Common/UI/QuestPanelButton.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.UI.Quests;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
@@ -10,7 +11,7 @@ namespace PathOfTerraria.Common.UI;
 
 public class QuestPanelButton : SmartUiState
 {
-	public override bool Visible => Main.playerInventory || UIQuestPopupState.FlashQuestButton > 0;
+	public override bool Visible => (Main.playerInventory || UIQuestPopupState.FlashQuestButton > 0) && !Main.LocalPlayer.GetModPlayer<QuestModPlayer>().FirstQuest;
 
 	private static Asset<Texture2D> BookTexture = null;
 


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Hide quest icon in inventory before first quest
- Flip FirstQuest saving pattern - this means it doesn't have to save after the player gets their first quest, saving a completely negligible amount of disk space
