### PR TITLE
clean up on death effect, spawn raven on first level up in the world

### DIFF
--- a/Common/NPCs/OnDeathNPC.cs
+++ b/Common/NPCs/OnDeathNPC.cs
@@ -1,0 +1,52 @@
+﻿using PathOfTerraria.Common.World.Passes;
+using SubworldLibrary;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.NPCs;
+
+/// <summary>
+/// Handles death effects for boss NPCs that are delayed. 
+/// There is no hook for it in tMod, as <see cref="ModNPC.OnKill"/> is not blocked by the loot blocker.<br/>
+/// This is static as it doesn't need to be instanced.
+/// </summary>
+internal static class OnDeathNPC
+{
+	public static void OnDeathEffects(NPC npc)
+	{
+		if (npc.type == NPCID.WallofFlesh)
+		{
+			int x = (int)npc.Center.X / 16;
+			int y = (int)npc.Center.Y / 16;
+			int width = npc.width / 2 / 16 + 1;
+
+			for (int i = x - width; i <= x + width; i++)
+			{
+				for (int j = y - width; j <= y + width; j++)
+				{
+					Tile tile = Main.tile[i, j];
+
+					if (i == x - width || i == x + width || j == y - width || j == y + width)
+					{
+						if (!tile.HasTile)
+						{
+							tile.TileType = (ushort)(WorldGen.crimson ? 347u : 140u);
+							tile.HasTile = true;
+						}
+					}
+
+					tile.LiquidType = LiquidID.Water;
+					tile.LiquidAmount = 0;
+
+					if (Main.netMode == NetmodeID.Server)
+					{
+						NetMessage.SendTileSquare(-1, i, j);
+					}
+					else
+					{
+						WorldGen.SquareTileFrame(i, j);
+					}
+				}
+			}
+		}
+	}
+}

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -27,6 +27,7 @@ public class RavencrestSystem : ModSystem
 
 	private static readonly Dictionary<string, ImprovableStructure> structures = [];
 
+	public bool SpawnedRaven = false;
 	public bool SpawnedScout = false;
 	public Point16 EntrancePosition;
 	public bool OneTimeCheckDone = false;
@@ -197,6 +198,7 @@ public class RavencrestSystem : ModSystem
 			SpawnedMorvenPos = morven;
 		}
 
+		SpawnedRaven = tag.GetBool("spawnedRaven");
 		EntrancePosition = tag.Get<Point16>("entrance");
 
 		foreach (KeyValuePair<string, ImprovableStructure> structure in structures)
@@ -222,6 +224,7 @@ public class RavencrestSystem : ModSystem
 			tag.Add("morven", SpawnedMorvenPos.Value);
 		}
 
+		tag.Add("spawnedRaven", SpawnedRaven);
 		tag.Add("entrance", EntrancePosition);
 
 		foreach (KeyValuePair<string, ImprovableStructure> structure in structures)

--- a/Common/Systems/BossTracker.cs
+++ b/Common/Systems/BossTracker.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.NPCs;
+using PathOfTerraria.Common.Subworlds;
 using SubworldLibrary;
 using System.Collections.Generic;
 using System.IO;
