### PR TITLE
Fix/606 Generate Affix Updates

### DIFF
--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -80,6 +80,14 @@ public abstract class Affix : ILocalizedModType
 		MinValue = reader.ReadSingle();
 	}
 
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <param name="value">The set value of the affix. Set to -1 if using minValue and maxValue</param>
+	/// <param name="minValue">When value is -1, the minimum value of the roll range for the affix</param>
+	/// <param name="maxValue">When value is -1, the maximum value of the roll range for the affix</param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
 	public static Affix CreateAffix<T>(float value = -1, float minValue = 0f, float maxValue = 1f)
 	{
 		var instance = (Affix)Activator.CreateInstance(typeof(T));
@@ -199,7 +207,8 @@ internal class AffixHandler : ILoadable
 	public static List<ItemAffix> GetAffixes(Item item)
 	{
 		return _itemAffixes
-			.Where(proto => proto.RequiredInfluence == Influence.None || proto.RequiredInfluence == item.GetInstanceData().Influence)
+			.Where(proto => proto.RequiredInfluence == Influence.None ||
+			                proto.RequiredInfluence == item.GetInstanceData().Influence)
 			.Where(proto => (item.GetInstanceData().ItemType & proto.PossibleTypes) == item.GetInstanceData().ItemType)
 			.ToList();
 	}
@@ -217,7 +226,7 @@ internal class AffixHandler : ILoadable
 	public static int IndexFromItemAffix(Affix affix)
 	{
 		ItemAffix a = _itemAffixes.First(a => affix.GetType() == a.GetType());
-		
+
 		if (a is null)
 		{
 			return 0;

--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -84,25 +84,40 @@ public abstract class Affix : ILocalizedModType
 	/// 
 	/// </summary>
 	/// <param name="value">The set value of the affix. Set to -1 if using minValue and maxValue</param>
-	/// <param name="minValue">When value is -1, the minimum value of the roll range for the affix</param>
-	/// <param name="maxValue">When value is -1, the maximum value of the roll range for the affix</param>
 	/// <typeparam name="T"></typeparam>
 	/// <returns></returns>
-	public static Affix CreateAffix<T>(float value = -1, float minValue = 0f, float maxValue = 1f)
+	public static Affix CreateAffix<T>(float value)
+	{
+		var instance = (Affix)Activator.CreateInstance(typeof(T));
+		
+		if (instance == null)
+		{
+			throw new Exception($"Could not create affix of type {typeof(T).Name}");
+		}
+		
+		instance.Value = value;
+		return instance;
+	}
+	
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <param name="minValue">The minimum value of the roll range for the affix</param>
+	/// <param name="maxValue">The maximum value of the roll range for the affix</param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public static Affix CreateAffix<T>(float minValue = 0f, float maxValue = 1f)
 	{
 		var instance = (Affix)Activator.CreateInstance(typeof(T));
 
+		if (instance == null)
+		{
+			throw new Exception($"Could not create affix of type {typeof(T).Name}");
+		}
+
 		instance.MinValue = minValue;
 		instance.MaxValue = maxValue;
-
-		if (value == -1)
-		{
-			instance.Roll();
-		}
-		else
-		{
-			instance.Value = value;
-		}
+		instance.Roll();
 
 		return instance;
 	}

--- a/Content/Items/Currency/CorruptShard.cs
+++ b/Content/Items/Currency/CorruptShard.cs
@@ -77,8 +77,8 @@ internal class CorruptShard : CurrencyShard
 	private static void AddAffix(PoTInstanceItemData data)
 	{
 		WeightedRandom<ItemAffix> affixes = new();
-		affixes.Add((ItemAffix)Affix.CreateAffix<FlatLifeAffix>(-1, 10, 20), 1);
-		affixes.Add((ItemAffix)Affix.CreateAffix<DefenseItemAffix>(-1, 4, 6), 1);
+		affixes.Add((ItemAffix)Affix.CreateAffix<FlatLifeAffix>(10, 20), 1);
+		affixes.Add((ItemAffix)Affix.CreateAffix<DefenseItemAffix>(4, 6), 1);
 		affixes.Add((ItemAffix)Affix.CreateAffix<IncreasedAttackSpeedAffix>(5), 0.01f);
 
 		ItemAffix chosenAffix = affixes.Get();

--- a/Content/Items/Gear/Amulets/AddedLife/VigorAmulet.cs
+++ b/Content/Items/Gear/Amulets/AddedLife/VigorAmulet.cs
@@ -8,6 +8,6 @@ public class VigorAmulet : Amulet
 {
 	public override List<ItemAffix> GenerateImplicits()
 	{
-		return [(ItemAffix)Affix.CreateAffix<AddedLifeAffix>(-1, 3, 6)];
+		return [(ItemAffix)Affix.CreateAffix<AddedLifeAffix>(-3, 6)];
 	}
 }

--- a/Content/Items/Gear/Rings/AddedDamage/StoneRing.cs
+++ b/Content/Items/Gear/Rings/AddedDamage/StoneRing.cs
@@ -8,6 +8,6 @@ public class StoneRing : Ring
 {
 	public override List<ItemAffix> GenerateImplicits()
 	{
-		return [(ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 2, 3)];
+		return [(ItemAffix)Affix.CreateAffix<AddedDamageAffix>(2, 3)];
 	}
 }

--- a/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
@@ -80,10 +80,10 @@ internal class CorruptedBattleaxe : IronBattleaxe
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 1, 4);
-		var increasedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15f, 25f);
+		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(1, 4);
+		var increasedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(15f, 25f);
 		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<IncreasedAttackSpeedAffix>(0.1f);
-		var armorShredAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyArmorShredGearAffix>(-1, 0.1f, 0.2f);
+		var armorShredAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyArmorShredGearAffix>(0.1f, 0.2f);
 		armorShredAffix.Duration = 120;
 		return [addedDamageAffix, increasedDamageAffix, attackSpeedAffix, armorShredAffix];
 	}

--- a/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/CorruptedBattleaxe.cs
@@ -78,13 +78,13 @@ internal class CorruptedBattleaxe : IronBattleaxe
 		return type == ModContent.ProjectileType<CorruptedBattleaxeProjectile>();	
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 1, 4);
 		var increasedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15f, 25f);
 		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<IncreasedAttackSpeedAffix>(0.1f);
 		var armorShredAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyArmorShredGearAffix>(-1, 0.1f, 0.2f);
 		armorShredAffix.Duration = 120;
