### PR TITLE
fix(#609): garrick despawning before quest is finishable

### DIFF
--- a/Common/Subworlds/RavencrestContent/TavernManager.cs
+++ b/Common/Subworlds/RavencrestContent/TavernManager.cs
@@ -65,10 +65,10 @@ internal class TavernManager : ModSystem
 			}
 		}
 
-		Queue<int> types = [];
+		Queue<int> types = new(guarantees);
 		Queue<Point16> seatsToUse = [];
 
-		for (int i = 0; i < Seats.Length; ++i)
+		for (int i = types.Count; i < Seats.Length; ++i)
 		{
 			if (entries.elements.Count > 0)
 			{

--- a/Common/Systems/Questing/QuestSystem.cs
+++ b/Common/Systems/Questing/QuestSystem.cs
@@ -11,7 +11,7 @@ internal class QuestSystem : ModSystem
 	{
 		if (Main.netMode == NetmodeID.SinglePlayer)
 		{
-			return !NPC.downedSlimeKing && QuestUnlockManager.CanStartQuest<KingSlimeQuest>();
+			return Quest.GetLocalPlayerInstance<KingSlimeQuest>().Active || QuestUnlockManager.CanStartQuest<KingSlimeQuest>();
 		}
 
 		return false;

--- a/Common/Systems/Questing/QuestSystem.cs
+++ b/Common/Systems/Questing/QuestSystem.cs
@@ -1,22 +1,10 @@
-﻿using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
-using PathOfTerraria.Common.UI.Quests;
+﻿using PathOfTerraria.Common.UI.Quests;
 using PathOfTerraria.Core.UI.SmartUI;
-using Terraria.ID;
 
 namespace PathOfTerraria.Common.Systems.Questing;
 
 internal class QuestSystem : ModSystem
 {
-	public static bool ForceGarrickSpawn()
-	{
-		if (Main.netMode == NetmodeID.SinglePlayer)
-		{
-			return Quest.GetLocalPlayerInstance<KingSlimeQuest>().Active || QuestUnlockManager.CanStartQuest<KingSlimeQuest>();
-		}
-
-		return false;
-	}
-
 	public override void ClearWorld()
 	{
 		if (Main.dedServ)

--- a/Content/NPCs/Town/GarrickNPC.cs
+++ b/Content/NPCs/Town/GarrickNPC.cs
@@ -207,7 +207,7 @@ public sealed class GarrickNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, 
 
 	public bool ForceSpawnInTavern()
 	{
-		return QuestSystem.ForceGarrickSpawn();
+		return Quest.GetLocalPlayerInstance<KingSlimeQuest>().Active || QuestUnlockManager.CanStartQuest<KingSlimeQuest>();
 	}
 
 	public float SpawnChanceInTavern()


### PR DESCRIPTION
﻿### Link Issues
Resolves: #609 

### Description of Work
- Fixes Garrick 'despawning' before King Slime quest is finished, locking progress
- Fixes issue in TavernManager where 'guaranteed' spawns (such as Garrick) would not spawn properly
- Removed ForceGarrickSpawn code from QuestSystem
- Removed useless anti-MP check on Garrick spawn code