### PR TITLE
Footage edits fixes

### DIFF
--- a/Common/Systems/HellEvent/HellEventSystem.cs
+++ b/Common/Systems/HellEvent/HellEventSystem.cs
@@ -14,7 +14,7 @@ internal class HellEventSystem : ModSystem
 
 	private int eventTimer = 0;
 
-	public override void PreUpdateEntities()
+	public override void PostUpdatePlayers()
 	{
 		EventOccuringInstant = false;
 

--- a/Common/Systems/HellEvent/HellEventSystem.cs
+++ b/Common/Systems/HellEvent/HellEventSystem.cs
@@ -13,6 +13,7 @@ internal class HellEventSystem : ModSystem
 	public static float EventStrength = 0;
 
 	private int eventTimer = 0;
+	private int delayTimer = 0;
 
 	public override void PostUpdatePlayers()
 	{
@@ -23,18 +24,14 @@ internal class HellEventSystem : ModSystem
 			return;
 		}
 
+		if (++delayTimer < 60)
+		{
+			return;
+		}
+
 		eventTimer++;
 
-		bool canEventOccur = false;
-
-		foreach (Player player in Main.ActivePlayers)
-		{
-			if (QuestUnlockManager.CanStartQuest<WoFQuest>())
-			{
-				canEventOccur = true;
-				break;
-			}
-		}
+		bool canEventOccur = GetCanOccur();
 
 		if (!canEventOccur)
 		{
@@ -45,6 +42,22 @@ internal class HellEventSystem : ModSystem
 		{
 			EventOccuringInstant = true;
 		}
+	}
+
+	private static bool GetCanOccur()
+	{
+		bool canEventOccur = false;
+
+		foreach (Player player in Main.ActivePlayers)
+		{
+			if (player.Center.Y / 16 > Main.maxTilesX - 400 && QuestUnlockManager.CanStartQuest<WoFQuest>())
+			{
+				canEventOccur = true;
+				break;
+			}
+		}
+
+		return canEventOccur;
 	}
 
 	public override void PreUpdatePlayers()

--- a/Content/NPCs/Town/BlacksmithNPC.cs
+++ b/Content/NPCs/Town/BlacksmithNPC.cs
@@ -118,7 +118,7 @@ public class BlacksmithNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOv
 	public override void SetChatButtons(ref string button, ref string button2)
 	{
 		button = Language.GetTextValue("LegacyInterface.28");
-		button2 = QuestUnlockManager.CanStartQuest<BlacksmithStartQuest>() ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
+		button2 = !QuestUnlockManager.CanStartQuest<BlacksmithStartQuest>() ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)

--- a/Content/NPCs/Town/HunterNPC.cs
+++ b/Content/NPCs/Town/HunterNPC.cs
@@ -92,7 +92,7 @@ public class HunterNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverhe
 		}
 		else
 		{
-			button2 = QuestUnlockManager.CanStartQuest<HunterStartQuest>() ? "" : Language.GetOrRegister($"Mods.{PoTMod.ModName}.NPCs.Quest").Value;
+			button2 = !QuestUnlockManager.CanStartQuest<HunterStartQuest>() ? "" : Language.GetOrRegister($"Mods.{PoTMod.ModName}.NPCs.Quest").Value;
 		}
 	}
 

--- a/Content/NPCs/Town/WizardNPC.cs
+++ b/Content/NPCs/Town/WizardNPC.cs
@@ -121,7 +121,7 @@ public class WizardNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverhe
 	public override void SetChatButtons(ref string button, ref string button2)
 	{
 		button = Language.GetTextValue("LegacyInterface.28");
-		button2 = QuestUnlockManager.CanStartQuest<WizardStartQuest>() ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
+		button2 = !QuestUnlockManager.CanStartQuest<WizardStartQuest>() ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)


### PR DESCRIPTION
### Description of Work
- Fixes issue with QuestUnlockManager.CanStartQuest being called too soon in gameplay, before it's set, causing error
- Fixed issue with a bunch of town NPCs only giving their quest if it cannot be started