### PR TITLE
fix(#615): fix spawn issue & widen chasms

### DIFF
--- a/Common/Subworlds/BossDomains/DeerDomain/DeerclopsSpawnEdits.cs
+++ b/Common/Subworlds/BossDomains/DeerDomain/DeerclopsSpawnEdits.cs
@@ -28,12 +28,10 @@ internal class DeerclopsSpawnEdits : GlobalNPC
 
 	public override void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns)
 	{
-		if (SubworldSystem.Current is not DeerclopsDomain)
+		if (SubworldSystem.Current is DeerclopsDomain)
 		{
-			return;
+			spawnRate = 80;
+			maxSpawns = 4;
 		}
-
-		spawnRate += 5;
-		maxSpawns = 8;
 	}
 }

--- a/Common/Subworlds/BossDomains/DeerclopsDomain.cs
+++ b/Common/Subworlds/BossDomains/DeerclopsDomain.cs
@@ -164,6 +164,8 @@ public class DeerclopsDomain : BossDomainSubworld
 
 	private void Tunnels(GenerationProgress progress, GameConfiguration configuration)
 	{
+		const float VerticalTunnelSize = 3f;
+
 		FastNoiseLite noise = GetSurfaceNoise();
 		Main.spawnTileX = Width / 2;
 		Main.spawnTileY = (int)(Height * 0.7f);
@@ -175,8 +177,8 @@ public class DeerclopsDomain : BossDomainSubworld
 		StartTunnel(noise, firstTunnelXStart, out Vector2[] points, out Vector2 last);
 
 		// Second tunnel
-		points = Tunnel.GeneratePoints([last, new(MathHelper.Lerp(last.X, Width / 2, 0.3f), last.Y - 80)], 6, 3.5f, 0.5f);
-		DigThrough(points, noise, 1);
+		points = Tunnel.GeneratePoints([last, new(MathHelper.Lerp(last.X, Width / 2, 0.3f), last.Y - 80)], 6, 3f, 0.5f);
+		DigThrough(points, noise, VerticalTunnelSize);
 		AddLanterns(points);
 		last = points.Last();
 		var chasmPoints = points.Clone() as Vector2[];
@@ -184,8 +186,8 @@ public class DeerclopsDomain : BossDomainSubworld
 		last = CreateHorizontalTunnel(noise, points, chasmPoints);
 
 		// Third tunnel
-		points = Tunnel.GeneratePoints([last, new(MathHelper.Lerp(last.X, Width / 2, 0.3f), last.Y - 80)], 6, 3.5f, 0.5f);
-		DigThrough(points, noise, 1);
+		points = Tunnel.GeneratePoints([last, new(MathHelper.Lerp(last.X, Width / 2, 0.3f), last.Y - 80)], 6, 3f, 0.5f);
+		DigThrough(points, noise, VerticalTunnelSize);
 		AddLanterns(points);
 		last = points.Last();
 		chasmPoints = points.Clone() as Vector2[];
@@ -194,8 +196,8 @@ public class DeerclopsDomain : BossDomainSubworld
 		last = points.Last();
 
 		// To surface
-		points = Tunnel.GeneratePoints([last, new(Width / 2, Surface), new(Width / 2, Surface - 20)], 6, 3.5f, 0.5f);
-		DigThrough(points, noise, 1);
+		points = Tunnel.GeneratePoints([last, new(Width / 2, Surface), new(Width / 2, Surface - 20)], 6, 3f, 0.5f);
+		DigThrough(points, noise, VerticalTunnelSize);
 		AddLanterns(points, 8);
 	}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #615 

### Description of Work
- Widens the semi-vertical chasms of the Deerclops domain & makes the chasm's "points" less far apart
- Sets spawn rate to a fixed rate, adding consistency and fixing weird issue with DragonLens(?)
