### PR TITLE
fix: fixes tool power tooltips and descriptors

### DIFF
--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -214,6 +214,27 @@ partial class PoTGlobalItem
 			tooltips.Add(def);
 		}
 
+		if (item.pick > 0)
+		{
+			var pick = new TooltipLine(Mod, "Pickaxe", $"[i:{ItemID.SilverBullet}] {HighlightNumbers($"{item.pick} {Localize("Pickaxe")}", baseColor: "DDDDDD")}");
+			
+			tooltips.Add(pick);
+		}
+		
+		if (item.axe > 0)
+		{
+			var pick = new TooltipLine(Mod, "Axe", $"[i:{ItemID.SilverBullet}] {HighlightNumbers($"{item.axe * 5} {Localize("Axe")}", baseColor: "DDDDDD")}");
+			
+			tooltips.Add(pick);
+		}
+		
+		if (item.hammer > 0)
+		{
+			var pick = new TooltipLine(Mod, "Hammer", $"[i:{ItemID.SilverBullet}] {HighlightNumbers($"{item.hammer} {Localize("Hammer")}", baseColor: "DDDDDD")}");
+			
+			tooltips.Add(pick);
+		}
+		
 		tooltips.AddRange(oldStats);
 
 		if (item.ModItem is Map map && map.Tier > 0)

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -12,6 +12,9 @@ Tooltips: {
 	Level: Item level:
 	Damage: Damage
 	Defense: Defense
+	Pickaxe: Pickaxe Power
+	Axe: Axe Power
+	Hammer: Hammer Power
 }
 
 Influence: {
@@ -337,3 +340,5 @@ Shield: {
 }
 
 Map.Name: Map
+
+None.Name: None


### PR DESCRIPTION
﻿### Link Issues
Resolves: #700 

### Description of Work
* Fixes item tool power tooltips by manually adding them through `GlobalItem::ModifyTooltips()`.
* Fixes item tooltip descriptors by creating a new localization key at `Mods.PathOfTerraria.Gear.Tooltips.None.Name`.

### Comments
