### PR TITLE
Fix escape to close tree

### DIFF
--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -145,7 +145,7 @@ internal class TreeState : DraggableSmartUi
 			{
 				if (Player.controlInv && Player.releaseInventory)
 				{
-					SmartUiLoader.GetUiState<TreeState>().Toggle();
+					SmartUiLoader.GetUiState<TreeState>().DefaultClose();
 				}
 
 				Player.controlInv = false;


### PR DESCRIPTION
﻿### Link Issues
Resolves: #621 

### Description of Work
Properly closes the passives/skill tree when using escape.

### Comments
This is the easiest PR I've ever done anywhere