### PR TITLE
Fix equips failing

### DIFF
--- a/Content/Items/Gear/Armor/Chestplate/BodyArmor.cs
+++ b/Content/Items/Gear/Armor/Chestplate/BodyArmor.cs
@@ -1,5 +1,6 @@
 ﻿namespace PathOfTerraria.Content.Items.Gear.Armor.Chestplate;
 
+[AutoloadEquip(EquipType.Body)]
 internal class BodyArmor : Chestplate
 {
 }

--- a/Content/Items/Gear/Armor/Chestplate/Breastplate.cs
+++ b/Content/Items/Gear/Armor/Chestplate/Breastplate.cs
@@ -1,5 +1,6 @@
 ﻿namespace PathOfTerraria.Content.Items.Gear.Armor.Chestplate;
 
+[AutoloadEquip(EquipType.Body)]
 internal class Breastplate : Chestplate
 {
 }

--- a/Content/Items/Gear/Armor/Chestplate/Chestplate.cs
+++ b/Content/Items/Gear/Armor/Chestplate/Chestplate.cs
@@ -3,7 +3,6 @@ using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Chestplate;
 
-[AutoloadEquip(EquipType.Body)]
 internal abstract class Chestplate : Gear
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Gear/Armor/Body/Base";

--- a/Content/Items/Gear/Armor/Chestplate/Chestplate.cs
+++ b/Content/Items/Gear/Armor/Chestplate/Chestplate.cs
@@ -3,6 +3,10 @@ using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Chestplate;
 
+/// <summary>
+/// Defines the base class for a chestplate.<br/>
+/// Note: You need to manually apply the <see cref="AutoloadEquip"/> attribute for <see cref="EquipType.Body"/>; the attribute can't be inherited and so turns into boilerplate.
+/// </summary>
 internal abstract class Chestplate : Gear
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Gear/Armor/Body/Base";

--- a/Content/Items/Gear/Armor/Helmet/Crown.cs
+++ b/Content/Items/Gear/Armor/Helmet/Crown.cs
@@ -1,3 +1,4 @@
 ﻿namespace PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 
+[AutoloadEquip(EquipType.Head)]
 internal class Crown : Helmet;

--- a/Content/Items/Gear/Armor/Helmet/Helmet.cs
+++ b/Content/Items/Gear/Armor/Helmet/Helmet.cs
@@ -3,6 +3,10 @@ using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 
+/// <summary>
+/// Defines the base class for a helmet.<br/>
+/// Note: You need to manually apply the <see cref="AutoloadEquip"/> attribute for <see cref="EquipType.Head"/>; the attribute can't be inherited and so turns into boilerplate.
+/// </summary>
 internal abstract class Helmet : Gear
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Gear/Armor/Helmet/Base";

--- a/Content/Items/Gear/Armor/Helmet/Helmet.cs
+++ b/Content/Items/Gear/Armor/Helmet/Helmet.cs
@@ -3,7 +3,6 @@ using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 
-[AutoloadEquip(EquipType.Head)]
 internal abstract class Helmet : Gear
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Gear/Armor/Helmet/Base";

--- a/Content/Items/Gear/Armor/Helmet/Visor.cs
+++ b/Content/Items/Gear/Armor/Helmet/Visor.cs
@@ -1,3 +1,4 @@
 ﻿namespace PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 
+[AutoloadEquip(EquipType.Head)]
 internal class Visor : Helmet;

--- a/Content/Items/Gear/Armor/Leggings/Leggings.cs
+++ b/Content/Items/Gear/Armor/Leggings/Leggings.cs
@@ -6,6 +6,10 @@ using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
+/// <summary>
+/// Defines the base class for a legging.<br/>
+/// Note: You need to manually apply the <see cref="AutoloadEquip"/> attribute for <see cref="EquipType.Legs"/>; the attribute can't be inherited and so turns into boilerplate.
+/// </summary>
 internal abstract class Leggings : Gear
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Gear/Armor/Legs/Base";

--- a/Content/Items/Gear/Armor/Leggings/Leggings.cs
+++ b/Content/Items/Gear/Armor/Leggings/Leggings.cs
@@ -6,7 +6,6 @@ using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
-[AutoloadEquip(EquipType.Legs)]
 internal abstract class Leggings : Gear
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Gear/Armor/Legs/Base";

--- a/Content/Items/Gear/Armor/Leggings/Tassets.cs
+++ b/Content/Items/Gear/Armor/Leggings/Tassets.cs
@@ -2,6 +2,7 @@
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
+[AutoloadEquip(EquipType.Legs)]
 internal class Tassets : Leggings
 {
 	public override void PostRoll()

--- a/Content/Items/Gear/Armor/Leggings/Treads.cs
+++ b/Content/Items/Gear/Armor/Leggings/Treads.cs
@@ -2,6 +2,7 @@
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
+[AutoloadEquip(EquipType.Legs)]
 internal class Treads : Leggings
 {
 	public override void PostRoll()


### PR DESCRIPTION
﻿### Link Issues
Resolves: #602 

### Description of Work
- Spams the AutoloadEquip attribute on all of our armor Gear

### Comments
This is fun. 
The issue was twofold: while our predicates for the armor slots are fine and functional, they still work with the underlying vanilla logic. So the legs slot still needs to be an item with a leg equip slot.
This brings us to issue two - the AutoloadEquip attribute *is not* inherited to children classes. This means the solution was applying it to every individual class. Fun!

I've documented this annoyance for clarity.
