### PR TITLE
fix implicits not being called, fix negative affix on vigoramulet

### DIFF
--- a/Content/Items/Gear/Amulets/AddedLife/VigorAmulet.cs
+++ b/Content/Items/Gear/Amulets/AddedLife/VigorAmulet.cs
@@ -8,6 +8,6 @@ public class VigorAmulet : Amulet
 {
 	public override List<ItemAffix> GenerateImplicits()
 	{
-		return [(ItemAffix)Affix.CreateAffix<AddedLifeAffix>(-3, 6)];
+		return [(ItemAffix)Affix.CreateAffix<AddedLifeAffix>(3, 6)];
 	}
 }

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -74,7 +74,7 @@ public static class PoTItemHelper
 		PoTInstanceItemData data = item.GetInstanceData();
 
 		data.Affixes.Clear();
-		data.Affixes.AddRange(GenerateAffixes.Invoke(item));
+		data.Affixes.AddRange(GenerateImplicits.Invoke(item));
 		data.ImplicitCount = data.Affixes.Count;
 
 		for (int i = 0; i < GetAffixCount(item); i++)


### PR DESCRIPTION
### Description of Work
- Fixed GenerateImplicits never being called
- Fixed VigorAmulet giving negative stats unintentionally