### PR TITLE
fix overlapping text on held gear, spammed exception if using a spawn…

### DIFF
--- a/Common/Subworlds/BossDomains/Hardmode/QueenDomain/QueenSlimeDomainSpawns.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenDomain/QueenSlimeDomainSpawns.cs
@@ -34,6 +34,11 @@ internal class QueenSlimeDomainSpawns : GlobalNPC
 
 	public override void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns)
 	{
+		if (SubworldSystem.Current is not QueenSlimeDomain)
+		{
+			return;
+		}
+
 		spawnRate = (int)(spawnRate * 0.8f);
 		maxSpawns += 2;
 	}

--- a/Common/UI/Tooltip.cs
+++ b/Common/UI/Tooltip.cs
@@ -113,11 +113,20 @@ public class Tooltip : SmartUiState, ILoadable
 		}
 		else if (fancyTooltips.Count > 0)
 		{
+			float yOffset = 0;
+
 			for (int i = 0; i < fancyTooltips.Count; ++i)
 			{
 				DrawableTooltipLine line = fancyTooltips[i];
 
-				ChatManager.DrawColorCodedStringWithShadow(Main.spriteBatch, FontAssets.MouseText.Value, line.Text, pos + new Vector2(0, 30 * i), line.OverrideColor ?? line.Color, 0f, Vector2.Zero, new(0.9f));
+				ChatManager.DrawColorCodedStringWithShadow(Main.spriteBatch, FontAssets.MouseText.Value, line.Text, pos + new Vector2(0, yOffset), line.OverrideColor ?? line.Color, 0f, line.Origin, new(0.9f));
+				yOffset += 30 * line.BaseScale.Y;
+				int newLineCount = line.Text.Count(x => x == '\n');
+
+				if (newLineCount > 0)
+				{
+					yOffset += 20 * newLineCount;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
… disabler

### Description of Work
- Adds "is in Queen Slime Domain" check to Queen Slime Domain spawning
- Adjusts the size of the offset for text in Gear hover tooltip; not perfectly accurate, but doesn't overlap anymore
