### PR TITLE
Unique roll fix

### DIFF
--- a/Content/Items/Gear/Weapons/Bow/Twinbow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Twinbow.cs
@@ -23,6 +23,7 @@ internal class Twinbow : Bow
 
 		PoTStaticItemData staticData = this.GetStaticData();
 		staticData.DropChance = null;
+		staticData.IsUnique = true;
 		staticData.Description = this.GetLocalization("Description");
 		staticData.AltUseDescription = this.GetLocalization("AltUseDescription");
 

--- a/Core/Items/PoTGlobalItem.cs
+++ b/Core/Items/PoTGlobalItem.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Systems.ModPlayers;
+﻿using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.Systems.ModPlayers;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -11,12 +12,22 @@ internal sealed partial class PoTGlobalItem : GlobalItem
 
 	// IMPORTANT: Called *after* ModItem::SetDefaults.
 	// https://github.com/tModLoader/tModLoader/blob/1.4.4/patches/tModLoader/Terraria/ModLoader/Core/GlobalLoaderUtils.cs#L20
-	public override void SetDefaults(Item entity)
+	public override void SetDefaults(Item item)
 	{
-		base.SetDefaults(entity);
+		base.SetDefaults(item);
+
+		PoTInstanceItemData data = item.GetInstanceData();
+		PoTStaticItemData staticData = item.GetStaticData();
 
 		// Makes Affixes use a new reference so that rerolling or updating Affixes in another instance doesn't share the reference
-		entity.GetInstanceData().Affixes = [];
+		data.Affixes = [];
+
+		if (staticData.IsUnique)
+		{
+			data.Rarity = ItemRarity.Unique;
+		}
+
+		PoTItemHelper.Roll(item, PoTItemHelper.PickItemLevel());
 	}
 
 	public override void UpdateEquip(Item item, Player player)


### PR DESCRIPTION
### Description of Work
- Makes all PoTGlobalItem items set if they're unique & roll in SetDefaults

### Comments
This does NOT make DragonLens or other cheat mod items roll rarity; this could be done trivially if desired. This DOES mean you can just pull out any unique, and it'll be a proper unique with all the affixes it should have. Finally.