### PR TITLE
Hide undiscovered quest markers

### DIFF
--- a/Common/NPCs/QuestMarkers/Vanilla/OldManMarkerNPC.cs
+++ b/Common/NPCs/QuestMarkers/Vanilla/OldManMarkerNPC.cs
@@ -54,10 +54,14 @@ internal class OldManModifiers : GlobalNPC
 	{
 		NPC talkNPC = Main.LocalPlayer.TalkNPC;
 
-		if (talkNPC is not null && talkNPC.type == NPCID.OldMan && QuestUnlockManager.CanStartQuest<SkeletronQuest>())
+		if (talkNPC is not null && talkNPC.type == NPCID.OldMan)
 		{
 			buttonOne = "";
-			buttonTwo = Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
+
+			if (QuestUnlockManager.CanStartQuest<SkeletronQuest>())
+			{
+				buttonTwo = Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest");
+			}
 		}
 	}
 

--- a/Common/Systems/MapContent/QuestMarkerHook.cs
+++ b/Common/Systems/MapContent/QuestMarkerHook.cs
@@ -28,9 +28,17 @@ internal class QuestMarkerHook : ILoadable
 	private void Draw(On_NPCHeadRenderer.orig_DrawWithOutlines orig, NPCHeadRenderer self, Entity entity, int headId, Vector2 position, 
 		Color color, float rotation, float scale, SpriteEffects effects)
 	{
+		Point mapPos = entity.Center.ToTileCoordinates();
+		bool revealed = Main.Map.IsRevealed(mapPos.X, mapPos.Y);
+
+		if (entity is NPC oldMan && oldMan.type == NPCID.OldMan && !revealed)
+		{
+			return; // Hide Old Man head icon unless the area's been explored already, better fitting vanilla's functionality & not giving away the dungeon immediately
+		}
+
 		orig(self, entity, headId, position, color, rotation, scale, effects);
 
-		if (entity is NPC npc && (npc.ModNPC is IQuestMarkerNPC questNPC || VanillaQuestMarkerNPCs.TryGetValue(npc.type, out questNPC)))
+		if (entity is NPC npc && (npc.ModNPC is IQuestMarkerNPC questNPC || VanillaQuestMarkerNPCs.TryGetValue(npc.type, out questNPC)) && revealed)
 		{
 			QuestMarkerType markerType = DetermineMarker(questNPC);
 

--- a/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
@@ -142,7 +142,7 @@ GarrickNPC: {
 	Dialogue: {
 		0: The ground shakes uncontrollably in the King's domain. As if slime seeps into the rock.
 		1: Adventurers often fail to tell you of how slimy adventuring is. I am not one of those adventurers. It's extremely slimy.
-		2: Watch your head. Generally good active, but especially in the King's domain.
+		2: Watch your head. Generally good advice, but especially in the King's domain.
 		3: Forge your blade as powerful as you can. Cutting through slime is deceptively difficult.
 		Quest: You may be able to tell - I've not had the best time. Tried to take down the King, almost lost everything. You are the one who restored Ravencrest, yes? Would I ask of you; slay the King Slime on my behalf? I'll reward you greatly. Take this map; I drew it on the long walk back. Good luck!
 		EoCQuestLine: Oh, the Eye you say? Formidable. I recall Eldric speaking of it, though he almost certainly undersold it. Here, I've been tasked with keeping this. Now is the time to use it.


### PR DESCRIPTION
﻿### Link Issues
Resolves: #497 

### Description of Work
- Hides quest icons from displaying when in undiscovered areas
- Stops the Old Man's icon from rendering & showing hover text when not discovered, to hide the Dungeon before discovery