-		return [increasedDamageAffix, increasedDamageAffix, attackSpeedAffix, armorShredAffix];
+		return [addedDamageAffix, increasedDamageAffix, attackSpeedAffix, armorShredAffix];
 	}
 }

--- a/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
@@ -63,9 +63,9 @@ internal class GuardianAngel : SteelBattleaxe
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 1, 4);
-		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<IncreasedAttackSpeedAffix>(-1, 0.2f, 0.6f);
-		var armorShredAffix = (ItemAffix)Affix.CreateAffix<AddedKnockbackItemAffix>(-1, 0.1f, 0.2f);
+		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(1, 4);
+		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<IncreasedAttackSpeedAffix>(0.2f, 0.6f);
+		var armorShredAffix = (ItemAffix)Affix.CreateAffix<AddedKnockbackItemAffix>(0.1f, 0.2f);
 		var noFallDamage = (ItemAffix)Affix.CreateAffix<NoFallDamageAffix>(1);
 		return [addedDamageAffix, attackSpeedAffix, armorShredAffix, noFallDamage];
 	}

--- a/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/GuardianAngel.cs
@@ -61,7 +61,7 @@ internal class GuardianAngel : SteelBattleaxe
 		}
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 1, 4);
 		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<IncreasedAttackSpeedAffix>(-1, 0.2f, 0.6f);

--- a/Content/Items/Gear/Weapons/Battleaxe/IronBattleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/IronBattleaxe.cs
@@ -4,7 +4,6 @@ namespace PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 
 internal class IronBattleaxe : Battleaxe
 {
-
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();

--- a/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
@@ -18,7 +18,7 @@ internal class Bloodclotter : PlatinumGlaive
 	public override bool UseChargeAlt => false;
 	public override bool AutoloadProjectile => false;
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
 		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<BloodSiphonAffix>(1, 1, 1);

--- a/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
@@ -21,8 +21,8 @@ internal class Bloodclotter : PlatinumGlaive
 	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
-		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<BloodSiphonAffix>(1, 1, 1);
-		var bloodclotAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyBloodclotItemAffix>(1, 1, 1);
+		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<BloodSiphonAffix>(1);
+		var bloodclotAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyBloodclotItemAffix>(1);
 		return [addedDamageAffix, moltenShellAffix, bloodclotAffix];
 	}
 

