### PR TITLE
Rename burning red boots, adjust color

### DIFF
--- a/Common/UI/Tooltip.cs
+++ b/Common/UI/Tooltip.cs
@@ -52,7 +52,7 @@ public class Tooltip : SmartUiState, ILoadable
 	/// <param name="newTooltip"></param>
 	public static void SetTooltip(string newTooltip)
 	{
-		ReLogic.Graphics.DynamicSpriteFont font = FontAssets.MouseText.Value;
+		DynamicSpriteFont font = FontAssets.MouseText.Value;
 		tooltip = StringUtils.WrapString(newTooltip, DrawWidth * 2, font, 1);
 	}
 

--- a/Content/Items/Gear/Armor/Leggings/BurningRedBoots.cs
+++ b/Content/Items/Gear/Armor/Leggings/BurningRedBoots.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
-using PathOfTerraria.Common.Systems.Affixes;
+﻿using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
-using Terraria.Localization;
 using PathOfTerraria.Core.Items;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
@@ -29,7 +30,17 @@ internal class BurningRedBoots : Leggings, GenerateName.IItem
 
 	string GenerateName.IItem.GenerateName(string defaultName)
 	{
-		return $"[c/FF0000:{Language.GetTextValue("Mods.PathOfTerraria.Items.BurningRedBoots.DisplayName")}]";
+		return Language.GetTextValue("Mods.PathOfTerraria.Items.BurningRedBoots.DisplayName");
+	}
+
+	public override void ModifyTooltips(List<TooltipLine> tooltips)
+	{
+		TooltipLine nameTip = tooltips.First(x => x.Name == "ItemName");
+
+		if (nameTip is not null)
+		{
+			nameTip.OverrideColor = Color.Red;
+		}
 	}
 
 	public override void PostRoll()

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -105,6 +105,7 @@ partial class PoTGlobalItem
 		base.ModifyTooltips(item, tooltips);
 		var oldTooltips = tooltips.Where(x => x.Name.StartsWith("Tooltip")).ToList();
 		TooltipLine setBonusLine = tooltips.FirstOrDefault(x => x.Name == "SetBonus");
+		TooltipLine nameLine = tooltips.FirstOrDefault(x => x.Name == "ItemName");
 
 		if (setBonusLine is not null)
 		{
@@ -121,10 +122,18 @@ partial class PoTGlobalItem
 			data.SpecialName = GenerateName.Invoke(item);
 		}
 
-		var nameLine = new TooltipLine(Mod, "Name", data.SpecialName)
+		if (nameLine is null)
 		{
-			OverrideColor = GetRarityColor(data.Rarity)
-		};
+			nameLine = new TooltipLine(Mod, "Name", data.SpecialName)
+			{
+				OverrideColor = GetRarityColor(data.Rarity)
+			};
+		}
+		else
+		{
+			nameLine.OverrideColor ??= GetRarityColor(data.Rarity);
+		}
+
 		tooltips.Add(nameLine);
 
 		if (data.Corrupted)

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -131,6 +131,7 @@ partial class PoTGlobalItem
 		}
 		else
 		{
+			nameLine.Text = data.SpecialName;
 			nameLine.OverrideColor ??= GetRarityColor(data.Rarity);
 		}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #613 

### Description of Work
- Renames BruningRedBoots.cs to BurningRedBoots.cs
- Removes color tag from the Boot's name
- Recolors the ItemName tooltipline instead, makes that persist & override the PoT itemname

### Comments
It's a little awkward to recolor names...I'm not sure why the Burning Red Boots do this, as they're the only item to do so, but yeah. In the hover tag, the name is a default white. I can change this if desired; either way, the erroneous tag is fixed.