### PR TITLE
disable affixes on all invalid npcs

### DIFF
--- a/Common/NPCs/AffixFreeNPCs.cs
+++ b/Common/NPCs/AffixFreeNPCs.cs
@@ -12,5 +12,8 @@ internal class AffixFreeNPCs : GlobalNPC
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemFistRight);
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemHead);
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemHeadFree);
+		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimeOld);
+		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimePurple);
+		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimeYellow);
 	}
 }

--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -146,7 +146,7 @@ internal class ArpgNPC : GlobalNPC
 	{
 		//We only want to trigger these changes on hostile non-boss, non Eater of Worlds mobs in-game
 		if (npc.friendly || npc.boss || Main.gameMenu || npc.type is NPCID.EaterofWorldsBody or NPCID.EaterofWorldsHead or NPCID.EaterofWorldsTail || npc.immortal 
-			|| npc.dontTakeDamage || NoAffixesSet.Contains(npc.type) || NPCID.Sets.ProjectileNPC[npc.type])
+			|| npc.dontTakeDamage || NPCID.Sets.ProjectileNPC[npc.type] || npc.CountsAsACritter || NoAffixesSet.Contains(npc.type))
 		{
 			return;
 		}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #702

### Description of Work
- Disables affixes on anything that counts as a critter (`NPC.CountsAsCritter`), blacklists ballooned purple town slime