--- a/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
@@ -20,7 +20,7 @@ internal class Bloodclotter : PlatinumGlaive
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
+		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(15, 25);
 		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<BloodSiphonAffix>(1);
 		var bloodclotAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyBloodclotItemAffix>(1);
 		return [addedDamageAffix, moltenShellAffix, bloodclotAffix];

--- a/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
+++ b/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
@@ -34,7 +34,7 @@ internal class MoltenDangpa : LeadDangpa
 		Item.shoot = ModContent.ProjectileType<MoltenDangpaThrown>();
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
 		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(-1, 0.05f, 0.1f);

--- a/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
+++ b/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
@@ -39,7 +39,7 @@ internal class MoltenDangpa : LeadDangpa
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
 		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(-1, 0.05f, 0.1f);
 		var healKillBurnAffix = (ItemAffix)Affix.CreateAffix<HealOnKillingBurningEnemiesAffix>(-1, 1f, 4f);
-		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<MoltenShellAffix>(1, 1, 1);
+		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<MoltenShellAffix>(1);
 		return [addedDamageAffix, attackSpeedAffix, healKillBurnAffix, moltenShellAffix];
 	}
 

--- a/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
+++ b/Content/Items/Gear/Weapons/Javelins/MoltenDangpa.cs
@@ -36,9 +36,9 @@ internal class MoltenDangpa : LeadDangpa
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
-		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(-1, 0.05f, 0.1f);
-		var healKillBurnAffix = (ItemAffix)Affix.CreateAffix<HealOnKillingBurningEnemiesAffix>(-1, 1f, 4f);
+		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(15, 25);
+		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(0.05f, 0.1f);
+		var healKillBurnAffix = (ItemAffix)Affix.CreateAffix<HealOnKillingBurningEnemiesAffix>(1f, 4f);
 		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<MoltenShellAffix>(1);
 		return [addedDamageAffix, attackSpeedAffix, healKillBurnAffix, moltenShellAffix];
 	}

--- a/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
@@ -29,9 +29,9 @@ internal class Rottenbone : PlatinumGlaive
 	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
-		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<FetidCarapaceAffix>(1, 1, 1);
+		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<FetidCarapaceAffix>(1);
 		var bloodclotAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyPoisonItemAffix>(-1, 0.05f, 0.1f);
-		var poisonedStrengthAffix = (ItemAffix)Affix.CreateAffix<BuffPoisonedHitsAffix>(0.2f, 0.2f, 0.2f);
+		var poisonedStrengthAffix = (ItemAffix)Affix.CreateAffix<BuffPoisonedHitsAffix>(0.2f);
 		return [addedDamageAffix, moltenShellAffix, bloodclotAffix, poisonedStrengthAffix];
 	}
 

--- a/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
@@ -26,7 +26,7 @@ internal class Rottenbone : PlatinumGlaive
 		staticData.Description = this.GetLocalization("Description");
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
 		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<FetidCarapaceAffix>(1, 1, 1);

--- a/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Rottenbone.cs
@@ -28,9 +28,9 @@ internal class Rottenbone : PlatinumGlaive
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
+		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(15, 25);
 		var moltenShellAffix = (ItemAffix)Affix.CreateAffix<FetidCarapaceAffix>(1);
-		var bloodclotAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyPoisonItemAffix>(-1, 0.05f, 0.1f);
+		var bloodclotAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyPoisonItemAffix>(0.05f, 0.1f);
 		var poisonedStrengthAffix = (ItemAffix)Affix.CreateAffix<BuffPoisonedHitsAffix>(0.2f);
 		return [addedDamageAffix, moltenShellAffix, bloodclotAffix, poisonedStrengthAffix];
 	}

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -55,7 +55,7 @@ internal class BloodOath : Sword, GenerateName.IItem
 		return $"[c/FF0000:{Language.GetTextValue("Mods.PathOfTerraria.Items.BloodOath.DisplayName")}]";
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(0, 2, 5);
 		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(0, 10, 10); // Add 10% life

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -57,7 +57,7 @@ internal class BloodOath : Sword, GenerateName.IItem
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 2, 5);
+		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(2, 5);
 		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(10); // Add 10% life
 		return [sharpAffix, lifeAffix];
 	}

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -57,8 +57,8 @@ internal class BloodOath : Sword, GenerateName.IItem
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(0, 2, 5);
-		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(0, 10, 10); // Add 10% life
+		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 2, 5);
+		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(10); // Add 10% life
 		return [sharpAffix, lifeAffix];
 	}
 

