### PR TITLE
fix(#750): remove base divisor when on large monitors

### DIFF
--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -58,6 +58,7 @@ internal class TutorialUIState : UIState
 		// Temp fix to position the guide correctly on ultra-wide monitors + 4k monitors
 		if (Main.screenWidth > 3000)
 		{
+			_baseYDivisor = 4;
 			pos = new Vector2(Main.screenWidth, Main.screenHeight + 500) / new Vector2(2, _baseYDivisor);
 		}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #750

### Description of Work
*  remove base divisor when on large monitors - Not needed on 1440p or 4k so it was just throwing it off-screen

### Comments
