### PR TITLE
fix: ravencrest defaulting to hardmode

### DIFF
--- a/Common/Subworlds/RavencrestSubworld.cs
+++ b/Common/Subworlds/RavencrestSubworld.cs
@@ -104,7 +104,13 @@ internal class RavencrestSubworld : MappingWorld
 			}
 
 			pool.Clear();
-			pool.Add(ModContent.NPCType<TownScoutNPC>(), ModContent.GetInstance<TownScoutNPC>().SpawnChance(spawnInfo));
+
+			float scoutChance = ModContent.GetInstance<TownScoutNPC>().SpawnChance(spawnInfo);
+
+			if (scoutChance > 0)
+			{
+				pool.Add(ModContent.NPCType<TownScoutNPC>(), scoutChance);
+			}
 		}
 	}
 }

--- a/Common/Subworlds/RavencrestSubworld.cs
+++ b/Common/Subworlds/RavencrestSubworld.cs
@@ -79,6 +79,8 @@ internal class RavencrestSubworld : MappingWorld
 			int y = npc.TileSpawn.Y * 16;
 			NPC.NewNPC(Entity.GetSource_TownSpawn(), x, y, npc.Type);
 		}
+
+		Main.hardMode = false;
 	}
 
 	public override void Update()

--- a/Content/NPCs/Town/TownScoutNPC.cs
+++ b/Content/NPCs/Town/TownScoutNPC.cs
@@ -97,11 +97,16 @@ public sealed class TownScoutNPC : ModNPC
 			}
 		}
 
+		if (!anyHealthyPlayer)
+		{
+			return 0;
+		}
+
 		float chance = NPC.downedGoblins ? 0.1f : 5;
 		bool spawnedScout = ModContent.GetInstance<RavencrestSystem>().SpawnedScout;
 
-		return SubworldSystem.Current is RavencrestSubworld && NPC.downedSlimeKing && anyHealthyPlayer && WorldGen.shadowOrbSmashed 
-			&& !NPC.AnyNPCs(Type) && (spawnInfo.SpawnTileX < 80 || spawnInfo.SpawnTileX > Main.maxTilesX - 80) && !spawnedScout ? chance : 0;
+		return SubworldSystem.Current is RavencrestSubworld && NPC.downedSlimeKing && WorldGen.shadowOrbSmashed 
+			&& (spawnInfo.SpawnTileX < 80 || spawnInfo.SpawnTileX > Main.maxTilesX - 80) && !spawnedScout ? chance : 0;
 	}
 
 	public override bool CheckActive()


### PR DESCRIPTION
### Linked Issues
Resolves: #601 

### Description of Work
- Ravencrest, on first entered, would default to hardmode. Disabled that.
- Fixed and/or updated Goblin Scout spawn in Ravencrest