--- a/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
@@ -42,10 +42,10 @@ internal class DwarvenGreatsword : Sword, GenerateName.IItem
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(0, 33, 33); // Add 33% damage
-		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(0, 50, 50); // Add 50% life
-		var kbAffix = (ItemAffix)Affix.CreateAffix<AddedKnockbackItemAffix>(0, 10, 10); // Add 10% kb
-		var shredAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyArmorShredGearAffix>(0, 1, 1); // Add shred affix
+		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(33); // Add 33% damage
+		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(50); // Add 50% life
+		var kbAffix = (ItemAffix)Affix.CreateAffix<AddedKnockbackItemAffix>(10); // Add 10% kb
+		var shredAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyArmorShredGearAffix>(1); // Add shred affix
 
 		return [sharpAffix, lifeAffix, kbAffix, shredAffix];
 	}

--- a/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
@@ -40,7 +40,7 @@ internal class DwarvenGreatsword : Sword, GenerateName.IItem
 		return Language.GetTextValue("Mods.PathOfTerraria.Items.DwarvenGreatsword.DisplayName");
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(0, 33, 33); // Add 33% damage
 		var lifeAffix = (ItemAffix)Affix.CreateAffix<AddedLifeAffix>(0, 50, 50); // Add 50% life

--- a/Content/Items/Gear/Weapons/Sword/FireStarter.cs
+++ b/Content/Items/Gear/Weapons/Sword/FireStarter.cs
@@ -38,7 +38,7 @@ internal class FireStarter : Sword, GenerateName.IItem
 		return $"[c/FF0000:{Language.GetTextValue("Mods.PathOfTerraria.Items.FireStarter.DisplayName")}]";
 	}
 	
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 1, 4);
 		var onFireAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(-1, 0.1f, 0.15f);

--- a/Content/Items/Gear/Weapons/Sword/FireStarter.cs
+++ b/Content/Items/Gear/Weapons/Sword/FireStarter.cs
@@ -40,8 +40,8 @@ internal class FireStarter : Sword, GenerateName.IItem
 	
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(-1, 1, 4);
-		var onFireAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(-1, 0.1f, 0.15f);
+		var sharpAffix = (ItemAffix)Affix.CreateAffix<AddedDamageAffix>(1, 4);
+		var onFireAffix = (ItemAffix)Affix.CreateAffix<ChanceToApplyOnFireGearAffix>(0.1f, 0.15f);
 		return [sharpAffix, onFireAffix];
 	}
 	

--- a/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
+++ b/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
@@ -35,7 +35,7 @@ internal class StarlightBulwark : LeadBattleBulwark
 		staticData.Description = this.GetLocalization("Description");
 	}
 
-	public override List<ItemAffix> GenerateImplicits()
+	public override List<ItemAffix> GenerateAffixes()
 	{
 		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
 		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ManaAffix>(-1, 15, 20);

--- a/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
+++ b/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
@@ -37,9 +37,9 @@ internal class StarlightBulwark : LeadBattleBulwark
 
 	public override List<ItemAffix> GenerateAffixes()
 	{
-		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(-1, 15, 25);
-		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ManaAffix>(-1, 15, 20);
-		var noFallDamageAffix = (ItemAffix)Affix.CreateAffix<NoFallDamageAffix>(-1, 1f, 4f);
+		var addedDamageAffix = (ItemAffix)Affix.CreateAffix<IncreasedDamageAffix>(15, 25);
+		var attackSpeedAffix = (ItemAffix)Affix.CreateAffix<ManaAffix>(15, 20);
+		var noFallDamageAffix = (ItemAffix)Affix.CreateAffix<NoFallDamageAffix>(1f, 4f);
 		return [addedDamageAffix, attackSpeedAffix, noFallDamageAffix];
 	}
 

--- a/Core/Commands/SpawnUniqueItemCommand.cs
+++ b/Core/Commands/SpawnUniqueItemCommand.cs
@@ -11,7 +11,7 @@ public sealed class SpawnUniqueItemCommand : ModCommand
 
 	public override CommandType Type => CommandType.Chat;
 
-	public override string Usage => "[c/ff6a00:Usage: /uitem <name> <count> <ilevel> <quality increase> <geartype> <relative X> <relative Y>]";
+	public override string Usage => "[c/ff6a00:Usage: /uitem <name> <count> <ilevel> <geartype> <relative X> <relative Y>]";
 
 	public override string Description => "Spawns unique item(s) for testing items and loot generation. " +
 		"Class name does not need to be full; for example, \"Guardia\" will be enough to find the Guardian Angel item.";
@@ -55,17 +55,12 @@ public sealed class SpawnUniqueItemCommand : ModCommand
 			ilevel = 0;
 		}
 
