### PR TITLE
More favourable Ravencrest entrance gen

### DIFF
--- a/Common/UI/Guide/TutorialNPCs.cs
+++ b/Common/UI/Guide/TutorialNPCs.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace PathOfTerraria.Common.UI.Guide;
+
+/// <summary>
+/// Handles NPC spawns while the tutorial is active.
+/// </summary>
+internal class TutorialNPCs : GlobalNPC
+{
+	public override void EditSpawnPool(IDictionary<int, float> pool, NPCSpawnInfo spawnInfo)
+	{
+		Player p = spawnInfo.Player;
+
+		//Is the player is in a surface evil biome and has not completed the tutorial, disable spawns
+		if (!p.GetModPlayer<TutorialPlayer>().CompletedTutorial && (p.ZoneCrimson || p.ZoneCorrupt) && (p.Center.Y / 16) <= Main.worldSurface)
+		{
+			pool.Clear();
+		}
+	}
+}

--- a/Common/UI/Guide/TutorialPlayer.cs
+++ b/Common/UI/Guide/TutorialPlayer.cs
@@ -22,12 +22,15 @@ public enum TutorialCheck : byte
 /// </summary>
 internal class TutorialPlayer : ModPlayer
 {
+	/// <summary> Whether the player has completed the tutorial (<see cref="TutorialCheck.FinishedTutorial"/>). </summary>
+	public bool CompletedTutorial => TutorialChecks.Contains(TutorialCheck.FinishedTutorial);
+
 	public HashSet<TutorialCheck> TutorialChecks = [];
 	public byte TutorialStep = 0;
 
 	public override void OnEnterWorld()
 	{
-		if (!TutorialChecks.Contains(TutorialCheck.FinishedTutorial))
+		if (!CompletedTutorial)
 		{
 			UIManager.Register("Tutorial UI", "Vanilla: Player Chat", new TutorialUIState());
 		}

--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -9,13 +9,11 @@ using ReLogic.Content;
 using ReLogic.Graphics;
 using SubworldLibrary;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.UI;
 using Terraria.UI.Chat;
-using Terraria.Social.Steam;
 using PathOfTerraria.Common.UI.Quests;
 using PathOfTerraria.Common.Systems.ModPlayers;
 
@@ -46,7 +44,7 @@ internal class TutorialUIState : UIState
 
 	protected override void DrawSelf(SpriteBatch spriteBatch)
 	{
-		_opacity = MathHelper.Lerp(_opacity, Step > 13 ? 0 : 1, 0.05f);
+		_opacity = MathHelper.Lerp(_opacity, HideSelf() ? 0 : 1, 0.05f);
 
 		if (_opacity < 0.001f)
 		{
@@ -80,6 +78,11 @@ internal class TutorialUIState : UIState
 
 			IncrementStep();
 		});
+
+		bool HideSelf() //Under what conditions this panel should fade out in
+		{
+			return Step > 13 || Main.npcChatText != string.Empty;
+		}
 	}
 
 	public override void Update(GameTime gameTime)

--- a/Common/World/Generation/StructureTools.cs
+++ b/Common/World/Generation/StructureTools.cs
@@ -66,7 +66,7 @@ internal static class StructureTools
 	}
 
 	/// <summary>
-	/// Determines flatness & depth placement of an area. Returns average heights; use <paramref name="valid"/> to check if the space is valid.<br/>
+	/// Determines flatness and depth placement of an area. Returns average heights; use <paramref name="valid"/> to check if the space is valid.<br/>
 	/// This needs a lot of tweaking to get perfect.
 	/// </summary>
 	/// <param name="x">Left of the area.</param>


### PR DESCRIPTION
﻿### Link Issues
Resolves: https://github.com/Path-of-Terraria/PathOfTerraria/issues/753
Resolves: #736 

### Description of Work
- Makes the Ravencrest entrance avoid generating beyond the corruption/crimson, and disables surface corruption/crimson spawns for the duration of Guided Tour in the circumstance that it does
- Hides the active tutorial step when any dialogue is open
