### PR TITLE
fix(#608,#632): fix quest button, raven in ravencrest, morgana locali…

### DIFF
--- a/Common/Systems/ModPlayers/ExpModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExpModPlayer.cs
@@ -1,6 +1,7 @@
 ﻿using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Common.World.Passes;
+using SubworldLibrary;
 using Terraria.Audio;
 using Terraria.Localization;
 using Terraria.ModLoader.IO;
@@ -35,7 +36,7 @@ public class ExpModPlayer : ModPlayer
 
 		Player.GetModPlayer<PassiveTreePlayer>().Points++;
 
-		if (Level == 1 && !ModContent.GetInstance<RavencrestSystem>().SpawnedRaven)
+		if (Level == 1 && !ModContent.GetInstance<RavencrestSystem>().SpawnedRaven && SubworldSystem.Current is null)
 		{
 			new RavenPass().Generate(null, null);
 		}

--- a/Common/Systems/Questing/QuestUnlockManager.cs
+++ b/Common/Systems/Questing/QuestUnlockManager.cs
@@ -19,7 +19,7 @@ internal class QuestUnlockManager : ModSystem
 
 	public static bool CanStartQuest(string name)
 	{
-		return ModContent.GetInstance<QuestUnlockManager>().isAvailable[name];
+		return ModContent.GetInstance<QuestUnlockManager>().isAvailable[name] && Quest.GetLocalPlayerInstance(name).CanBeStarted;
 	}
 
 	public static bool LocationHasQuest(string location)

--- a/Common/Systems/Questing/Quests/MainPath/QueenBeeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/QueenBeeQuest.cs
@@ -25,10 +25,10 @@ internal class QueenBeeQuest : Quest
 		return
 		[
 			new CollectCount(ItemID.Stinger, 5),
-			new InteractWithNPC(NPCQuestGiver, Language.GetText("Mods.PathOfTerraria.NPCs.WitchNPC.Dialogue.GotStingers"), onSuccess: 
+			new InteractWithNPC(NPCQuestGiver, Language.GetText("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.GotStingers"), onSuccess: 
 				npc => Item.NewItem(new EntitySource_Gift(npc), npc.Bottom, ModContent.ItemType<LargeStinger>())),
 			new KillCount(NPCID.QueenBee, 1, this.GetLocalization("KillQueen")),
-			new InteractWithNPC(NPCQuestGiver, Language.GetText("Mods.PathOfTerraria.NPCs.WitchNPC.Dialogue.QueenBeeKilled"))
+			new InteractWithNPC(NPCQuestGiver, Language.GetText("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.QueenBeeKilled"))
 			{
 				CountsAsCompletedOnMarker = true
 			},

--- a/Common/Systems/Questing/Quests/MainPath/WitchStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/WitchStartQuest.cs
@@ -55,10 +55,10 @@ internal class WitchStartQuest : Quest
 
 				return storage.TryGetValue(ModContent.ItemType<BatWings>(), out int wing) && storage.TryGetValue(ModContent.ItemType<OwlFeather>(), out int feather)
 					&& wing > 0 && feather > 1;
-			}, 1, Language.GetText($"Mods.{PoTMod.ModName}.NPCs.WitchNPC.QuestCondition")),
-			new InteractWithNPC(ModContent.NPCType<MorganaNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.WitchNPC.Dialogue.Quest2")),
-			new ConditionCheck(p => p.ownedProjectileCounts[ModContent.ProjectileType<OwlSummon>()] > 0, 1, Language.GetText($"Mods.{PoTMod.ModName}.NPCs.WitchNPC.SummonCondition")),
-			new InteractWithNPC(ModContent.NPCType<MorganaNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.WitchNPC.Dialogue.Quest3")),
+			}, 1, Language.GetText($"Mods.{PoTMod.ModName}.NPCs.MorganaNPC.QuestCondition")),
+			new InteractWithNPC(ModContent.NPCType<MorganaNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.Quest2")),
+			new ConditionCheck(p => p.ownedProjectileCounts[ModContent.ProjectileType<OwlSummon>()] > 0, 1, Language.GetText($"Mods.{PoTMod.ModName}.NPCs.MorganaNPC.SummonCondition")),
+			new InteractWithNPC(ModContent.NPCType<MorganaNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.Quest3")),
 		];
 	}
 

--- a/Content/NPCs/Town/MorganaNPC.cs
+++ b/Content/NPCs/Town/MorganaNPC.cs
@@ -110,12 +110,12 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 		if (quest is WitchStartQuest)
 		{
 			Item.NewItem(new EntitySource_Gift(NPC), NPC.Hitbox, ModContent.ItemType<GrimoireItem>());
-			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.WitchNPC.Dialogue.Quest");
+			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.Quest");
 			Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<WitchStartQuest>();
 		}
 		else
 		{
-			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.WitchNPC.Dialogue.QueenBeeQuest");
+			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.QueenBeeQuest");
 			Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<QueenBeeQuest>();
 		}
 	}


### PR DESCRIPTION
…zation

﻿### Link Issues
Resolves: #608 
Resolves: #632

### Description of Work
- Fixed the Ephemeral Raven spawning in Ravencrest (or other subworlds)
- Fixed Quest button continuing to appear after accepting a quest
- Fixed some Morgana localization still using the WitchNPC name