### PR TITLE
Passive UI zoom

### DIFF
--- a/Common/UI/DraggableSmartUi.cs
+++ b/Common/UI/DraggableSmartUi.cs
@@ -57,13 +57,15 @@ public abstract class DraggableSmartUi : SmartUiState
 		CloseButton.Top.Set(10, 0f);
 		CloseButton.Width.Set(38, 0);
 		CloseButton.Height.Set(38, 0);
-		CloseButton.OnLeftClick += (a, b) =>
-		{
-			IsVisible = false;
-			SoundEngine.PlaySound(SoundID.MenuClose, Main.LocalPlayer.Center);
-		};
+		CloseButton.OnLeftClick += (_, _) => DefaultClose();
 		CloseButton.SetVisibility(1, 1);
 		Panel.Append(CloseButton);
+	}
+
+	protected virtual void DefaultClose()
+	{
+		IsVisible = false;
+		SoundEngine.PlaySound(SoundID.MenuClose, Main.LocalPlayer.Center);
 	}
 
 	public virtual void AppendChildren()

--- a/Common/UI/PassiveTree/PassiveTreeInnerPanel.cs
+++ b/Common/UI/PassiveTree/PassiveTreeInnerPanel.cs
@@ -16,7 +16,6 @@ internal class PassiveTreeInnerPanel : SmartUiElement
 
 	private Vector2 _start;
 	private Vector2 _lineOff;
-	private float _zoom = 1f;
 
 	public override void Draw(SpriteBatch spriteBatch)
 	{
@@ -25,7 +24,7 @@ internal class PassiveTreeInnerPanel : SmartUiElement
 		spriteBatch.GraphicsDevice.ScissorRectangle = Panel.GetDimensions().ToRectangle();
 
 		spriteBatch.End();
-		spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix + Matrix.CreateScale(_zoom));
+		spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix);
 
 		foreach (PassiveEdge edge in PassiveTreeSystem.Edges)
 		{
@@ -86,9 +85,6 @@ internal class PassiveTreeInnerPanel : SmartUiElement
 
 	public override void SafeUpdate(GameTime gameTime)
 	{
-		_zoom += PlayerInput.ScrollWheelDeltaForUI * 0.0005f;
-		_zoom = MathHelper.Clamp(_zoom, 0.1f, 1f);
-
 		Vector2 offsetChange = Vector2.Zero;
 
 		if (MouseContained.Left)

--- a/Common/UI/PassiveTree/PassiveTreeInnerPanel.cs
+++ b/Common/UI/PassiveTree/PassiveTreeInnerPanel.cs
@@ -1,19 +1,22 @@
 ﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Core.UI.SmartUI;
+using Terraria.GameInput;
 using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.PassiveTree;
 
 internal class PassiveTreeInnerPanel : SmartUiElement
 {
-	private Vector2 _start;
-	private Vector2 _lineOff;
+	private static PassiveTreePlayer PassiveTreeSystem => Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
+	private static TreeState UiTreeState => SmartUiLoader.GetUiState<TreeState>();
+
+	public override string TabName => "PassiveTree";
 
 	private UIElement Panel => Parent;
 
-	private PassiveTreePlayer PassiveTreeSystem => Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
-	private TreeState UiTreeState => SmartUiLoader.GetUiState<TreeState>();
-	public override string TabName => "PassiveTree";
+	private Vector2 _start;
+	private Vector2 _lineOff;
+	private float _zoom = 1f;
 
 	public override void Draw(SpriteBatch spriteBatch)
 	{
@@ -22,7 +25,7 @@ internal class PassiveTreeInnerPanel : SmartUiElement
 		spriteBatch.GraphicsDevice.ScissorRectangle = Panel.GetDimensions().ToRectangle();
 
 		spriteBatch.End();
-		spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix);
+		spriteBatch.Begin(default, default, default, default, default, default, Main.UIScaleMatrix + Matrix.CreateScale(_zoom));
 
 		foreach (PassiveEdge edge in PassiveTreeSystem.Edges)
 		{
@@ -83,6 +86,9 @@ internal class PassiveTreeInnerPanel : SmartUiElement
 
 	public override void SafeUpdate(GameTime gameTime)
 	{
+		_zoom += PlayerInput.ScrollWheelDeltaForUI * 0.0005f;
+		_zoom = MathHelper.Clamp(_zoom, 0.1f, 1f);
+
 		Vector2 offsetChange = Vector2.Zero;
 
 		if (MouseContained.Left)

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -84,8 +84,8 @@ JewelSocket: {
 }
 
 LifeRegenPassive: {
-	Name: LifeRegenPassive
-	Tooltip: ""
+	Name: Stronger Heart
+	Tooltip: Increased life regeneration
 }
 
 DecreasedManaCostPassive: {
@@ -129,7 +129,7 @@ ShockChancePassive: {
 }
 
 IncreasedMinionDamagePassive: {
-	Name: IncreasedMinionDamagePassive
+	Name: Increased Minion Damage
 	Tooltip: Increases your minions' damage by 10% per level
 }
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #565

### Description of Work
- Increases the size of the passive tree to be almost the full size of the screen, some buffer due to UI overlap
- Fixes AddedMinionDamagePassive broken localization

### Comments
We'll definitely still want zoom on the UI in the future, we'll see where we are on the playtest.
