### PR TITLE
fix CanStartQuest early throw

### DIFF
--- a/Common/Systems/Questing/QuestUnlockManager.cs
+++ b/Common/Systems/Questing/QuestUnlockManager.cs
@@ -19,7 +19,10 @@ internal class QuestUnlockManager : ModSystem
 
 	public static bool CanStartQuest(string name)
 	{
-		return ModContent.GetInstance<QuestUnlockManager>().isAvailable[name] && Quest.GetLocalPlayerInstance(name).CanBeStarted;
+		// We need to use TryGetValue here as otherwise very early access to this method can throw KeyNotFound.
+		// This is because the isAvailable population occurs late in the update process.
+		QuestUnlockManager manager = ModContent.GetInstance<QuestUnlockManager>();
+		return manager.isAvailable.TryGetValue(name, out bool value) && value && Quest.GetLocalPlayerInstance(name).CanBeStarted;
 	}
 
 	public static bool LocationHasQuest(string location)


### PR DESCRIPTION
### Description of Work
- Fixes KeyNotFoundException being thrown by a Clothier's checking if a quest is available when you load into a world with him nearby
This error would likely persist for other NPCs and other checks too.