### PR TITLE
Make PoTGlobalItem public

### DIFF
--- a/Core/Items/PoTGlobalItem.cs
+++ b/Core/Items/PoTGlobalItem.cs
@@ -3,7 +3,7 @@ using PathOfTerraria.Common.Systems.ModPlayers;
 
 namespace PathOfTerraria.Core.Items;
 
-internal sealed partial class PoTGlobalItem : GlobalItem
+public sealed partial class PoTGlobalItem : GlobalItem
 {
 	public override void Load()
 	{


### PR DESCRIPTION
### Description of Work
Makes PoTGlobalItem public so I can use it in the online mod.