@@ -39,44 +40,12 @@ internal class BossTracker : ModSystem
 	{
 		if (SubworldSystem.Current is BossDomainSubworld)
 		{
-			if (self.type == NPCID.WallofFlesh)
-			{
-				int x = (int)self.Center.X / 16;
-				int y = (int)self.Center.Y / 16;
-				int width = self.width / 2 / 16 + 1;
-
-				for (int i = x - width; i <= x + width; i++)
-				{
-					for (int j = y - width; j <= y + width; j++)
-					{
-						Tile tile = Main.tile[i, j];
-
-						if (i == x - width || i == x + width || j == y - width || j == y + width)
-						{
-							if (!tile.HasTile)
-							{
-								tile.TileType = (ushort)(WorldGen.crimson ? 347u : 140u);
-								tile.HasTile = true;
-							}
-						}
-
-						tile.LiquidType = LiquidID.Water;
-						tile.LiquidAmount = 0;
-
-						if (Main.netMode == NetmodeID.Server)
-						{
-							NetMessage.SendTileSquare(-1, i, j);
-						}
-						else
-						{
-							WorldGen.SquareTileFrame(i, j);
-						}
-					}
-				}
-			}
-
 			self.type = NPCID.None;
 			self.boss = false;
+		}
+		else
+		{
+			OnDeathNPC.OnDeathEffects(self);
 		}
 
 		orig(self, closestPlayer);

--- a/Common/Systems/ModPlayers/ExpModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExpModPlayer.cs
@@ -1,4 +1,6 @@
-﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+﻿using PathOfTerraria.Common.Subworlds.RavencrestContent;
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.World.Passes;
 using Terraria.Audio;
 using Terraria.Localization;
 using Terraria.ModLoader.IO;
@@ -32,6 +34,11 @@ public class ExpModPlayer : ModPlayer
 		Main.NewText(Language.GetText("Mods.PathOfTerraria.Misc.Experience.SkillUp"), new Color(255, 255, 160));
 
 		Player.GetModPlayer<PassiveTreePlayer>().Points++;
+
+		if (Level == 1 && !ModContent.GetInstance<RavencrestSystem>().SpawnedRaven)
+		{
+			new RavenPass().Generate(null, null);
+		}
 	}
 
 	public override void SaveData(TagCompound tag)

--- a/Common/World/Passes/RavencrestEntrancePass.cs
+++ b/Common/World/Passes/RavencrestEntrancePass.cs
@@ -1,8 +1,10 @@
 ﻿using PathOfTerraria.Common.Subworlds.BossDomains;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
+using PathOfTerraria.Common.Systems.Networking.Handlers;
 using PathOfTerraria.Common.World.Generation;
 using PathOfTerraria.Common.World.Generation.Tools;
 using PathOfTerraria.Content.NPCs.Town;
+using SubworldLibrary;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.DataStructures;
@@ -120,6 +122,9 @@ public class RavencrestMicrobiome : MicroBiome
 	}
 }
 
+/// <summary>
+/// Originally written for worldgen, this no longer runs during worldgen. Instead, it runs in <see cref="Systems.ModPlayers.ExpModPlayer"/> on first level up.
+/// </summary>
 internal class RavenPass : AutoGenStep
 {
 	public override void Generate(GenerationProgress progress, GameConfiguration config)
@@ -143,12 +148,19 @@ internal class RavenPass : AutoGenStep
 			}
 		}
 
-		NPC.NewNPC(Entity.GetSource_NaturalSpawn(), x * 16, y * 16, ModContent.NPCType<RavenNPC>());
+		if (!WorldGen.generatingWorld && Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			SpawnNPCOnServerHandler.Send((short)ModContent.NPCType<RavenNPC>(), new Vector2(x, y) * 16);
+		}
+		else
+		{
+			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), x * 16, y * 16, ModContent.NPCType<RavenNPC>());
+		}
 	}
 
 	public override int GenIndex(List<GenPass> tasks)
 	{
-		return tasks.FindIndex(x => x.Name == "Smooth World") + 2;
+		return -1;
 	}
 }
 

--- a/Content/NPCs/Town/RavenNPC.cs
+++ b/Content/NPCs/Town/RavenNPC.cs
@@ -26,6 +26,7 @@ public sealed class RavenNPC : ModNPC
 		NPC.dontTakeDamageFromHostiles = true;
 		NPC.netAlways = true;
 		NPC.netUpdate2 = true;
+		NPC.Opacity = 0f;
 
 		AnimationType = NPCID.Bird;
 		AIType = NPCID.Bird;
@@ -76,6 +77,10 @@ public sealed class RavenNPC : ModNPC
 					Dust.NewDust(NPC.position, NPC.width, NPC.height, Main.rand.NextBool() ? DustID.GemDiamond : DustID.Phantasmal);
 				}
 			}
+		}
+		else
+		{
+			NPC.Opacity = MathHelper.Lerp(NPC.Opacity, 0.8f, 0.05f);
 		}
 
 		if (NPC.direction != Math.Sign(entrancePosition.X - NPC.Center.X))


### PR DESCRIPTION
﻿### Link Issues
Resolves: #553

### Description of Work
- Moves WoF death effect box to its own file for cleanliness
- Reworks Raven spawn pass to be used during gameplay, on level up from 0 to 1 (only once per world)
- Make Raven fade in so if it spawns near a player it's not jarring