### PR TITLE
fix: hell event conditioning, rhine quest check, remove old code

### DIFF
--- a/Common/Systems/HellEvent/HellEventSystem.cs
+++ b/Common/Systems/HellEvent/HellEventSystem.cs
@@ -50,7 +50,7 @@ internal class HellEventSystem : ModSystem
 
 		foreach (Player player in Main.ActivePlayers)
 		{
-			if (player.Center.Y / 16 > Main.maxTilesX - 400 && QuestUnlockManager.CanStartQuest<WoFQuest>())
+			if (player.Center.Y / 16 > Main.maxTilesY - 400 && Quest.GetSingleton<WoFQuest>().Available())
 			{
 				canEventOccur = true;
 				break;

--- a/Common/Systems/Questing/Quest.cs
+++ b/Common/Systems/Questing/Quest.cs
@@ -85,6 +85,13 @@ public abstract class Quest : ModType, ILocalizedModType
 		return QuestsByName[name];
 	}
 
+	/// <inheritdoc cref="GetSingleton(string)"/>
+	/// <typeparam name="T">The type of the quest to get.</typeparam>
+	public static Quest GetSingleton<T>() where T : Quest
+	{
+		return GetSingleton(ModContent.GetInstance<T>().FullName);
+	}
+
 	/// <summary>
 	/// Gets the actual instance of the given quest on the local player.
 	/// </summary>

--- a/Content/Items/Gear/Weapons/Bow/Bow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Bow.cs
@@ -18,12 +18,6 @@ internal abstract class Bow : Gear
 	/// </summary>
 	public static Dictionary<int, Asset<Texture2D>> BowProjectileSpritesById = [];
 
-	public int ItemLevel
-	{
-		get => 1;
-		set => this.GetInstanceData().RealLevel = value; // Technically preserves previous behavior.
-	}
-
 	protected override string GearLocalizationCategory => "Bow";
 	protected virtual int AnimationSpeed => 6;
 	protected virtual float CooldownTimeInSeconds => 5;

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -12,12 +12,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class BloodOath : Sword, GenerateName.IItem
 {
-	public int ItemLevel
-	{
-		get => 1;
-		set => this.GetInstanceData().RealLevel = value; // Technically preserves previous behavior.
-	}
-
 	protected override bool CloneNewInstances => true;
 
 	private readonly HashSet<int> _hitNpcs = [];

--- a/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
@@ -11,12 +11,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class DwarvenGreatsword : Sword, GenerateName.IItem
 {
-	public int ItemLevel
-	{
-		get => 1;
-		set => this.GetInstanceData().RealLevel = value; // Technically preserves previous behavior.
-	}
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/Items/Gear/Weapons/Sword/FireStarter.cs
+++ b/Content/Items/Gear/Weapons/Sword/FireStarter.cs
@@ -13,12 +13,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class FireStarter : Sword, GenerateName.IItem
 {
-	public int ItemLevel
-	{
-		get => 1;
-		set => this.GetInstanceData().RealLevel = value; // Technically preserves previous behavior.
-	}
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/Items/Gear/Weapons/Sword/StoneSword.cs
+++ b/Content/Items/Gear/Weapons/Sword/StoneSword.cs
@@ -6,12 +6,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class StoneSword : Sword
 {
-	public int ItemLevel
-	{
-		get => 1;
-		set => this.GetInstanceData().RealLevel = value; // Technically preserves previous behavior.
-	}
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/Items/Gear/Weapons/Sword/WoodenSword.cs
+++ b/Content/Items/Gear/Weapons/Sword/WoodenSword.cs
@@ -6,12 +6,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class WoodenSword : Sword
 {
-	public int ItemLevel
-	{
-		get => 1;
-		set => this.GetInstanceData().RealLevel = value; // Technically preserves previous behavior.
-	}
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/NPCs/Town/RhineNPC.cs
+++ b/Content/NPCs/Town/RhineNPC.cs
@@ -109,7 +109,7 @@ public class RhineNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ITavernNP
 	public override void SetChatButtons(ref string button, ref string button2)
 	{
 		button = Main.LocalPlayer.HasItem(ModContent.ItemType<SimpleCompass>()) ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.RhineNPC.NewCompass.Button");
-		button2 = !Quest.GetLocalPlayerInstance<DeerclopsQuest>().CanBeStarted && NPC.downedBoss1 ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
+		button2 = !QuestUnlockManager.CanStartQuest<DeerclopsQuest>() ? "" : Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)


### PR DESCRIPTION
### Description of Work
- Improves Hell Event ("hell earthquake") conditions by making it quicker to check, fixes inconsistency
- Fixes Rhine poorly checking if her quest can be taken
- Removes ItemLevel property a bunch of items had for some reason
- Adds generic overload to Quest.GetSingleton