### PR TITLE
fix: fixes blacksmith start quest kill counts

### DIFF
--- a/Common/Systems/Questing/Quests/MainPath/BlacksmithStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/BlacksmithStartQuest.cs
@@ -63,7 +63,7 @@ internal class BlacksmithStartQuest : Quest
 				Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<IronBroadsword>());
 				return true;
 			}),
-			new KillCount(NPCID.Zombie, 15, this.GetLocalization("Kill.Zombies")),
+			new KillCount(static npc => NPCID.Sets.Zombies[npc.type], 15, this.GetLocalization("Kill.Zombies")),
 			new InteractWithNPC(ModContent.NPCType<BlacksmithNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.BlacksmithNPC.Dialogue.Quest3"),
 			[
 				new GiveItem(30, ItemID.StoneBlock), new(50, ItemID.Wood), new(10, ItemID.GoldBar, ItemID.PlatinumBar)


### PR DESCRIPTION
﻿### Link Issues
Resolves: #701 

### Description of Work
* Uses `NPCID.Sets.Zombies[]` to determine whether an `NPC` is a zombie, instead of manually checking its `type`.

### Comments
This expects for modded zombie NPCs to mark `NPCID.Sets.Zombies[]` as true; otherwise, they won't be considered as zombies for the quest.