### PR TITLE
fix prime map unimpl., skeletron map candrop being prime condition

### DIFF
--- a/Content/Items/Consumables/Maps/BossMaps/PrimeMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/PrimeMap.cs
@@ -9,7 +9,7 @@ internal class PrimeMap : Map
 {
 	public override int MaxUses => GetBossUseCount();
 	public override int WorldTier => 59;
-	public override bool CanDrop => throw new NotImplementedException();
+	public override bool CanDrop => PoTItemHelper.PickItemLevel() >= 58 && NPC.downedMechBoss3;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Consumables/Maps/BossMaps/SkeletronMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/SkeletronMap.cs
@@ -9,7 +9,7 @@ internal class SkeletronMap : Map
 {
 	public override int MaxUses => GetBossUseCount();
 	public override int WorldTier => 40;
-	public override bool CanDrop => PoTItemHelper.PickItemLevel() >= 58 && NPC.downedMechBoss3;
+	public override bool CanDrop => NPC.downedBoss3;
 
 	public override void SetStaticDefaults()
 	{


### PR DESCRIPTION
### Description of Work
- Fixes Skeletron Prime's map having no implementation for CanDrop
- Fixes Skeletron's map having the implementation that should be on Skeletron Prime

### Comments