-		if (!float.TryParse(args[3], out float qualityIncrease))
-		{
-			qualityIncrease = 0;
-		}
-
-		if (!float.TryParse(args[4], out float relX))
+		if (!float.TryParse(args[3], out float relX))
 		{
 			relX = 0;
 		}
 
-		if (!float.TryParse(args[5], out float relY))
+		if (!float.TryParse(args[4], out float relY))
 		{
 			relY = 0;
 		}

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -61,34 +61,12 @@ public static class PoTItemHelper
 	public static void Roll(Item item, int itemLevel)
 	{
 		PoTInstanceItemData data = item.GetInstanceData();
-		PoTStaticItemData staticData = item.GetStaticData();
 
 		SetItemLevel.Invoke(item, itemLevel);
-
-		// Only level 50+ gear can get influence.
-		if (data.RealLevel > 50 && !staticData.IsUnique && (data.ItemType & ItemType.AllGear) == ItemType.AllGear)
-		{
-			// Quality does not affect influence right now.
-			// Might not need to, seems to generaet plenty often late game.
-			int inf = Main.rand.Next(400) - data.RealLevel;
-
-			if (inf < 30)
-			{
-				data.Influence = Main.rand.NextBool() ? Influence.Solar : Influence.Lunar;
-			}
-		}
 
 		RollAffixes(item);
 		PostRoll.Invoke(item);
 		data.SpecialName = GenerateName.Invoke(item);
-	}
-
-	public static void Reroll(Item item)
-	{
-		// TODO: Don't call ANY variant of SetDefaults here... please?
-		item.GetInstanceData().Affixes.Clear();
-		item.ModItem?.SetDefaults();
-		Roll(item, PickItemLevel());
 	}
 
 	private static void RollAffixes(Item item)

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -7,7 +7,6 @@ using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Data;
 using PathOfTerraria.Common.Systems.ModPlayers;
-using PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -95,7 +94,6 @@ public static class PoTItemHelper
 	private static void RollAffixes(Item item)
 	{
 		PoTInstanceItemData data = item.GetInstanceData();
-		PoTStaticItemData staticData = item.GetStaticData();
 
 		data.Affixes.Clear();
 		data.Affixes.AddRange(GenerateAffixes.Invoke(item));
@@ -106,7 +104,7 @@ public static class PoTItemHelper
 			AddNewAffix(item, data);
 		}
 
-		List<ItemAffix> uniqueItemAffixes = GenerateImplicits.Invoke(item);
+		List<ItemAffix> uniqueItemAffixes = GenerateAffixes.Invoke(item);
 
 		foreach (ItemAffix affix in uniqueItemAffixes)
 		{
@@ -227,37 +225,36 @@ public static class PoTItemHelper
 
 	#endregion
 
-	// TODO: Un-hardcode?
 	public static int PickItemLevel()
 	{
 		if (NPC.downedMoonlord)
 		{
-			return Main.rand.Next(150, 201);
+			return 70;
 		}
 
 		if (NPC.downedAncientCultist)
 		{
-			return Main.rand.Next(110, 151);
+			return 65;
 		}
 
 		if (NPC.downedGolemBoss)
 		{
-			return Main.rand.Next(95, 131);
+			return 60;
 		}
 
 		if (NPC.downedPlantBoss)
 		{
-			return Main.rand.Next(80, 121);
+			return 55;
 		}
 
 		if (NPC.downedMechBossAny)
 		{
-			return Main.rand.Next(75, 111);
+			return 50;
 		}
 
 		if (Main.hardMode)
 		{
-			return 50;
+			return 45;
 		}
 
 		if (NPC.downedBoss3) //Skeletron
@@ -269,7 +266,7 @@ public static class PoTItemHelper
 		{
 			return 35;
 		}
-
+		
 		if (NPC.downedQueenBee)
 		{
 			return 30;


### PR DESCRIPTION
﻿### Link Issues
Resolves: #606

### Description of Work
- Updates all uniques to use Generate Affixes instead for their affixes
- Updates the uitem command and removes the quality increase parameter
- Normalizes the item level table
- Fixes Corrupted Battleaxe not getting the correct affixes
- Removes items getting influence over the item level of 50
- Fixes several uniques that had incorrectly assigned affix values
- Adds documentation around CreateAffix


### Comments