### PR TITLE
fix some swords not inheriting from broadsword

### DIFF
--- a/Content/Items/Gear/Weapons/Sword/CopperBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/CopperBroadsword.cs
@@ -4,7 +4,7 @@ using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
-internal class CopperBroadsword : Sword
+internal class CopperBroadsword : Broadsword
 {
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Weapons/Sword/IronBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/IronBroadsword.cs
@@ -4,9 +4,8 @@ using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
-internal class IronBroadsword : Sword
+internal class IronBroadsword : Broadsword
 {
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/Items/Gear/Weapons/Sword/SteelBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/SteelBroadsword.cs
@@ -4,7 +4,7 @@ using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
-internal class SteelBroadsword : Sword
+internal class SteelBroadsword : Broadsword
 {
 	public override void SetStaticDefaults()
 	{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #583

### Description of Work
Makes all XBroadsword items inherit from Broadsword instead of Sword.
