### PR TITLE
Shield swap fix

### DIFF
--- a/Common/Systems/ModPlayers/GearSwapManager.cs
+++ b/Common/Systems/ModPlayers/GearSwapManager.cs
@@ -21,7 +21,7 @@ public sealed class GearSwapManager : ModPlayer
 
 	public override void UpdateEquips()
 	{
-		if (Main.dedServ || !GearSwapKeybind.SwapKeybind.JustPressed)
+		if (Main.dedServ || !GearSwapKeybind.SwapKeybind.JustPressed || Main.LocalPlayer.itemTime > 0)
 		{
 			return;
 		}

--- a/Common/Systems/ModPlayers/WarShieldPlayer.cs
+++ b/Common/Systems/ModPlayers/WarShieldPlayer.cs
@@ -5,6 +5,8 @@ namespace PathOfTerraria.Common.Systems.ModPlayers;
 
 internal class WarShieldPlayer : ModPlayer
 {
+	protected override bool CloneNewInstances => true;
+
 	public bool CanBash => _bashCooldown <= 0;
 	public bool Bashing => _bashTime > 0;
 
@@ -12,6 +14,14 @@ internal class WarShieldPlayer : ModPlayer
 
 	private int _bashCooldown = 0;
 	private int _bashTime = 0;
+
+	public override ModPlayer Clone(Player newEntity)
+	{
+		var player = base.Clone(newEntity) as WarShieldPlayer;
+		player._bashCooldown = _bashCooldown;
+		player._bashTime = _bashTime;
+		return player;
+	}
 
 	public override void PreUpdateMovement()
 	{

--- a/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
+++ b/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
@@ -53,7 +53,7 @@ internal class StarlightBulwark : LeadBattleBulwark
 
 	public override bool? UseItem(Player player)
 	{
-		if (player.altFunctionUse != 2)
+		if (player.altFunctionUse != 2 && player.GetModPlayer<WarShieldPlayer>().CanBash)
 		{
 			player.GetModPlayer<WarShieldPlayer>().StartBash(Data.DashTime, _specialAlt ? Data.DashTime : Data.Cooldown, Data.DashMagnitude);
 		}

--- a/Content/Items/Gear/Weapons/WarShields/WarShield.cs
+++ b/Content/Items/Gear/Weapons/WarShields/WarShield.cs
@@ -78,7 +78,7 @@ internal abstract class WarShield : Gear, IParryItem, GetItemLevel.IItem
 		{
 			return false;
 		}
-		
+
 		return player.GetModPlayer<WarShieldPlayer>().CanBash;
 	}
 
@@ -89,7 +89,7 @@ internal abstract class WarShield : Gear, IParryItem, GetItemLevel.IItem
 
 	public override bool? UseItem(Player player)
 	{
-		if (player.altFunctionUse != 2)
+		if (player.altFunctionUse != 2 && player.GetModPlayer<WarShieldPlayer>().CanBash)
 		{
 			player.GetModPlayer<WarShieldPlayer>().StartBash(Data.DashTime, Data.Cooldown, Data.DashMagnitude);
 		}

--- a/Content/Items/Gear/Weapons/WarShields/WarShield.cs
+++ b/Content/Items/Gear/Weapons/WarShields/WarShield.cs
@@ -89,7 +89,7 @@ internal abstract class WarShield : Gear, IParryItem, GetItemLevel.IItem
 
 	public override bool? UseItem(Player player)
 	{
-		if (player.altFunctionUse != 2 && player.GetModPlayer<WarShieldPlayer>().CanBash)
+		if (player.altFunctionUse != 2)
 		{
 			player.GetModPlayer<WarShieldPlayer>().StartBash(Data.DashTime, Data.Cooldown, Data.DashMagnitude);
 		}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #611 

### Description of Work
- Fixed very fun issue with War Shields being spammable if swapped with a melee weapon
- Fixed all other issues of a similar ilk

### Comments
Shame it had to go!