### PR TITLE
chore: do some broadsword rebalancing

### DIFF
--- a/Content/Items/Gear/Weapons/Sword/Broadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/Broadsword.cs
@@ -8,7 +8,7 @@ internal class Broadsword : Sword
 
 		Item.width = 52; 
 		Item.height = 52;
-		Item.damage = 35;
+		Item.damage = 15;
 		Item.useTime = 60;
 		Item.useAnimation = 65;
 	}

--- a/Content/Items/Gear/Weapons/Sword/CopperBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/CopperBroadsword.cs
@@ -21,7 +21,7 @@ internal class CopperBroadsword : Broadsword
 	{
 		base.SetDefaults();
 
-		Item.damage = 8;
+		Item.damage = 26;
 		Item.width = 42;
 		Item.height = 42;
 		Item.UseSound = SoundID.Item1;

--- a/Content/Items/Gear/Weapons/Sword/IronBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/IronBroadsword.cs
@@ -21,7 +21,7 @@ internal class IronBroadsword : Broadsword
 	{
 		base.SetDefaults();
 
-		Item.damage = 10;
+		Item.damage = 18;
 		Item.width = 46;
 		Item.height = 46;
 		Item.UseSound = SoundID.Item1;

--- a/Content/Items/Gear/Weapons/Sword/Katana.cs
+++ b/Content/Items/Gear/Weapons/Sword/Katana.cs
@@ -1,10 +1,16 @@
-﻿namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
+﻿using PathOfTerraria.Core.Items;
+
+namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
 internal class Katana : Sword
 {
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();
+		
+		PoTStaticItemData staticData = this.GetStaticData();
+		staticData.DropChance = 1f;
+		staticData.MinDropItemLevel = 15;
 
 		GearAlternatives.Register(Type, Terraria.ID.ItemID.Katana);
 	}

--- a/Content/Items/Gear/Weapons/Sword/SteelBroadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/SteelBroadsword.cs
@@ -19,7 +19,7 @@ internal class SteelBroadsword : Broadsword
 	{
 		base.SetDefaults();
 
-		Item.damage = 12;
+		Item.damage = 38;
 		Item.width = 46;
 		Item.height = 46;
 		Item.UseSound = SoundID.Item1;


### PR DESCRIPTION

### Description of Work
Broadswords were rather underpowered with how slow they would attack. The damage numbers have been tweaked drastically to fix this

Iron Broadsword 10 → 18
Steel Broadsword 12 → 38
Copper Broadsword  8 → 26
Katana was given a minimum area level to drop at 15as it was a very strong sword early game.

### Comments
