### PR TITLE
fix tutorial skill point issue, add in tooltip for missing skill

### DIFF
--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -17,6 +17,7 @@ using Terraria.UI;
 using Terraria.UI.Chat;
 using Terraria.Social.Steam;
 using PathOfTerraria.Common.UI.Quests;
+using PathOfTerraria.Common.Systems.ModPlayers;
 
 namespace PathOfTerraria.Common.UI.Guide;
 
@@ -128,7 +129,11 @@ internal class TutorialUIState : UIState
 		plr.GetModPlayer<TutorialPlayer>().TutorialStep = (byte)Step;
 		StoredStep = Step;
 
-		if (Step == 10)
+		if (Step == 1)
+		{
+			plr.GetModPlayer<ExpModPlayer>().Exp += plr.GetModPlayer<ExpModPlayer>().NextLevel + 1;
+		}
+		else if (Step == 10)
 		{
 			Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<FirstQuest>();
 		}
@@ -136,7 +141,6 @@ internal class TutorialUIState : UIState
 		{
 			if (!NPC.AnyNPCs(ModContent.NPCType<RavenNPC>()))
 			{
-
 				if (Main.netMode == NetmodeID.SinglePlayer)
 				{
 					NPC.NewNPC(Entity.GetSource_NaturalSpawn(), (int)plr.Center.X, (int)plr.Center.Y - 200, ModContent.NPCType<RavenNPC>());

--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -60,7 +60,11 @@ internal class TutorialUIState : UIState
 		DrawBacked(spriteBatch, pos + new Vector2(110, 110), "Skip Guide", true, () => 
 		{
 			Step = 13;
-			Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Exp += Main.LocalPlayer.GetModPlayer<ExpModPlayer>().NextLevel + 1;
+
+			if (Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Level == 0)
+			{
+				Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Exp += Main.LocalPlayer.GetModPlayer<ExpModPlayer>().NextLevel + 1;
+			}
 
 			IncrementStep();
 		});

--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -60,6 +60,8 @@ internal class TutorialUIState : UIState
 		DrawBacked(spriteBatch, pos + new Vector2(110, 110), "Skip Guide", true, () => 
 		{
 			Step = 13;
+			Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Exp += Main.LocalPlayer.GetModPlayer<ExpModPlayer>().NextLevel + 1;
+
 			IncrementStep();
 		});
 	}

--- a/Localization/en-US/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.UI.hjson
@@ -44,6 +44,8 @@ DropVisualizer: {
 SkillUI: {
 	Back: Back
 	NoPassives: This skill has no passives.
+	NoSkill: (No skill)
+	ChooseSkill: Choose a skill from the Skill menu to use it.
 }
 
 Guide: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #728
Resolves: #729

### Description of Work
- Adds in "No skill" text when hovering over an empty skill slot
- Levels up the player once before doing the tutorial step which requires a skill point