### PR TITLE
feat(#561): adds better hotkey tooltips for skills

### DIFF
--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -265,28 +265,25 @@ internal sealed class NewHotbar : SmartUiState
 			
 			Tooltip.SetName(skill.DisplayName.Value + " " + level);
 
-			string noKeybindMessage = Language.GetText("Mods.PathOfTerraria.Skills.NoKeybindLine").Value;
+			string manaCost = Language.GetText("Mods.PathOfTerraria.Skills.ManaLine").WithFormatArgs(skill.ManaCost).Value;
 
-			string keybind = skillIndex switch
+			string weapon = skill.WeaponType != ItemID.None
+				? Language.GetText("Mods.PathOfTerraria.Skills.WeaponLine").WithFormatArgs(skill.WeaponType).Value
+				: Language.GetText("Mods.PathOfTerraria.Skills.NoWeaponLine").Value;
+
+			string noKeybindName = Language.GetText("Mods.PathOfTerraria.Skills.NoKeybindLine").Value;
+
+			string keybindName = skillIndex switch
 			{
-				0 => TryGetKeybindName(SkillCombatPlayer.Skill1Keybind.GetAssignedKeys().FirstOrDefault(), false, out string firstSkillKeybind) ? firstSkillKeybind : noKeybindMessage,
-				1 => TryGetKeybindName(SkillCombatPlayer.Skill2Keybind.GetAssignedKeys().FirstOrDefault(), false, out string secondSkillKeybind) ? secondSkillKeybind : noKeybindMessage,
-				2 => TryGetKeybindName(SkillCombatPlayer.Skill3Keybind.GetAssignedKeys().FirstOrDefault(), false, out string thirdSkillKeybind) ? thirdSkillKeybind : noKeybindMessage,
+				0 => TryGetKeybindName(SkillCombatPlayer.Skill1Keybind.GetAssignedKeys().FirstOrDefault(), false, out string skill1KeybindName) ? skill1KeybindName : noKeybindName,
+				1 => TryGetKeybindName(SkillCombatPlayer.Skill2Keybind.GetAssignedKeys().FirstOrDefault(), false, out string skill2KeybindName) ? skill2KeybindName : noKeybindName,
+				2 => TryGetKeybindName(SkillCombatPlayer.Skill3Keybind.GetAssignedKeys().FirstOrDefault(), false, out string skill3KeybindName) ? skill3KeybindName : noKeybindName,
 				_ => ""
 			};
 			
-			string manaCost = Language.GetText("Mods.PathOfTerraria.Skills.ManaLine").WithFormatArgs(skill.ManaCost).Value;
-
-			string weapon = Language.GetText("Mods.PathOfTerraria.Skills.WeaponLine").WithFormatArgs(skill.WeaponType).Value;
-
-			if (skill.WeaponType > ItemID.None)
-			{
-				weapon = Language.GetText("Mods.PathOfTerraria.Skills.NoWeaponLine").Value;
-			}
-
-			string indicator = Language.GetText("Mods.PathOfTerraria.Skills.KeybindLine").WithFormatArgs(keybind).Value;
+			string keybindLine = Language.GetText("Mods.PathOfTerraria.Skills.KeybindLine").WithFormatArgs(keybindName).Value;
 			
-			string tooltip = $"{indicator}\n{skill.Description.Value}\n{manaCost}\n{weapon}";
+			string tooltip = $"{keybindLine}\n{skill.Description.Value}\n{manaCost}\n{weapon}";
 
 			if (skill.Duration != 0)
 			{

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -276,7 +276,13 @@ internal sealed class NewHotbar : SmartUiState
 			};
 			
 			string manaCost = Language.GetText("Mods.PathOfTerraria.Skills.ManaLine").WithFormatArgs(skill.ManaCost).Value;
+
 			string weapon = Language.GetText("Mods.PathOfTerraria.Skills.WeaponLine").WithFormatArgs(skill.WeaponType).Value;
+
+			if (skill.WeaponType > ItemID.None)
+			{
+				weapon = Language.GetText("Mods.PathOfTerraria.Skills.NoWeaponLine").Value;
+			}
 			
 			string tooltip = $"(Press \"{keybind}\" to use)\n{skill.Description.Value}\n{manaCost}\n{weapon}";
 

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -265,7 +265,7 @@ internal sealed class NewHotbar : SmartUiState
 			
 			Tooltip.SetName(skill.DisplayName.Value + " " + level);
 
-			string noKeybindMessage = "No keybind detected";
+			string noKeybindMessage = Language.GetText("Mods.PathOfTerraria.Skills.NoKeybindLine").Value;
 
 			string keybind = skillIndex switch
 			{
@@ -283,8 +283,10 @@ internal sealed class NewHotbar : SmartUiState
 			{
 				weapon = Language.GetText("Mods.PathOfTerraria.Skills.NoWeaponLine").Value;
 			}
+
+			string indicator = Language.GetText("Mods.PathOfTerraria.Skills.KeybindLine").WithFormatArgs(keybind).Value;
 			
-			string tooltip = $"(Press \"{keybind}\" to use)\n{skill.Description.Value}\n{manaCost}\n{weapon}";
+			string tooltip = $"{indicator}\n{skill.Description.Value}\n{manaCost}\n{weapon}";
 
 			if (skill.Duration != 0)
 			{

--- a/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
@@ -3,8 +3,10 @@ LevelLine: (Level {0}/{1})
 ManaLine: Costs {0} mana
 WeaponLine: Must use a {0} weapon
 NoWeaponLine: No weapon required
+NoKeybindLine: No keybind detected
 DurationLine: Lasts {0} seconds
 CooldownLine: "{0} second cooldown"
+KeybindLine: Press {0} to use
 
 # These are the actual localization lines for skills.
 Nova: {

--- a/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
@@ -2,6 +2,7 @@
 LevelLine: (Level {0}/{1})
 ManaLine: Costs {0} mana
 WeaponLine: Must use a {0} weapon
+NoWeaponLine: No weapon required
 DurationLine: Lasts {0} seconds
 CooldownLine: "{0} second cooldown"
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #561 

### Description of Work
* Trims skill keybind names if they're too long
* Shows the full skill keybind name in its tooltip
### Comments
Unfortunately, `Tooltip` provides practically nothing regarding text customization. That is, different scales, colors, fonts, etc. which results in everything being crumpled together on the tooltip.

![image](https://github.com/user-attachments/assets/9bea65da-ffd0-45a6-8f42-ccabdbbece3b)