### PR TITLE
Fix vanilla items not having an ItemType

### DIFF
--- a/Common/Data/Models/VanillaItemData.cs
+++ b/Common/Data/Models/VanillaItemData.cs
@@ -1,0 +1,6 @@
+﻿namespace PathOfTerraria.Common.Data.Models;
+
+internal class VanillaItemData()
+{
+	public string ItemType { get; set; }
+}

--- a/Common/Data/VanillaItemData/AbigailsFlower.json
+++ b/Common/Data/VanillaItemData/AbigailsFlower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/AcornAxe.json
+++ b/Common/Data/VanillaItemData/AcornAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/ActuationAccessory.json
+++ b/Common/Data/VanillaItemData/ActuationAccessory.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AdamantiteBreastplate.json
+++ b/Common/Data/VanillaItemData/AdamantiteBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AdamantiteChainsaw.json
+++ b/Common/Data/VanillaItemData/AdamantiteChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/AdamantiteDrill.json
+++ b/Common/Data/VanillaItemData/AdamantiteDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/AdamantiteGlaive.json
+++ b/Common/Data/VanillaItemData/AdamantiteGlaive.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/AdamantiteHeadgear.json
+++ b/Common/Data/VanillaItemData/AdamantiteHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AdamantiteHelmet.json
+++ b/Common/Data/VanillaItemData/AdamantiteHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AdamantiteLeggings.json
+++ b/Common/Data/VanillaItemData/AdamantiteLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AdamantiteMask.json
+++ b/Common/Data/VanillaItemData/AdamantiteMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AdamantitePickaxe.json
+++ b/Common/Data/VanillaItemData/AdamantitePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/AdamantiteRepeater.json
+++ b/Common/Data/VanillaItemData/AdamantiteRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/AdamantiteSword.json
+++ b/Common/Data/VanillaItemData/AdamantiteSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/AdamantiteWaraxe.json
+++ b/Common/Data/VanillaItemData/AdamantiteWaraxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/AdhesiveBandage.json
+++ b/Common/Data/VanillaItemData/AdhesiveBandage.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Aglet.json
+++ b/Common/Data/VanillaItemData/Aglet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AleThrowingGlove.json
+++ b/Common/Data/VanillaItemData/AleThrowingGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Amarok.json
+++ b/Common/Data/VanillaItemData/Amarok.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/AmberRobe.json
+++ b/Common/Data/VanillaItemData/AmberRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AmberStaff.json
+++ b/Common/Data/VanillaItemData/AmberStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/AmethystStaff.json
+++ b/Common/Data/VanillaItemData/AmethystStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/AmphibianBoots.json
+++ b/Common/Data/VanillaItemData/AmphibianBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Anchor.json
+++ b/Common/Data/VanillaItemData/Anchor.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/AncientBattleArmorHat.json
+++ b/Common/Data/VanillaItemData/AncientBattleArmorHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientBattleArmorPants.json
+++ b/Common/Data/VanillaItemData/AncientBattleArmorPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientBattleArmorShirt.json
+++ b/Common/Data/VanillaItemData/AncientBattleArmorShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AncientChisel.json
+++ b/Common/Data/VanillaItemData/AncientChisel.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AncientCobaltBreastplate.json
+++ b/Common/Data/VanillaItemData/AncientCobaltBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AncientCobaltHelmet.json
+++ b/Common/Data/VanillaItemData/AncientCobaltHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientCobaltLeggings.json
+++ b/Common/Data/VanillaItemData/AncientCobaltLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientGoldHelmet.json
+++ b/Common/Data/VanillaItemData/AncientGoldHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientHallowedGreaves.json
+++ b/Common/Data/VanillaItemData/AncientHallowedGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientHallowedHeadgear.json
+++ b/Common/Data/VanillaItemData/AncientHallowedHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientHallowedHelmet.json
+++ b/Common/Data/VanillaItemData/AncientHallowedHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientHallowedHood.json
+++ b/Common/Data/VanillaItemData/AncientHallowedHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientHallowedMask.json
+++ b/Common/Data/VanillaItemData/AncientHallowedMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientHallowedPlateMail.json
+++ b/Common/Data/VanillaItemData/AncientHallowedPlateMail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AncientIronHelmet.json
+++ b/Common/Data/VanillaItemData/AncientIronHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientNecroHelmet.json
+++ b/Common/Data/VanillaItemData/AncientNecroHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientShadowGreaves.json
+++ b/Common/Data/VanillaItemData/AncientShadowGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientShadowHelmet.json
+++ b/Common/Data/VanillaItemData/AncientShadowHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AncientShadowScalemail.json
+++ b/Common/Data/VanillaItemData/AncientShadowScalemail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AngelHalo.json
+++ b/Common/Data/VanillaItemData/AngelHalo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AngelWings.json
+++ b/Common/Data/VanillaItemData/AngelWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AnglerEarring.json
+++ b/Common/Data/VanillaItemData/AnglerEarring.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AnglerHat.json
+++ b/Common/Data/VanillaItemData/AnglerHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AnglerPants.json
+++ b/Common/Data/VanillaItemData/AnglerPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AnglerTackleBag.json
+++ b/Common/Data/VanillaItemData/AnglerTackleBag.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AnglerVest.json
+++ b/Common/Data/VanillaItemData/AnglerVest.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AnkhCharm.json
+++ b/Common/Data/VanillaItemData/AnkhCharm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AnkhShield.json
+++ b/Common/Data/VanillaItemData/AnkhShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AnkletoftheWind.json
+++ b/Common/Data/VanillaItemData/AnkletoftheWind.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AntlionClaw.json
+++ b/Common/Data/VanillaItemData/AntlionClaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ApprenticeAltHead.json
+++ b/Common/Data/VanillaItemData/ApprenticeAltHead.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ApprenticeAltPants.json
+++ b/Common/Data/VanillaItemData/ApprenticeAltPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ApprenticeAltShirt.json
+++ b/Common/Data/VanillaItemData/ApprenticeAltShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ApprenticeHat.json
+++ b/Common/Data/VanillaItemData/ApprenticeHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ApprenticeRobe.json
+++ b/Common/Data/VanillaItemData/ApprenticeRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ApprenticeScarf.json
+++ b/Common/Data/VanillaItemData/ApprenticeScarf.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ApprenticeStaffT3.json
+++ b/Common/Data/VanillaItemData/ApprenticeStaffT3.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ApprenticeTrousers.json
+++ b/Common/Data/VanillaItemData/ApprenticeTrousers.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AquaScepter.json
+++ b/Common/Data/VanillaItemData/AquaScepter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ArcaneFlower.json
+++ b/Common/Data/VanillaItemData/ArcaneFlower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ArchitectGizmoPack.json
+++ b/Common/Data/VanillaItemData/ArchitectGizmoPack.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ArcticDivingGear.json
+++ b/Common/Data/VanillaItemData/ArcticDivingGear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Arkhalis.json
+++ b/Common/Data/VanillaItemData/Arkhalis.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ArkhalisWings.json
+++ b/Common/Data/VanillaItemData/ArkhalisWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ArmorBracing.json
+++ b/Common/Data/VanillaItemData/ArmorBracing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ArmorPolish.json
+++ b/Common/Data/VanillaItemData/ArmorPolish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/AshWoodBow.json
+++ b/Common/Data/VanillaItemData/AshWoodBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/AshWoodBreastplate.json
+++ b/Common/Data/VanillaItemData/AshWoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/AshWoodGreaves.json
+++ b/Common/Data/VanillaItemData/AshWoodGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AshWoodHammer.json
+++ b/Common/Data/VanillaItemData/AshWoodHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/AshWoodHelmet.json
+++ b/Common/Data/VanillaItemData/AshWoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/AshWoodSword.json
+++ b/Common/Data/VanillaItemData/AshWoodSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/AvengerEmblem.json
+++ b/Common/Data/VanillaItemData/AvengerEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BabyBirdStaff.json
+++ b/Common/Data/VanillaItemData/BabyBirdStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/BallOHurt.json
+++ b/Common/Data/VanillaItemData/BallOHurt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/BalloonHorseshoeFart.json
+++ b/Common/Data/VanillaItemData/BalloonHorseshoeFart.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BalloonHorseshoeHoney.json
+++ b/Common/Data/VanillaItemData/BalloonHorseshoeHoney.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BalloonHorseshoeSharkron.json
+++ b/Common/Data/VanillaItemData/BalloonHorseshoeSharkron.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BalloonPufferfish.json
+++ b/Common/Data/VanillaItemData/BalloonPufferfish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Bananarang.json
+++ b/Common/Data/VanillaItemData/Bananarang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/BandofRegeneration.json
+++ b/Common/Data/VanillaItemData/BandofRegeneration.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BandofStarpower.json
+++ b/Common/Data/VanillaItemData/BandofStarpower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BatBat.json
+++ b/Common/Data/VanillaItemData/BatBat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BatScepter.json
+++ b/Common/Data/VanillaItemData/BatScepter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/BatWings.json
+++ b/Common/Data/VanillaItemData/BatWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BeamSword.json
+++ b/Common/Data/VanillaItemData/BeamSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BeeBreastplate.json
+++ b/Common/Data/VanillaItemData/BeeBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/BeeCloak.json
+++ b/Common/Data/VanillaItemData/BeeCloak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BeeGreaves.json
+++ b/Common/Data/VanillaItemData/BeeGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/BeeGun.json
+++ b/Common/Data/VanillaItemData/BeeGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/BeeHeadgear.json
+++ b/Common/Data/VanillaItemData/BeeHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/BeeKeeper.json
+++ b/Common/Data/VanillaItemData/BeeKeeper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BeeWings.json
+++ b/Common/Data/VanillaItemData/BeeWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Beenade.json
+++ b/Common/Data/VanillaItemData/Beenade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BeesKnees.json
+++ b/Common/Data/VanillaItemData/BeesKnees.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BeetleHelmet.json
+++ b/Common/Data/VanillaItemData/BeetleHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/BeetleLeggings.json
+++ b/Common/Data/VanillaItemData/BeetleLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/BeetleScaleMail.json
+++ b/Common/Data/VanillaItemData/BeetleScaleMail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/BeetleShell.json
+++ b/Common/Data/VanillaItemData/BeetleShell.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/BeetleWings.json
+++ b/Common/Data/VanillaItemData/BeetleWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BejeweledValkyrieWing.json
+++ b/Common/Data/VanillaItemData/BejeweledValkyrieWing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BerserkerGlove.json
+++ b/Common/Data/VanillaItemData/BerserkerGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BetsyWings.json
+++ b/Common/Data/VanillaItemData/BetsyWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Bezoar.json
+++ b/Common/Data/VanillaItemData/Bezoar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlackBelt.json
+++ b/Common/Data/VanillaItemData/BlackBelt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlackCounterweight.json
+++ b/Common/Data/VanillaItemData/BlackCounterweight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlackString.json
+++ b/Common/Data/VanillaItemData/BlackString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BladedGlove.json
+++ b/Common/Data/VanillaItemData/BladedGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BladeofGrass.json
+++ b/Common/Data/VanillaItemData/BladeofGrass.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Bladetongue.json
+++ b/Common/Data/VanillaItemData/Bladetongue.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BlandWhip.json
+++ b/Common/Data/VanillaItemData/BlandWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/Blindfold.json
+++ b/Common/Data/VanillaItemData/Blindfold.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlizzardStaff.json
+++ b/Common/Data/VanillaItemData/BlizzardStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/BlizzardinaBalloon.json
+++ b/Common/Data/VanillaItemData/BlizzardinaBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlizzardinaBottle.json
+++ b/Common/Data/VanillaItemData/BlizzardinaBottle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BloodButcherer.json
+++ b/Common/Data/VanillaItemData/BloodButcherer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BloodHamaxe.json
+++ b/Common/Data/VanillaItemData/BloodHamaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/BloodLustCluster.json
+++ b/Common/Data/VanillaItemData/BloodLustCluster.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/BloodMoonMonolith.json
+++ b/Common/Data/VanillaItemData/BloodMoonMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BloodRainBow.json
+++ b/Common/Data/VanillaItemData/BloodRainBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BloodyMachete.json
+++ b/Common/Data/VanillaItemData/BloodyMachete.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Blowgun.json
+++ b/Common/Data/VanillaItemData/Blowgun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Blowpipe.json
+++ b/Common/Data/VanillaItemData/Blowpipe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BlueCounterweight.json
+++ b/Common/Data/VanillaItemData/BlueCounterweight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlueFlare.json
+++ b/Common/Data/VanillaItemData/BlueFlare.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BlueHorseshoeBalloon.json
+++ b/Common/Data/VanillaItemData/BlueHorseshoeBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BlueMoon.json
+++ b/Common/Data/VanillaItemData/BlueMoon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/BluePhaseblade.json
+++ b/Common/Data/VanillaItemData/BluePhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BluePhasesaber.json
+++ b/Common/Data/VanillaItemData/BluePhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BlueString.json
+++ b/Common/Data/VanillaItemData/BlueString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Bone.json
+++ b/Common/Data/VanillaItemData/Bone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BoneArrow.json
+++ b/Common/Data/VanillaItemData/BoneArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/BoneDagger.json
+++ b/Common/Data/VanillaItemData/BoneDagger.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BoneGlove.json
+++ b/Common/Data/VanillaItemData/BoneGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BoneHelm.json
+++ b/Common/Data/VanillaItemData/BoneHelm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BoneJavelin.json
+++ b/Common/Data/VanillaItemData/BoneJavelin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BonePickaxe.json
+++ b/Common/Data/VanillaItemData/BonePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BoneSword.json
+++ b/Common/Data/VanillaItemData/BoneSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BoneWhip.json
+++ b/Common/Data/VanillaItemData/BoneWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/BoneWings.json
+++ b/Common/Data/VanillaItemData/BoneWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BookStaff.json
+++ b/Common/Data/VanillaItemData/BookStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/BookofSkulls.json
+++ b/Common/Data/VanillaItemData/BookofSkulls.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Boomstick.json
+++ b/Common/Data/VanillaItemData/Boomstick.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BorealWoodBow.json
+++ b/Common/Data/VanillaItemData/BorealWoodBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BorealWoodBreastplate.json
+++ b/Common/Data/VanillaItemData/BorealWoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/BorealWoodGreaves.json
+++ b/Common/Data/VanillaItemData/BorealWoodGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/BorealWoodHammer.json
+++ b/Common/Data/VanillaItemData/BorealWoodHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BorealWoodHelmet.json
+++ b/Common/Data/VanillaItemData/BorealWoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/BorealWoodSword.json
+++ b/Common/Data/VanillaItemData/BorealWoodSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BouncingShield.json
+++ b/Common/Data/VanillaItemData/BouncingShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/BouncyGrenade.json
+++ b/Common/Data/VanillaItemData/BouncyGrenade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/BrainOfConfusion.json
+++ b/Common/Data/VanillaItemData/BrainOfConfusion.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BreakerBlade.json
+++ b/Common/Data/VanillaItemData/BreakerBlade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BreathingReed.json
+++ b/Common/Data/VanillaItemData/BreathingReed.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/BrickLayer.json
+++ b/Common/Data/VanillaItemData/BrickLayer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BrownString.json
+++ b/Common/Data/VanillaItemData/BrownString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BubbleGun.json
+++ b/Common/Data/VanillaItemData/BubbleGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/BundleofBalloons.json
+++ b/Common/Data/VanillaItemData/BundleofBalloons.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/BunnyTail.json
+++ b/Common/Data/VanillaItemData/BunnyTail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ButchersChainsaw.json
+++ b/Common/Data/VanillaItemData/ButchersChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ButterflyWings.json
+++ b/Common/Data/VanillaItemData/ButterflyWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CactusBreastplate.json
+++ b/Common/Data/VanillaItemData/CactusBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/CactusHelmet.json
+++ b/Common/Data/VanillaItemData/CactusHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CactusLeggings.json
+++ b/Common/Data/VanillaItemData/CactusLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CactusPickaxe.json
+++ b/Common/Data/VanillaItemData/CactusPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CactusSword.json
+++ b/Common/Data/VanillaItemData/CactusSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CandyCaneSword.json
+++ b/Common/Data/VanillaItemData/CandyCaneSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CandyCorn.json
+++ b/Common/Data/VanillaItemData/CandyCorn.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CandyCornRifle.json
+++ b/Common/Data/VanillaItemData/CandyCornRifle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Cascade.json
+++ b/Common/Data/VanillaItemData/Cascade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Celeb2.json
+++ b/Common/Data/VanillaItemData/Celeb2.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CelestialCuffs.json
+++ b/Common/Data/VanillaItemData/CelestialCuffs.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CelestialEmblem.json
+++ b/Common/Data/VanillaItemData/CelestialEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CelestialMagnet.json
+++ b/Common/Data/VanillaItemData/CelestialMagnet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CelestialShell.json
+++ b/Common/Data/VanillaItemData/CelestialShell.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CelestialStone.json
+++ b/Common/Data/VanillaItemData/CelestialStone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CenxsWings.json
+++ b/Common/Data/VanillaItemData/CenxsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ChainGuillotines.json
+++ b/Common/Data/VanillaItemData/ChainGuillotines.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ChainGun.json
+++ b/Common/Data/VanillaItemData/ChainGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ChainKnife.json
+++ b/Common/Data/VanillaItemData/ChainKnife.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ChargedBlasterCannon.json
+++ b/Common/Data/VanillaItemData/ChargedBlasterCannon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/CharmofMyths.json
+++ b/Common/Data/VanillaItemData/CharmofMyths.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Chik.json
+++ b/Common/Data/VanillaItemData/Chik.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteArrow.json
+++ b/Common/Data/VanillaItemData/ChlorophyteArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteBullet.json
+++ b/Common/Data/VanillaItemData/ChlorophyteBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteChainsaw.json
+++ b/Common/Data/VanillaItemData/ChlorophyteChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteClaymore.json
+++ b/Common/Data/VanillaItemData/ChlorophyteClaymore.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteDrill.json
+++ b/Common/Data/VanillaItemData/ChlorophyteDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteGreataxe.json
+++ b/Common/Data/VanillaItemData/ChlorophyteGreataxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteGreaves.json
+++ b/Common/Data/VanillaItemData/ChlorophyteGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteHeadgear.json
+++ b/Common/Data/VanillaItemData/ChlorophyteHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteHelmet.json
+++ b/Common/Data/VanillaItemData/ChlorophyteHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteJackhammer.json
+++ b/Common/Data/VanillaItemData/ChlorophyteJackhammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteMask.json
+++ b/Common/Data/VanillaItemData/ChlorophyteMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ChlorophytePartisan.json
+++ b/Common/Data/VanillaItemData/ChlorophytePartisan.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/ChlorophytePickaxe.json
+++ b/Common/Data/VanillaItemData/ChlorophytePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ChlorophytePlateMail.json
+++ b/Common/Data/VanillaItemData/ChlorophytePlateMail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteSaber.json
+++ b/Common/Data/VanillaItemData/ChlorophyteSaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteShotbow.json
+++ b/Common/Data/VanillaItemData/ChlorophyteShotbow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ChlorophyteWarhammer.json
+++ b/Common/Data/VanillaItemData/ChlorophyteWarhammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ChristmasTreeSword.json
+++ b/Common/Data/VanillaItemData/ChristmasTreeSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ClimbingClaws.json
+++ b/Common/Data/VanillaItemData/ClimbingClaws.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ClingerStaff.json
+++ b/Common/Data/VanillaItemData/ClingerStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ClockworkAssaultRifle.json
+++ b/Common/Data/VanillaItemData/ClockworkAssaultRifle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ClothierVoodooDoll.json
+++ b/Common/Data/VanillaItemData/ClothierVoodooDoll.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CloudinaBalloon.json
+++ b/Common/Data/VanillaItemData/CloudinaBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CloudinaBottle.json
+++ b/Common/Data/VanillaItemData/CloudinaBottle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ClusterRocketI.json
+++ b/Common/Data/VanillaItemData/ClusterRocketI.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/ClusterRocketII.json
+++ b/Common/Data/VanillaItemData/ClusterRocketII.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/CnadyCanePickaxe.json
+++ b/Common/Data/VanillaItemData/CnadyCanePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CobaltBreastplate.json
+++ b/Common/Data/VanillaItemData/CobaltBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/CobaltChainsaw.json
+++ b/Common/Data/VanillaItemData/CobaltChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/CobaltDrill.json
+++ b/Common/Data/VanillaItemData/CobaltDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/CobaltHat.json
+++ b/Common/Data/VanillaItemData/CobaltHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CobaltHelmet.json
+++ b/Common/Data/VanillaItemData/CobaltHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CobaltLeggings.json
+++ b/Common/Data/VanillaItemData/CobaltLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CobaltMask.json
+++ b/Common/Data/VanillaItemData/CobaltMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CobaltNaginata.json
+++ b/Common/Data/VanillaItemData/CobaltNaginata.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/CobaltPickaxe.json
+++ b/Common/Data/VanillaItemData/CobaltPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CobaltRepeater.json
+++ b/Common/Data/VanillaItemData/CobaltRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CobaltShield.json
+++ b/Common/Data/VanillaItemData/CobaltShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CobaltSword.json
+++ b/Common/Data/VanillaItemData/CobaltSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CobaltWaraxe.json
+++ b/Common/Data/VanillaItemData/CobaltWaraxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/Code1.json
+++ b/Common/Data/VanillaItemData/Code1.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Code2.json
+++ b/Common/Data/VanillaItemData/Code2.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/CoinRing.json
+++ b/Common/Data/VanillaItemData/CoinRing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CombatWrench.json
+++ b/Common/Data/VanillaItemData/CombatWrench.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Compass.json
+++ b/Common/Data/VanillaItemData/Compass.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CoolWhip.json
+++ b/Common/Data/VanillaItemData/CoolWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/CopperAxe.json
+++ b/Common/Data/VanillaItemData/CopperAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/CopperBow.json
+++ b/Common/Data/VanillaItemData/CopperBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CopperBroadsword.json
+++ b/Common/Data/VanillaItemData/CopperBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CopperChainmail.json
+++ b/Common/Data/VanillaItemData/CopperChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/CopperCoin.json
+++ b/Common/Data/VanillaItemData/CopperCoin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CopperGreaves.json
+++ b/Common/Data/VanillaItemData/CopperGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CopperHammer.json
+++ b/Common/Data/VanillaItemData/CopperHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CopperHelmet.json
+++ b/Common/Data/VanillaItemData/CopperHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CopperPickaxe.json
+++ b/Common/Data/VanillaItemData/CopperPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CopperShortsword.json
+++ b/Common/Data/VanillaItemData/CopperShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CopperWatch.json
+++ b/Common/Data/VanillaItemData/CopperWatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CordageGuide.json
+++ b/Common/Data/VanillaItemData/CordageGuide.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CorruptYoyo.json
+++ b/Common/Data/VanillaItemData/CorruptYoyo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/CountercurseMantra.json
+++ b/Common/Data/VanillaItemData/CountercurseMantra.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CreativeWings.json
+++ b/Common/Data/VanillaItemData/CreativeWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CrimsonCloak.json
+++ b/Common/Data/VanillaItemData/CrimsonCloak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CrimsonGreaves.json
+++ b/Common/Data/VanillaItemData/CrimsonGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CrimsonHelmet.json
+++ b/Common/Data/VanillaItemData/CrimsonHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CrimsonRod.json
+++ b/Common/Data/VanillaItemData/CrimsonRod.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/CrimsonScalemail.json
+++ b/Common/Data/VanillaItemData/CrimsonScalemail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/CrimsonYoyo.json
+++ b/Common/Data/VanillaItemData/CrimsonYoyo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/CritterShampoo.json
+++ b/Common/Data/VanillaItemData/CritterShampoo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CrossNecklace.json
+++ b/Common/Data/VanillaItemData/CrossNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CrownosWings.json
+++ b/Common/Data/VanillaItemData/CrownosWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/CrystalBullet.json
+++ b/Common/Data/VanillaItemData/CrystalBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/CrystalDart.json
+++ b/Common/Data/VanillaItemData/CrystalDart.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CrystalNinjaChestplate.json
+++ b/Common/Data/VanillaItemData/CrystalNinjaChestplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/CrystalNinjaHelmet.json
+++ b/Common/Data/VanillaItemData/CrystalNinjaHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CrystalNinjaLeggings.json
+++ b/Common/Data/VanillaItemData/CrystalNinjaLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/CrystalSerpent.json
+++ b/Common/Data/VanillaItemData/CrystalSerpent.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/CrystalStorm.json
+++ b/Common/Data/VanillaItemData/CrystalStorm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/CrystalVileShard.json
+++ b/Common/Data/VanillaItemData/CrystalVileShard.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/CursedArrow.json
+++ b/Common/Data/VanillaItemData/CursedArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/CursedBullet.json
+++ b/Common/Data/VanillaItemData/CursedBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/CursedDart.json
+++ b/Common/Data/VanillaItemData/CursedDart.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/CursedFlames.json
+++ b/Common/Data/VanillaItemData/CursedFlames.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/CursedFlare.json
+++ b/Common/Data/VanillaItemData/CursedFlare.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Cutlass.json
+++ b/Common/Data/VanillaItemData/Cutlass.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/CyanString.json
+++ b/Common/Data/VanillaItemData/CyanString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DD2BallistraTowerT1Popper.json
+++ b/Common/Data/VanillaItemData/DD2BallistraTowerT1Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2BallistraTowerT2Popper.json
+++ b/Common/Data/VanillaItemData/DD2BallistraTowerT2Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2BallistraTowerT3Popper.json
+++ b/Common/Data/VanillaItemData/DD2BallistraTowerT3Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2BetsyBow.json
+++ b/Common/Data/VanillaItemData/DD2BetsyBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/DD2ExplosiveTrapT1Popper.json
+++ b/Common/Data/VanillaItemData/DD2ExplosiveTrapT1Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2ExplosiveTrapT2Popper.json
+++ b/Common/Data/VanillaItemData/DD2ExplosiveTrapT2Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2ExplosiveTrapT3Popper.json
+++ b/Common/Data/VanillaItemData/DD2ExplosiveTrapT3Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2FlameburstTowerT1Popper.json
+++ b/Common/Data/VanillaItemData/DD2FlameburstTowerT1Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2FlameburstTowerT2Popper.json
+++ b/Common/Data/VanillaItemData/DD2FlameburstTowerT2Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2FlameburstTowerT3Popper.json
+++ b/Common/Data/VanillaItemData/DD2FlameburstTowerT3Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2LightningAuraT1Popper.json
+++ b/Common/Data/VanillaItemData/DD2LightningAuraT1Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2LightningAuraT2Popper.json
+++ b/Common/Data/VanillaItemData/DD2LightningAuraT2Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2LightningAuraT3Popper.json
+++ b/Common/Data/VanillaItemData/DD2LightningAuraT3Popper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DD2PhoenixBow.json
+++ b/Common/Data/VanillaItemData/DD2PhoenixBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/DD2SquireBetsySword.json
+++ b/Common/Data/VanillaItemData/DD2SquireBetsySword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/DD2SquireDemonSword.json
+++ b/Common/Data/VanillaItemData/DD2SquireDemonSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/DPSMeter.json
+++ b/Common/Data/VanillaItemData/DPSMeter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DTownsWings.json
+++ b/Common/Data/VanillaItemData/DTownsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DaedalusStormbow.json
+++ b/Common/Data/VanillaItemData/DaedalusStormbow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/DaoofPow.json
+++ b/Common/Data/VanillaItemData/DaoofPow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/DarkLance.json
+++ b/Common/Data/VanillaItemData/DarkLance.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/DartPistol.json
+++ b/Common/Data/VanillaItemData/DartPistol.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/DartRifle.json
+++ b/Common/Data/VanillaItemData/DartRifle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/DayBreak.json
+++ b/Common/Data/VanillaItemData/DayBreak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/DeadlySphereStaff.json
+++ b/Common/Data/VanillaItemData/DeadlySphereStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/DeathSickle.json
+++ b/Common/Data/VanillaItemData/DeathSickle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/DeathbringerPickaxe.json
+++ b/Common/Data/VanillaItemData/DeathbringerPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/DemonBow.json
+++ b/Common/Data/VanillaItemData/DemonBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/DemonScythe.json
+++ b/Common/Data/VanillaItemData/DemonScythe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/DemonWings.json
+++ b/Common/Data/VanillaItemData/DemonWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DepthMeter.json
+++ b/Common/Data/VanillaItemData/DepthMeter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DestroyerEmblem.json
+++ b/Common/Data/VanillaItemData/DestroyerEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DiamondRing.json
+++ b/Common/Data/VanillaItemData/DiamondRing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DiamondRobe.json
+++ b/Common/Data/VanillaItemData/DiamondRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/DiamondStaff.json
+++ b/Common/Data/VanillaItemData/DiamondStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/DiscountCard.json
+++ b/Common/Data/VanillaItemData/DiscountCard.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DivingGear.json
+++ b/Common/Data/VanillaItemData/DivingGear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DivingHelmet.json
+++ b/Common/Data/VanillaItemData/DivingHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/DogTail.json
+++ b/Common/Data/VanillaItemData/DogTail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/DontStarveShaderItem.json
+++ b/Common/Data/VanillaItemData/DontStarveShaderItem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Drax.json
+++ b/Common/Data/VanillaItemData/Drax.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/DripplerFlail.json
+++ b/Common/Data/VanillaItemData/DripplerFlail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/DryRocket.json
+++ b/Common/Data/VanillaItemData/DryRocket.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/DyeTradersScimitar.json
+++ b/Common/Data/VanillaItemData/DyeTradersScimitar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/EbonwoodBow.json
+++ b/Common/Data/VanillaItemData/EbonwoodBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/EbonwoodBreastplate.json
+++ b/Common/Data/VanillaItemData/EbonwoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/EbonwoodGreaves.json
+++ b/Common/Data/VanillaItemData/EbonwoodGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/EbonwoodHammer.json
+++ b/Common/Data/VanillaItemData/EbonwoodHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/EbonwoodHelmet.json
+++ b/Common/Data/VanillaItemData/EbonwoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/EbonwoodSword.json
+++ b/Common/Data/VanillaItemData/EbonwoodSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/EchoMonolith.json
+++ b/Common/Data/VanillaItemData/EchoMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ElectrosphereLauncher.json
+++ b/Common/Data/VanillaItemData/ElectrosphereLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ElfMelter.json
+++ b/Common/Data/VanillaItemData/ElfMelter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/EmeraldRobe.json
+++ b/Common/Data/VanillaItemData/EmeraldRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/EmeraldStaff.json
+++ b/Common/Data/VanillaItemData/EmeraldStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/EmpressBlade.json
+++ b/Common/Data/VanillaItemData/EmpressBlade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/EmpressFlightBooster.json
+++ b/Common/Data/VanillaItemData/EmpressFlightBooster.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/EmptyBucket.json
+++ b/Common/Data/VanillaItemData/EmptyBucket.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/EnchantedBoomerang.json
+++ b/Common/Data/VanillaItemData/EnchantedBoomerang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/EnchantedSword.json
+++ b/Common/Data/VanillaItemData/EnchantedSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/EndlessMusketPouch.json
+++ b/Common/Data/VanillaItemData/EndlessMusketPouch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/EndlessQuiver.json
+++ b/Common/Data/VanillaItemData/EndlessQuiver.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/EoCShield.json
+++ b/Common/Data/VanillaItemData/EoCShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/EskimoCoat.json
+++ b/Common/Data/VanillaItemData/EskimoCoat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/EskimoHood.json
+++ b/Common/Data/VanillaItemData/EskimoHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/EskimoPants.json
+++ b/Common/Data/VanillaItemData/EskimoPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/Excalibur.json
+++ b/Common/Data/VanillaItemData/Excalibur.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ExplodingBullet.json
+++ b/Common/Data/VanillaItemData/ExplodingBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/ExplosiveJackOLantern.json
+++ b/Common/Data/VanillaItemData/ExplosiveJackOLantern.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ExtendoGrip.json
+++ b/Common/Data/VanillaItemData/ExtendoGrip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/EyeoftheGolem.json
+++ b/Common/Data/VanillaItemData/EyeoftheGolem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FairyBoots.json
+++ b/Common/Data/VanillaItemData/FairyBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FairyQueenMagicItem.json
+++ b/Common/Data/VanillaItemData/FairyQueenMagicItem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/FairyQueenRangedItem.json
+++ b/Common/Data/VanillaItemData/FairyQueenRangedItem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/FairyWings.json
+++ b/Common/Data/VanillaItemData/FairyWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FalconBlade.json
+++ b/Common/Data/VanillaItemData/FalconBlade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FartInABalloon.json
+++ b/Common/Data/VanillaItemData/FartInABalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FartinaJar.json
+++ b/Common/Data/VanillaItemData/FartinaJar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FastClock.json
+++ b/Common/Data/VanillaItemData/FastClock.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FeralClaws.json
+++ b/Common/Data/VanillaItemData/FeralClaws.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FestiveWings.json
+++ b/Common/Data/VanillaItemData/FestiveWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FetidBaghnakhs.json
+++ b/Common/Data/VanillaItemData/FetidBaghnakhs.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FieryGreatsword.json
+++ b/Common/Data/VanillaItemData/FieryGreatsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FinWings.json
+++ b/Common/Data/VanillaItemData/FinWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FireGauntlet.json
+++ b/Common/Data/VanillaItemData/FireGauntlet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FireWhip.json
+++ b/Common/Data/VanillaItemData/FireWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/FireworksLauncher.json
+++ b/Common/Data/VanillaItemData/FireworksLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/FirstFractal.json
+++ b/Common/Data/VanillaItemData/FirstFractal.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/FishFinder.json
+++ b/Common/Data/VanillaItemData/FishFinder.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishermansGuide.json
+++ b/Common/Data/VanillaItemData/FishermansGuide.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobber.json
+++ b/Common/Data/VanillaItemData/FishingBobber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingArgon.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingArgon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingKrypton.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingKrypton.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingLava.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingLava.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingRainbow.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingRainbow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingStar.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingStar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingViolet.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingViolet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishingBobberGlowingXenon.json
+++ b/Common/Data/VanillaItemData/FishingBobberGlowingXenon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FishronWings.json
+++ b/Common/Data/VanillaItemData/FishronWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Flairon.json
+++ b/Common/Data/VanillaItemData/Flairon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Flamarang.json
+++ b/Common/Data/VanillaItemData/Flamarang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/FlameWakerBoots.json
+++ b/Common/Data/VanillaItemData/FlameWakerBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FlameWings.json
+++ b/Common/Data/VanillaItemData/FlameWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Flamelash.json
+++ b/Common/Data/VanillaItemData/Flamelash.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Flamethrower.json
+++ b/Common/Data/VanillaItemData/Flamethrower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/FlamingArrow.json
+++ b/Common/Data/VanillaItemData/FlamingArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/FlamingMace.json
+++ b/Common/Data/VanillaItemData/FlamingMace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/Flare.json
+++ b/Common/Data/VanillaItemData/Flare.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/FleshGrinder.json
+++ b/Common/Data/VanillaItemData/FleshGrinder.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FleshKnuckles.json
+++ b/Common/Data/VanillaItemData/FleshKnuckles.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FlintlockPistol.json
+++ b/Common/Data/VanillaItemData/FlintlockPistol.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/FlinxFurCoat.json
+++ b/Common/Data/VanillaItemData/FlinxFurCoat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/FlinxStaff.json
+++ b/Common/Data/VanillaItemData/FlinxStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/Flipper.json
+++ b/Common/Data/VanillaItemData/Flipper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FloatingTube.json
+++ b/Common/Data/VanillaItemData/FloatingTube.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FlowerBoots.json
+++ b/Common/Data/VanillaItemData/FlowerBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FlowerPow.json
+++ b/Common/Data/VanillaItemData/FlowerPow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/FlowerofFire.json
+++ b/Common/Data/VanillaItemData/FlowerofFire.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/FlowerofFrost.json
+++ b/Common/Data/VanillaItemData/FlowerofFrost.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/FlurryBoots.json
+++ b/Common/Data/VanillaItemData/FlurryBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FlyingCarpet.json
+++ b/Common/Data/VanillaItemData/FlyingCarpet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FlyingKnife.json
+++ b/Common/Data/VanillaItemData/FlyingKnife.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Flymeal.json
+++ b/Common/Data/VanillaItemData/Flymeal.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FoodBarbarianWings.json
+++ b/Common/Data/VanillaItemData/FoodBarbarianWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FormatC.json
+++ b/Common/Data/VanillaItemData/FormatC.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/FossilHelm.json
+++ b/Common/Data/VanillaItemData/FossilHelm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/FossilPants.json
+++ b/Common/Data/VanillaItemData/FossilPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/FossilPickaxe.json
+++ b/Common/Data/VanillaItemData/FossilPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FossilShirt.json
+++ b/Common/Data/VanillaItemData/FossilShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/FoxTail.json
+++ b/Common/Data/VanillaItemData/FoxTail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrogFlipper.json
+++ b/Common/Data/VanillaItemData/FrogFlipper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrogGear.json
+++ b/Common/Data/VanillaItemData/FrogGear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrogLeg.json
+++ b/Common/Data/VanillaItemData/FrogLeg.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrogWebbing.json
+++ b/Common/Data/VanillaItemData/FrogWebbing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrostBreastplate.json
+++ b/Common/Data/VanillaItemData/FrostBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/FrostDaggerfish.json
+++ b/Common/Data/VanillaItemData/FrostDaggerfish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/FrostHelmet.json
+++ b/Common/Data/VanillaItemData/FrostHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/FrostLeggings.json
+++ b/Common/Data/VanillaItemData/FrostLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/FrostStaff.json
+++ b/Common/Data/VanillaItemData/FrostStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Frostbrand.json
+++ b/Common/Data/VanillaItemData/Frostbrand.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/FrostburnArrow.json
+++ b/Common/Data/VanillaItemData/FrostburnArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/FrostsparkBoots.json
+++ b/Common/Data/VanillaItemData/FrostsparkBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrozenShield.json
+++ b/Common/Data/VanillaItemData/FrozenShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrozenTurtleShell.json
+++ b/Common/Data/VanillaItemData/FrozenTurtleShell.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FrozenWings.json
+++ b/Common/Data/VanillaItemData/FrozenWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/FruitcakeChakram.json
+++ b/Common/Data/VanillaItemData/FruitcakeChakram.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/GPS.json
+++ b/Common/Data/VanillaItemData/GPS.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Gatligator.json
+++ b/Common/Data/VanillaItemData/Gatligator.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/GhostWings.json
+++ b/Common/Data/VanillaItemData/GhostWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GhostarsWings.json
+++ b/Common/Data/VanillaItemData/GhostarsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Gi.json
+++ b/Common/Data/VanillaItemData/Gi.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/GingerBeard.json
+++ b/Common/Data/VanillaItemData/GingerBeard.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GladiatorBreastplate.json
+++ b/Common/Data/VanillaItemData/GladiatorBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/GladiatorHelmet.json
+++ b/Common/Data/VanillaItemData/GladiatorHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/GladiatorLeggings.json
+++ b/Common/Data/VanillaItemData/GladiatorLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/Gladius.json
+++ b/Common/Data/VanillaItemData/Gladius.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GlassSlipper.json
+++ b/Common/Data/VanillaItemData/GlassSlipper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GoblinTech.json
+++ b/Common/Data/VanillaItemData/GoblinTech.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Goggles.json
+++ b/Common/Data/VanillaItemData/Goggles.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/GoldAxe.json
+++ b/Common/Data/VanillaItemData/GoldAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/GoldBow.json
+++ b/Common/Data/VanillaItemData/GoldBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/GoldBroadsword.json
+++ b/Common/Data/VanillaItemData/GoldBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GoldChainmail.json
+++ b/Common/Data/VanillaItemData/GoldChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/GoldCoin.json
+++ b/Common/Data/VanillaItemData/GoldCoin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/GoldGreaves.json
+++ b/Common/Data/VanillaItemData/GoldGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/GoldHammer.json
+++ b/Common/Data/VanillaItemData/GoldHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GoldHelmet.json
+++ b/Common/Data/VanillaItemData/GoldHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/GoldPickaxe.json
+++ b/Common/Data/VanillaItemData/GoldPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GoldRing.json
+++ b/Common/Data/VanillaItemData/GoldRing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GoldShortsword.json
+++ b/Common/Data/VanillaItemData/GoldShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GoldWatch.json
+++ b/Common/Data/VanillaItemData/GoldWatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GoldenBullet.json
+++ b/Common/Data/VanillaItemData/GoldenBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/GoldenShower.json
+++ b/Common/Data/VanillaItemData/GoldenShower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/GolemFist.json
+++ b/Common/Data/VanillaItemData/GolemFist.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/GolfBall.json
+++ b/Common/Data/VanillaItemData/GolfBall.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedBlack.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedBlack.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedBlue.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedBlue.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedBrown.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedBrown.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedCyan.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedCyan.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedGreen.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedGreen.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedLimeGreen.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedLimeGreen.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedOrange.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedOrange.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedPink.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedPink.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedPurple.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedPurple.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedRed.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedRed.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedSkyBlue.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedSkyBlue.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedTeal.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedTeal.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedViolet.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedViolet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GolfBallDyedYellow.json
+++ b/Common/Data/VanillaItemData/GolfBallDyedYellow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Gradient.json
+++ b/Common/Data/VanillaItemData/Gradient.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/GravediggerShovel.json
+++ b/Common/Data/VanillaItemData/GravediggerShovel.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GravityGlobe.json
+++ b/Common/Data/VanillaItemData/GravityGlobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GreedyRing.json
+++ b/Common/Data/VanillaItemData/GreedyRing.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GreenCap.json
+++ b/Common/Data/VanillaItemData/GreenCap.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/GreenCounterweight.json
+++ b/Common/Data/VanillaItemData/GreenCounterweight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GreenPhaseblade.json
+++ b/Common/Data/VanillaItemData/GreenPhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GreenPhasesaber.json
+++ b/Common/Data/VanillaItemData/GreenPhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/GreenString.json
+++ b/Common/Data/VanillaItemData/GreenString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Grenade.json
+++ b/Common/Data/VanillaItemData/Grenade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/GrenadeLauncher.json
+++ b/Common/Data/VanillaItemData/GrenadeLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/GroxTheGreatWings.json
+++ b/Common/Data/VanillaItemData/GroxTheGreatWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/GuideVoodooDoll.json
+++ b/Common/Data/VanillaItemData/GuideVoodooDoll.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Gungnir.json
+++ b/Common/Data/VanillaItemData/Gungnir.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/GypsyRobe.json
+++ b/Common/Data/VanillaItemData/GypsyRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/HallowJoustingLance.json
+++ b/Common/Data/VanillaItemData/HallowJoustingLance.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/HallowedGreaves.json
+++ b/Common/Data/VanillaItemData/HallowedGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HallowedHeadgear.json
+++ b/Common/Data/VanillaItemData/HallowedHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HallowedHelmet.json
+++ b/Common/Data/VanillaItemData/HallowedHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HallowedHood.json
+++ b/Common/Data/VanillaItemData/HallowedHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HallowedMask.json
+++ b/Common/Data/VanillaItemData/HallowedMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HallowedPlateMail.json
+++ b/Common/Data/VanillaItemData/HallowedPlateMail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/HallowedRepeater.json
+++ b/Common/Data/VanillaItemData/HallowedRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/HamBat.json
+++ b/Common/Data/VanillaItemData/HamBat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Hammush.json
+++ b/Common/Data/VanillaItemData/Hammush.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/HandOfCreation.json
+++ b/Common/Data/VanillaItemData/HandOfCreation.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HandWarmer.json
+++ b/Common/Data/VanillaItemData/HandWarmer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Handgun.json
+++ b/Common/Data/VanillaItemData/Handgun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Harpoon.json
+++ b/Common/Data/VanillaItemData/Harpoon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/HarpyWings.json
+++ b/Common/Data/VanillaItemData/HarpyWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HeatRay.json
+++ b/Common/Data/VanillaItemData/HeatRay.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/HelFire.json
+++ b/Common/Data/VanillaItemData/HelFire.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/HellfireArrow.json
+++ b/Common/Data/VanillaItemData/HellfireArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/HellfireTreads.json
+++ b/Common/Data/VanillaItemData/HellfireTreads.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HellwingBow.json
+++ b/Common/Data/VanillaItemData/HellwingBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/HerculesBeetle.json
+++ b/Common/Data/VanillaItemData/HerculesBeetle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HermesBoots.json
+++ b/Common/Data/VanillaItemData/HermesBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HeroShield.json
+++ b/Common/Data/VanillaItemData/HeroShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HighTestFishingLine.json
+++ b/Common/Data/VanillaItemData/HighTestFishingLine.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HighVelocityBullet.json
+++ b/Common/Data/VanillaItemData/HighVelocityBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/HiveBackpack.json
+++ b/Common/Data/VanillaItemData/HiveBackpack.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HiveFive.json
+++ b/Common/Data/VanillaItemData/HiveFive.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/HolyArrow.json
+++ b/Common/Data/VanillaItemData/HolyArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/HoneyBalloon.json
+++ b/Common/Data/VanillaItemData/HoneyBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HoneyComb.json
+++ b/Common/Data/VanillaItemData/HoneyComb.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HoneyRocket.json
+++ b/Common/Data/VanillaItemData/HoneyRocket.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/HornetStaff.json
+++ b/Common/Data/VanillaItemData/HornetStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/HorseshoeBundle.json
+++ b/Common/Data/VanillaItemData/HorseshoeBundle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HoundiusShootius.json
+++ b/Common/Data/VanillaItemData/HoundiusShootius.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/Hoverboard.json
+++ b/Common/Data/VanillaItemData/Hoverboard.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HunterCloak.json
+++ b/Common/Data/VanillaItemData/HunterCloak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HuntressAltHead.json
+++ b/Common/Data/VanillaItemData/HuntressAltHead.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HuntressAltPants.json
+++ b/Common/Data/VanillaItemData/HuntressAltPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HuntressAltShirt.json
+++ b/Common/Data/VanillaItemData/HuntressAltShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/HuntressBuckler.json
+++ b/Common/Data/VanillaItemData/HuntressBuckler.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/HuntressJerkin.json
+++ b/Common/Data/VanillaItemData/HuntressJerkin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/HuntressPants.json
+++ b/Common/Data/VanillaItemData/HuntressPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/HuntressWig.json
+++ b/Common/Data/VanillaItemData/HuntressWig.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/IceBlade.json
+++ b/Common/Data/VanillaItemData/IceBlade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/IceBoomerang.json
+++ b/Common/Data/VanillaItemData/IceBoomerang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/IceBow.json
+++ b/Common/Data/VanillaItemData/IceBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/IceRod.json
+++ b/Common/Data/VanillaItemData/IceRod.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/IceSickle.json
+++ b/Common/Data/VanillaItemData/IceSickle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/IceSkates.json
+++ b/Common/Data/VanillaItemData/IceSkates.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/IchorArrow.json
+++ b/Common/Data/VanillaItemData/IchorArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/IchorBullet.json
+++ b/Common/Data/VanillaItemData/IchorBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/IchorDart.json
+++ b/Common/Data/VanillaItemData/IchorDart.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ImpStaff.json
+++ b/Common/Data/VanillaItemData/ImpStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/InfernoFork.json
+++ b/Common/Data/VanillaItemData/InfernoFork.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/InfluxWaver.json
+++ b/Common/Data/VanillaItemData/InfluxWaver.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/IronAxe.json
+++ b/Common/Data/VanillaItemData/IronAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/IronBow.json
+++ b/Common/Data/VanillaItemData/IronBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/IronBroadsword.json
+++ b/Common/Data/VanillaItemData/IronBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/IronChainmail.json
+++ b/Common/Data/VanillaItemData/IronChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/IronGreaves.json
+++ b/Common/Data/VanillaItemData/IronGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/IronHammer.json
+++ b/Common/Data/VanillaItemData/IronHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/IronHelmet.json
+++ b/Common/Data/VanillaItemData/IronHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/IronPickaxe.json
+++ b/Common/Data/VanillaItemData/IronPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/IronShortsword.json
+++ b/Common/Data/VanillaItemData/IronShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/JackOLanternLauncher.json
+++ b/Common/Data/VanillaItemData/JackOLanternLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Javelin.json
+++ b/Common/Data/VanillaItemData/Javelin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/JellyfishDivingGear.json
+++ b/Common/Data/VanillaItemData/JellyfishDivingGear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/JellyfishNecklace.json
+++ b/Common/Data/VanillaItemData/JellyfishNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/JestersArrow.json
+++ b/Common/Data/VanillaItemData/JestersArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/Jetpack.json
+++ b/Common/Data/VanillaItemData/Jetpack.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/JimsDroneVisor.json
+++ b/Common/Data/VanillaItemData/JimsDroneVisor.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/JimsWings.json
+++ b/Common/Data/VanillaItemData/JimsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/JoustingLance.json
+++ b/Common/Data/VanillaItemData/JoustingLance.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/JungleHat.json
+++ b/Common/Data/VanillaItemData/JungleHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/JunglePants.json
+++ b/Common/Data/VanillaItemData/JunglePants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/JungleRose.json
+++ b/Common/Data/VanillaItemData/JungleRose.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/JungleShirt.json
+++ b/Common/Data/VanillaItemData/JungleShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/JungleYoyo.json
+++ b/Common/Data/VanillaItemData/JungleYoyo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/KOCannon.json
+++ b/Common/Data/VanillaItemData/KOCannon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Katana.json
+++ b/Common/Data/VanillaItemData/Katana.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Keybrand.json
+++ b/Common/Data/VanillaItemData/Keybrand.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Kraken.json
+++ b/Common/Data/VanillaItemData/Kraken.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/LaserDrill.json
+++ b/Common/Data/VanillaItemData/LaserDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/LaserMachinegun.json
+++ b/Common/Data/VanillaItemData/LaserMachinegun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/LaserRifle.json
+++ b/Common/Data/VanillaItemData/LaserRifle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/LaserRuler.json
+++ b/Common/Data/VanillaItemData/LaserRuler.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LastPrism.json
+++ b/Common/Data/VanillaItemData/LastPrism.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/LavaCharm.json
+++ b/Common/Data/VanillaItemData/LavaCharm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LavaFishingHook.json
+++ b/Common/Data/VanillaItemData/LavaFishingHook.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LavaRocket.json
+++ b/Common/Data/VanillaItemData/LavaRocket.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/LavaSkull.json
+++ b/Common/Data/VanillaItemData/LavaSkull.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LavaWaders.json
+++ b/Common/Data/VanillaItemData/LavaWaders.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LavaproofTackleBag.json
+++ b/Common/Data/VanillaItemData/LavaproofTackleBag.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LeadAxe.json
+++ b/Common/Data/VanillaItemData/LeadAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/LeadBow.json
+++ b/Common/Data/VanillaItemData/LeadBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/LeadBroadsword.json
+++ b/Common/Data/VanillaItemData/LeadBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/LeadChainmail.json
+++ b/Common/Data/VanillaItemData/LeadChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/LeadGreaves.json
+++ b/Common/Data/VanillaItemData/LeadGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/LeadHammer.json
+++ b/Common/Data/VanillaItemData/LeadHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/LeadHelmet.json
+++ b/Common/Data/VanillaItemData/LeadHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/LeadPickaxe.json
+++ b/Common/Data/VanillaItemData/LeadPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/LeadShortsword.json
+++ b/Common/Data/VanillaItemData/LeadShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/LeafBlower.json
+++ b/Common/Data/VanillaItemData/LeafBlower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/LeafWings.json
+++ b/Common/Data/VanillaItemData/LeafWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LeinforsAccessory.json
+++ b/Common/Data/VanillaItemData/LeinforsAccessory.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LeinforsWings.json
+++ b/Common/Data/VanillaItemData/LeinforsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LifeformAnalyzer.json
+++ b/Common/Data/VanillaItemData/LifeformAnalyzer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LightDisc.json
+++ b/Common/Data/VanillaItemData/LightDisc.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/LightningBoots.json
+++ b/Common/Data/VanillaItemData/LightningBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LightsBane.json
+++ b/Common/Data/VanillaItemData/LightsBane.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/LimeString.json
+++ b/Common/Data/VanillaItemData/LimeString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LizardTail.json
+++ b/Common/Data/VanillaItemData/LizardTail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LokisWings.json
+++ b/Common/Data/VanillaItemData/LokisWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LongRainbowTrailWings.json
+++ b/Common/Data/VanillaItemData/LongRainbowTrailWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LuckyCoin.json
+++ b/Common/Data/VanillaItemData/LuckyCoin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LuckyHorseshoe.json
+++ b/Common/Data/VanillaItemData/LuckyHorseshoe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/LucyTheAxe.json
+++ b/Common/Data/VanillaItemData/LucyTheAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/LunarFlareBook.json
+++ b/Common/Data/VanillaItemData/LunarFlareBook.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/LunarHamaxeNebula.json
+++ b/Common/Data/VanillaItemData/LunarHamaxeNebula.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/LunarHamaxeSolar.json
+++ b/Common/Data/VanillaItemData/LunarHamaxeSolar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/LunarHamaxeStardust.json
+++ b/Common/Data/VanillaItemData/LunarHamaxeStardust.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/LunarHamaxeVortex.json
+++ b/Common/Data/VanillaItemData/LunarHamaxeVortex.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/Mace.json
+++ b/Common/Data/VanillaItemData/Mace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/MaceWhip.json
+++ b/Common/Data/VanillaItemData/MaceWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/MagicCuffs.json
+++ b/Common/Data/VanillaItemData/MagicCuffs.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MagicDagger.json
+++ b/Common/Data/VanillaItemData/MagicDagger.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/MagicHat.json
+++ b/Common/Data/VanillaItemData/MagicHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MagicMissile.json
+++ b/Common/Data/VanillaItemData/MagicMissile.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/MagicQuiver.json
+++ b/Common/Data/VanillaItemData/MagicQuiver.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MagicalHarp.json
+++ b/Common/Data/VanillaItemData/MagicalHarp.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Magiluminescence.json
+++ b/Common/Data/VanillaItemData/Magiluminescence.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MagmaStone.json
+++ b/Common/Data/VanillaItemData/MagmaStone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MagnetFlower.json
+++ b/Common/Data/VanillaItemData/MagnetFlower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MagnetSphere.json
+++ b/Common/Data/VanillaItemData/MagnetSphere.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ManaCloak.json
+++ b/Common/Data/VanillaItemData/ManaCloak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ManaFlower.json
+++ b/Common/Data/VanillaItemData/ManaFlower.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ManaRegenerationBand.json
+++ b/Common/Data/VanillaItemData/ManaRegenerationBand.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Marrow.json
+++ b/Common/Data/VanillaItemData/Marrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/MasterNinjaGear.json
+++ b/Common/Data/VanillaItemData/MasterNinjaGear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MechanicalGlove.json
+++ b/Common/Data/VanillaItemData/MechanicalGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MechanicalLens.json
+++ b/Common/Data/VanillaItemData/MechanicalLens.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MedicatedBandage.json
+++ b/Common/Data/VanillaItemData/MedicatedBandage.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MedusaHead.json
+++ b/Common/Data/VanillaItemData/MedusaHead.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Megaphone.json
+++ b/Common/Data/VanillaItemData/Megaphone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Megashark.json
+++ b/Common/Data/VanillaItemData/Megashark.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Meowmere.json
+++ b/Common/Data/VanillaItemData/Meowmere.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/MetalDetector.json
+++ b/Common/Data/VanillaItemData/MetalDetector.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MeteorHamaxe.json
+++ b/Common/Data/VanillaItemData/MeteorHamaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/MeteorHelmet.json
+++ b/Common/Data/VanillaItemData/MeteorHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MeteorLeggings.json
+++ b/Common/Data/VanillaItemData/MeteorLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MeteorShot.json
+++ b/Common/Data/VanillaItemData/MeteorShot.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/MeteorStaff.json
+++ b/Common/Data/VanillaItemData/MeteorStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/MeteorSuit.json
+++ b/Common/Data/VanillaItemData/MeteorSuit.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/MiniNukeI.json
+++ b/Common/Data/VanillaItemData/MiniNukeI.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/MiniNukeII.json
+++ b/Common/Data/VanillaItemData/MiniNukeII.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/MiningHelmet.json
+++ b/Common/Data/VanillaItemData/MiningHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MiningPants.json
+++ b/Common/Data/VanillaItemData/MiningPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MiningShirt.json
+++ b/Common/Data/VanillaItemData/MiningShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/Minishark.json
+++ b/Common/Data/VanillaItemData/Minishark.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/MolotovCocktail.json
+++ b/Common/Data/VanillaItemData/MolotovCocktail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/MoltenBreastplate.json
+++ b/Common/Data/VanillaItemData/MoltenBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/MoltenCharm.json
+++ b/Common/Data/VanillaItemData/MoltenCharm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MoltenFury.json
+++ b/Common/Data/VanillaItemData/MoltenFury.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/MoltenGreaves.json
+++ b/Common/Data/VanillaItemData/MoltenGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MoltenHamaxe.json
+++ b/Common/Data/VanillaItemData/MoltenHamaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/MoltenHelmet.json
+++ b/Common/Data/VanillaItemData/MoltenHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MoltenPickaxe.json
+++ b/Common/Data/VanillaItemData/MoltenPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/MoltenQuiver.json
+++ b/Common/Data/VanillaItemData/MoltenQuiver.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MoltenSkullRose.json
+++ b/Common/Data/VanillaItemData/MoltenSkullRose.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MonkAltHead.json
+++ b/Common/Data/VanillaItemData/MonkAltHead.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MonkAltPants.json
+++ b/Common/Data/VanillaItemData/MonkAltPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MonkAltShirt.json
+++ b/Common/Data/VanillaItemData/MonkAltShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/MonkBelt.json
+++ b/Common/Data/VanillaItemData/MonkBelt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MonkBrows.json
+++ b/Common/Data/VanillaItemData/MonkBrows.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MonkPants.json
+++ b/Common/Data/VanillaItemData/MonkPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MonkShirt.json
+++ b/Common/Data/VanillaItemData/MonkShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/MonkStaffT1.json
+++ b/Common/Data/VanillaItemData/MonkStaffT1.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/MonkStaffT2.json
+++ b/Common/Data/VanillaItemData/MonkStaffT2.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/MonkStaffT3.json
+++ b/Common/Data/VanillaItemData/MonkStaffT3.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/MoonCharm.json
+++ b/Common/Data/VanillaItemData/MoonCharm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MoonLordLegs.json
+++ b/Common/Data/VanillaItemData/MoonLordLegs.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MoonShell.json
+++ b/Common/Data/VanillaItemData/MoonShell.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MoonStone.json
+++ b/Common/Data/VanillaItemData/MoonStone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MoonlordArrow.json
+++ b/Common/Data/VanillaItemData/MoonlordArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/MoonlordBullet.json
+++ b/Common/Data/VanillaItemData/MoonlordBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/MoonlordTurretStaff.json
+++ b/Common/Data/VanillaItemData/MoonlordTurretStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/MothronWings.json
+++ b/Common/Data/VanillaItemData/MothronWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Muramasa.json
+++ b/Common/Data/VanillaItemData/Muramasa.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/MushroomSpear.json
+++ b/Common/Data/VanillaItemData/MushroomSpear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/MusicBox.json
+++ b/Common/Data/VanillaItemData/MusicBox.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxAltOverworldDay.json
+++ b/Common/Data/VanillaItemData/MusicBoxAltOverworldDay.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxAltUnderground.json
+++ b/Common/Data/VanillaItemData/MusicBoxAltUnderground.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxBoss1.json
+++ b/Common/Data/VanillaItemData/MusicBoxBoss1.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxBoss2.json
+++ b/Common/Data/VanillaItemData/MusicBoxBoss2.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxBoss3.json
+++ b/Common/Data/VanillaItemData/MusicBoxBoss3.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxBoss4.json
+++ b/Common/Data/VanillaItemData/MusicBoxBoss4.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxBoss5.json
+++ b/Common/Data/VanillaItemData/MusicBoxBoss5.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxConsoleTitle.json
+++ b/Common/Data/VanillaItemData/MusicBoxConsoleTitle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxCorruption.json
+++ b/Common/Data/VanillaItemData/MusicBoxCorruption.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxCredits.json
+++ b/Common/Data/VanillaItemData/MusicBoxCredits.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxCrimson.json
+++ b/Common/Data/VanillaItemData/MusicBoxCrimson.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxDD2.json
+++ b/Common/Data/VanillaItemData/MusicBoxDD2.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxDayRemix.json
+++ b/Common/Data/VanillaItemData/MusicBoxDayRemix.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxDeerclops.json
+++ b/Common/Data/VanillaItemData/MusicBoxDeerclops.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxDesert.json
+++ b/Common/Data/VanillaItemData/MusicBoxDesert.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxDukeFishron.json
+++ b/Common/Data/VanillaItemData/MusicBoxDukeFishron.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxDungeon.json
+++ b/Common/Data/VanillaItemData/MusicBoxDungeon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxEclipse.json
+++ b/Common/Data/VanillaItemData/MusicBoxEclipse.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxEerie.json
+++ b/Common/Data/VanillaItemData/MusicBoxEerie.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxEmpressOfLight.json
+++ b/Common/Data/VanillaItemData/MusicBoxEmpressOfLight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxFrostMoon.json
+++ b/Common/Data/VanillaItemData/MusicBoxFrostMoon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxGoblins.json
+++ b/Common/Data/VanillaItemData/MusicBoxGoblins.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxGraveyard.json
+++ b/Common/Data/VanillaItemData/MusicBoxGraveyard.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxHell.json
+++ b/Common/Data/VanillaItemData/MusicBoxHell.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxIce.json
+++ b/Common/Data/VanillaItemData/MusicBoxIce.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxJungle.json
+++ b/Common/Data/VanillaItemData/MusicBoxJungle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxJungleNight.json
+++ b/Common/Data/VanillaItemData/MusicBoxJungleNight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxLunarBoss.json
+++ b/Common/Data/VanillaItemData/MusicBoxLunarBoss.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxMartians.json
+++ b/Common/Data/VanillaItemData/MusicBoxMartians.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxMorningRain.json
+++ b/Common/Data/VanillaItemData/MusicBoxMorningRain.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxMushrooms.json
+++ b/Common/Data/VanillaItemData/MusicBoxMushrooms.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxNight.json
+++ b/Common/Data/VanillaItemData/MusicBoxNight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWBloodMoon.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWBloodMoon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWBoss1.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWBoss1.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWBoss2.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWBoss2.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWCorruption.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWCorruption.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWCrimson.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWCrimson.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWDay.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWDay.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWDesert.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWDesert.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWDungeon.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWDungeon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWHallow.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWHallow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWInvasion.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWInvasion.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWJungle.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWJungle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWMoonLord.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWMoonLord.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWMushroom.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWMushroom.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWNight.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWNight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWOcean.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWOcean.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWPlantera.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWPlantera.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWRain.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWRain.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWSnow.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWSnow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWSpace.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWSpace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWTowers.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWTowers.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWUnderground.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWUnderground.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWUndergroundCorruption.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWUndergroundCorruption.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWUndergroundCrimson.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWUndergroundCrimson.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWUndergroundHallow.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWUndergroundHallow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWUndergroundSnow.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWUndergroundSnow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWUnderworld.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWUnderworld.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOWWallOfFlesh.json
+++ b/Common/Data/VanillaItemData/MusicBoxOWWallOfFlesh.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOcean.json
+++ b/Common/Data/VanillaItemData/MusicBoxOcean.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOceanAlt.json
+++ b/Common/Data/VanillaItemData/MusicBoxOceanAlt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxOverworldDay.json
+++ b/Common/Data/VanillaItemData/MusicBoxOverworldDay.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxPirates.json
+++ b/Common/Data/VanillaItemData/MusicBoxPirates.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxPlantera.json
+++ b/Common/Data/VanillaItemData/MusicBoxPlantera.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxPumpkinMoon.json
+++ b/Common/Data/VanillaItemData/MusicBoxPumpkinMoon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxQueenSlime.json
+++ b/Common/Data/VanillaItemData/MusicBoxQueenSlime.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxRain.json
+++ b/Common/Data/VanillaItemData/MusicBoxRain.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxSandstorm.json
+++ b/Common/Data/VanillaItemData/MusicBoxSandstorm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxShimmer.json
+++ b/Common/Data/VanillaItemData/MusicBoxShimmer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxSlimeRain.json
+++ b/Common/Data/VanillaItemData/MusicBoxSlimeRain.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxSnow.json
+++ b/Common/Data/VanillaItemData/MusicBoxSnow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxSpace.json
+++ b/Common/Data/VanillaItemData/MusicBoxSpace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxSpaceAlt.json
+++ b/Common/Data/VanillaItemData/MusicBoxSpaceAlt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxStorm.json
+++ b/Common/Data/VanillaItemData/MusicBoxStorm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTemple.json
+++ b/Common/Data/VanillaItemData/MusicBoxTemple.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTheHallow.json
+++ b/Common/Data/VanillaItemData/MusicBoxTheHallow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTitle.json
+++ b/Common/Data/VanillaItemData/MusicBoxTitle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTitleAlt.json
+++ b/Common/Data/VanillaItemData/MusicBoxTitleAlt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTowers.json
+++ b/Common/Data/VanillaItemData/MusicBoxTowers.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTownDay.json
+++ b/Common/Data/VanillaItemData/MusicBoxTownDay.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxTownNight.json
+++ b/Common/Data/VanillaItemData/MusicBoxTownNight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxUnderground.json
+++ b/Common/Data/VanillaItemData/MusicBoxUnderground.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxUndergroundCorruption.json
+++ b/Common/Data/VanillaItemData/MusicBoxUndergroundCorruption.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxUndergroundCrimson.json
+++ b/Common/Data/VanillaItemData/MusicBoxUndergroundCrimson.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxUndergroundDesert.json
+++ b/Common/Data/VanillaItemData/MusicBoxUndergroundDesert.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxUndergroundHallow.json
+++ b/Common/Data/VanillaItemData/MusicBoxUndergroundHallow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxUndergroundJungle.json
+++ b/Common/Data/VanillaItemData/MusicBoxUndergroundJungle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MusicBoxWindyDay.json
+++ b/Common/Data/VanillaItemData/MusicBoxWindyDay.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Musket.json
+++ b/Common/Data/VanillaItemData/Musket.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/MusketBall.json
+++ b/Common/Data/VanillaItemData/MusketBall.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/MysteriousCape.json
+++ b/Common/Data/VanillaItemData/MysteriousCape.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/MythrilChainmail.json
+++ b/Common/Data/VanillaItemData/MythrilChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/MythrilChainsaw.json
+++ b/Common/Data/VanillaItemData/MythrilChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/MythrilDrill.json
+++ b/Common/Data/VanillaItemData/MythrilDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/MythrilGreaves.json
+++ b/Common/Data/VanillaItemData/MythrilGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MythrilHalberd.json
+++ b/Common/Data/VanillaItemData/MythrilHalberd.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/MythrilHat.json
+++ b/Common/Data/VanillaItemData/MythrilHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MythrilHelmet.json
+++ b/Common/Data/VanillaItemData/MythrilHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MythrilHood.json
+++ b/Common/Data/VanillaItemData/MythrilHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/MythrilPickaxe.json
+++ b/Common/Data/VanillaItemData/MythrilPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/MythrilRepeater.json
+++ b/Common/Data/VanillaItemData/MythrilRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/MythrilSword.json
+++ b/Common/Data/VanillaItemData/MythrilSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/MythrilWaraxe.json
+++ b/Common/Data/VanillaItemData/MythrilWaraxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/Nail.json
+++ b/Common/Data/VanillaItemData/Nail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/NailGun.json
+++ b/Common/Data/VanillaItemData/NailGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/NanoBullet.json
+++ b/Common/Data/VanillaItemData/NanoBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/NaturesGift.json
+++ b/Common/Data/VanillaItemData/NaturesGift.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Nazar.json
+++ b/Common/Data/VanillaItemData/Nazar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/NebulaArcanum.json
+++ b/Common/Data/VanillaItemData/NebulaArcanum.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/NebulaAxe.json
+++ b/Common/Data/VanillaItemData/NebulaAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/NebulaBlaze.json
+++ b/Common/Data/VanillaItemData/NebulaBlaze.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/NebulaBreastplate.json
+++ b/Common/Data/VanillaItemData/NebulaBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/NebulaChainsaw.json
+++ b/Common/Data/VanillaItemData/NebulaChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/NebulaDrill.json
+++ b/Common/Data/VanillaItemData/NebulaDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/NebulaHammer.json
+++ b/Common/Data/VanillaItemData/NebulaHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/NebulaHelmet.json
+++ b/Common/Data/VanillaItemData/NebulaHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NebulaLeggings.json
+++ b/Common/Data/VanillaItemData/NebulaLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NebulaMonolith.json
+++ b/Common/Data/VanillaItemData/NebulaMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/NebulaPickaxe.json
+++ b/Common/Data/VanillaItemData/NebulaPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/NecroBreastplate.json
+++ b/Common/Data/VanillaItemData/NecroBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/NecroGreaves.json
+++ b/Common/Data/VanillaItemData/NecroGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NecroHelmet.json
+++ b/Common/Data/VanillaItemData/NecroHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NecromanticScroll.json
+++ b/Common/Data/VanillaItemData/NecromanticScroll.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/NeptunesShell.json
+++ b/Common/Data/VanillaItemData/NeptunesShell.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/NettleBurst.json
+++ b/Common/Data/VanillaItemData/NettleBurst.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/NightVisionHelmet.json
+++ b/Common/Data/VanillaItemData/NightVisionHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NightmarePickaxe.json
+++ b/Common/Data/VanillaItemData/NightmarePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/NightsEdge.json
+++ b/Common/Data/VanillaItemData/NightsEdge.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/NimbusRod.json
+++ b/Common/Data/VanillaItemData/NimbusRod.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/NinjaHood.json
+++ b/Common/Data/VanillaItemData/NinjaHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NinjaPants.json
+++ b/Common/Data/VanillaItemData/NinjaPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/NinjaShirt.json
+++ b/Common/Data/VanillaItemData/NinjaShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/NorthPole.json
+++ b/Common/Data/VanillaItemData/NorthPole.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/ObsidianHelm.json
+++ b/Common/Data/VanillaItemData/ObsidianHelm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ObsidianHorseshoe.json
+++ b/Common/Data/VanillaItemData/ObsidianHorseshoe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ObsidianPants.json
+++ b/Common/Data/VanillaItemData/ObsidianPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ObsidianRose.json
+++ b/Common/Data/VanillaItemData/ObsidianRose.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ObsidianShield.json
+++ b/Common/Data/VanillaItemData/ObsidianShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ObsidianShirt.json
+++ b/Common/Data/VanillaItemData/ObsidianShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ObsidianSkull.json
+++ b/Common/Data/VanillaItemData/ObsidianSkull.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ObsidianSkullRose.json
+++ b/Common/Data/VanillaItemData/ObsidianSkullRose.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ObsidianSwordfish.json
+++ b/Common/Data/VanillaItemData/ObsidianSwordfish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/ObsidianWaterWalkingBoots.json
+++ b/Common/Data/VanillaItemData/ObsidianWaterWalkingBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/OnyxBlaster.json
+++ b/Common/Data/VanillaItemData/OnyxBlaster.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/OpticStaff.json
+++ b/Common/Data/VanillaItemData/OpticStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/OrangePhaseblade.json
+++ b/Common/Data/VanillaItemData/OrangePhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/OrangePhasesaber.json
+++ b/Common/Data/VanillaItemData/OrangePhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/OrangeString.json
+++ b/Common/Data/VanillaItemData/OrangeString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/OrichalcumBreastplate.json
+++ b/Common/Data/VanillaItemData/OrichalcumBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/OrichalcumChainsaw.json
+++ b/Common/Data/VanillaItemData/OrichalcumChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/OrichalcumDrill.json
+++ b/Common/Data/VanillaItemData/OrichalcumDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/OrichalcumHalberd.json
+++ b/Common/Data/VanillaItemData/OrichalcumHalberd.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/OrichalcumHeadgear.json
+++ b/Common/Data/VanillaItemData/OrichalcumHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/OrichalcumHelmet.json
+++ b/Common/Data/VanillaItemData/OrichalcumHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/OrichalcumLeggings.json
+++ b/Common/Data/VanillaItemData/OrichalcumLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/OrichalcumMask.json
+++ b/Common/Data/VanillaItemData/OrichalcumMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/OrichalcumPickaxe.json
+++ b/Common/Data/VanillaItemData/OrichalcumPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/OrichalcumRepeater.json
+++ b/Common/Data/VanillaItemData/OrichalcumRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/OrichalcumSword.json
+++ b/Common/Data/VanillaItemData/OrichalcumSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/OrichalcumWaraxe.json
+++ b/Common/Data/VanillaItemData/OrichalcumWaraxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/PDA.json
+++ b/Common/Data/VanillaItemData/PDA.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PaintSprayer.json
+++ b/Common/Data/VanillaItemData/PaintSprayer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PainterPaintballGun.json
+++ b/Common/Data/VanillaItemData/PainterPaintballGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PaladinsHammer.json
+++ b/Common/Data/VanillaItemData/PaladinsHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/PaladinsShield.json
+++ b/Common/Data/VanillaItemData/PaladinsShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PalladiumBreastplate.json
+++ b/Common/Data/VanillaItemData/PalladiumBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/PalladiumChainsaw.json
+++ b/Common/Data/VanillaItemData/PalladiumChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/PalladiumDrill.json
+++ b/Common/Data/VanillaItemData/PalladiumDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/PalladiumHeadgear.json
+++ b/Common/Data/VanillaItemData/PalladiumHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PalladiumHelmet.json
+++ b/Common/Data/VanillaItemData/PalladiumHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PalladiumLeggings.json
+++ b/Common/Data/VanillaItemData/PalladiumLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PalladiumMask.json
+++ b/Common/Data/VanillaItemData/PalladiumMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PalladiumPickaxe.json
+++ b/Common/Data/VanillaItemData/PalladiumPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PalladiumPike.json
+++ b/Common/Data/VanillaItemData/PalladiumPike.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/PalladiumRepeater.json
+++ b/Common/Data/VanillaItemData/PalladiumRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PalladiumSword.json
+++ b/Common/Data/VanillaItemData/PalladiumSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PalladiumWaraxe.json
+++ b/Common/Data/VanillaItemData/PalladiumWaraxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/PalmWoodBow.json
+++ b/Common/Data/VanillaItemData/PalmWoodBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PalmWoodBreastplate.json
+++ b/Common/Data/VanillaItemData/PalmWoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/PalmWoodGreaves.json
+++ b/Common/Data/VanillaItemData/PalmWoodGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PalmWoodHammer.json
+++ b/Common/Data/VanillaItemData/PalmWoodHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PalmWoodHelmet.json
+++ b/Common/Data/VanillaItemData/PalmWoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PalmWoodSword.json
+++ b/Common/Data/VanillaItemData/PalmWoodSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PanicNecklace.json
+++ b/Common/Data/VanillaItemData/PanicNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PaperAirplaneA.json
+++ b/Common/Data/VanillaItemData/PaperAirplaneA.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PaperAirplaneB.json
+++ b/Common/Data/VanillaItemData/PaperAirplaneB.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PapyrusScarab.json
+++ b/Common/Data/VanillaItemData/PapyrusScarab.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PartyBalloonAnimal.json
+++ b/Common/Data/VanillaItemData/PartyBalloonAnimal.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PartyBullet.json
+++ b/Common/Data/VanillaItemData/PartyBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/PartyBundleOfBalloonsAccessory.json
+++ b/Common/Data/VanillaItemData/PartyBundleOfBalloonsAccessory.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PartyGirlGrenade.json
+++ b/Common/Data/VanillaItemData/PartyGirlGrenade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PearlwoodBow.json
+++ b/Common/Data/VanillaItemData/PearlwoodBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PearlwoodBreastplate.json
+++ b/Common/Data/VanillaItemData/PearlwoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/PearlwoodGreaves.json
+++ b/Common/Data/VanillaItemData/PearlwoodGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PearlwoodHammer.json
+++ b/Common/Data/VanillaItemData/PearlwoodHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PearlwoodHelmet.json
+++ b/Common/Data/VanillaItemData/PearlwoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PearlwoodSword.json
+++ b/Common/Data/VanillaItemData/PearlwoodSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PewMaticHorn.json
+++ b/Common/Data/VanillaItemData/PewMaticHorn.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Phantasm.json
+++ b/Common/Data/VanillaItemData/Phantasm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PhilosophersStone.json
+++ b/Common/Data/VanillaItemData/PhilosophersStone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PhoenixBlaster.json
+++ b/Common/Data/VanillaItemData/PhoenixBlaster.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PickaxeAxe.json
+++ b/Common/Data/VanillaItemData/PickaxeAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/Picksaw.json
+++ b/Common/Data/VanillaItemData/Picksaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/PiercingStarlight.json
+++ b/Common/Data/VanillaItemData/PiercingStarlight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/PinkEskimoCoat.json
+++ b/Common/Data/VanillaItemData/PinkEskimoCoat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/PinkEskimoHood.json
+++ b/Common/Data/VanillaItemData/PinkEskimoHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PinkEskimoPants.json
+++ b/Common/Data/VanillaItemData/PinkEskimoPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PinkString.json
+++ b/Common/Data/VanillaItemData/PinkString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PiranhaGun.json
+++ b/Common/Data/VanillaItemData/PiranhaGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PirateStaff.json
+++ b/Common/Data/VanillaItemData/PirateStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/PlatinumAxe.json
+++ b/Common/Data/VanillaItemData/PlatinumAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/PlatinumBow.json
+++ b/Common/Data/VanillaItemData/PlatinumBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PlatinumBroadsword.json
+++ b/Common/Data/VanillaItemData/PlatinumBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PlatinumChainmail.json
+++ b/Common/Data/VanillaItemData/PlatinumChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/PlatinumCoin.json
+++ b/Common/Data/VanillaItemData/PlatinumCoin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PlatinumGreaves.json
+++ b/Common/Data/VanillaItemData/PlatinumGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PlatinumHammer.json
+++ b/Common/Data/VanillaItemData/PlatinumHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PlatinumHelmet.json
+++ b/Common/Data/VanillaItemData/PlatinumHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PlatinumPickaxe.json
+++ b/Common/Data/VanillaItemData/PlatinumPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PlatinumShortsword.json
+++ b/Common/Data/VanillaItemData/PlatinumShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PlatinumWatch.json
+++ b/Common/Data/VanillaItemData/PlatinumWatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PocketMirror.json
+++ b/Common/Data/VanillaItemData/PocketMirror.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PoisonDart.json
+++ b/Common/Data/VanillaItemData/PoisonDart.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PoisonStaff.json
+++ b/Common/Data/VanillaItemData/PoisonStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/PoisonedKnife.json
+++ b/Common/Data/VanillaItemData/PoisonedKnife.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PortableCementMixer.json
+++ b/Common/Data/VanillaItemData/PortableCementMixer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PortableStool.json
+++ b/Common/Data/VanillaItemData/PortableStool.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PossessedHatchet.json
+++ b/Common/Data/VanillaItemData/PossessedHatchet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/PowerGlove.json
+++ b/Common/Data/VanillaItemData/PowerGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PrinceCape.json
+++ b/Common/Data/VanillaItemData/PrinceCape.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PrincessWeapon.json
+++ b/Common/Data/VanillaItemData/PrincessWeapon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ProximityMineLauncher.json
+++ b/Common/Data/VanillaItemData/ProximityMineLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PsychoKnife.json
+++ b/Common/Data/VanillaItemData/PsychoKnife.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PulseBow.json
+++ b/Common/Data/VanillaItemData/PulseBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/PumpkinBreastplate.json
+++ b/Common/Data/VanillaItemData/PumpkinBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/PumpkinHelmet.json
+++ b/Common/Data/VanillaItemData/PumpkinHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PumpkinLeggings.json
+++ b/Common/Data/VanillaItemData/PumpkinLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/PurpleClubberfish.json
+++ b/Common/Data/VanillaItemData/PurpleClubberfish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PurpleCounterweight.json
+++ b/Common/Data/VanillaItemData/PurpleCounterweight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PurplePhaseblade.json
+++ b/Common/Data/VanillaItemData/PurplePhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PurplePhasesaber.json
+++ b/Common/Data/VanillaItemData/PurplePhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PurpleString.json
+++ b/Common/Data/VanillaItemData/PurpleString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PutridScent.json
+++ b/Common/Data/VanillaItemData/PutridScent.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Pwnhammer.json
+++ b/Common/Data/VanillaItemData/Pwnhammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/PygmyNecklace.json
+++ b/Common/Data/VanillaItemData/PygmyNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/PygmyStaff.json
+++ b/Common/Data/VanillaItemData/PygmyStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/QuadBarrelShotgun.json
+++ b/Common/Data/VanillaItemData/QuadBarrelShotgun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/QueenSpiderStaff.json
+++ b/Common/Data/VanillaItemData/QueenSpiderStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/REK.json
+++ b/Common/Data/VanillaItemData/REK.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Radar.json
+++ b/Common/Data/VanillaItemData/Radar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RainCoat.json
+++ b/Common/Data/VanillaItemData/RainCoat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/RainHat.json
+++ b/Common/Data/VanillaItemData/RainHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/RainbowCrystalStaff.json
+++ b/Common/Data/VanillaItemData/RainbowCrystalStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/RainbowCursor.json
+++ b/Common/Data/VanillaItemData/RainbowCursor.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RainbowFlare.json
+++ b/Common/Data/VanillaItemData/RainbowFlare.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/RainbowGun.json
+++ b/Common/Data/VanillaItemData/RainbowGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/RainbowRod.json
+++ b/Common/Data/VanillaItemData/RainbowRod.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/RainbowString.json
+++ b/Common/Data/VanillaItemData/RainbowString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RainbowWhip.json
+++ b/Common/Data/VanillaItemData/RainbowWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/RainbowWings.json
+++ b/Common/Data/VanillaItemData/RainbowWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Rally.json
+++ b/Common/Data/VanillaItemData/Rally.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/RangerEmblem.json
+++ b/Common/Data/VanillaItemData/RangerEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RavenStaff.json
+++ b/Common/Data/VanillaItemData/RavenStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/RazorbladeTyphoon.json
+++ b/Common/Data/VanillaItemData/RazorbladeTyphoon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Razorpine.json
+++ b/Common/Data/VanillaItemData/Razorpine.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ReaverShark.json
+++ b/Common/Data/VanillaItemData/ReaverShark.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ReconScope.json
+++ b/Common/Data/VanillaItemData/ReconScope.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RedCape.json
+++ b/Common/Data/VanillaItemData/RedCape.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RedCounterweight.json
+++ b/Common/Data/VanillaItemData/RedCounterweight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RedPhaseblade.json
+++ b/Common/Data/VanillaItemData/RedPhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/RedPhasesaber.json
+++ b/Common/Data/VanillaItemData/RedPhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/RedRyder.json
+++ b/Common/Data/VanillaItemData/RedRyder.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/RedString.json
+++ b/Common/Data/VanillaItemData/RedString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RedsWings.json
+++ b/Common/Data/VanillaItemData/RedsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RedsYoyo.json
+++ b/Common/Data/VanillaItemData/RedsYoyo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ReflectiveShades.json
+++ b/Common/Data/VanillaItemData/ReflectiveShades.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Revolver.json
+++ b/Common/Data/VanillaItemData/Revolver.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/RichMahoganyBow.json
+++ b/Common/Data/VanillaItemData/RichMahoganyBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/RichMahoganyBreastplate.json
+++ b/Common/Data/VanillaItemData/RichMahoganyBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/RichMahoganyGreaves.json
+++ b/Common/Data/VanillaItemData/RichMahoganyGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/RichMahoganyHammer.json
+++ b/Common/Data/VanillaItemData/RichMahoganyHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/RichMahoganyHelmet.json
+++ b/Common/Data/VanillaItemData/RichMahoganyHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/RichMahoganySword.json
+++ b/Common/Data/VanillaItemData/RichMahoganySword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/RifleScope.json
+++ b/Common/Data/VanillaItemData/RifleScope.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RocketBoots.json
+++ b/Common/Data/VanillaItemData/RocketBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RocketI.json
+++ b/Common/Data/VanillaItemData/RocketI.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/RocketII.json
+++ b/Common/Data/VanillaItemData/RocketII.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/RocketIII.json
+++ b/Common/Data/VanillaItemData/RocketIII.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/RocketIV.json
+++ b/Common/Data/VanillaItemData/RocketIV.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/RocketLauncher.json
+++ b/Common/Data/VanillaItemData/RocketLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Rockfish.json
+++ b/Common/Data/VanillaItemData/Rockfish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/RottenEgg.json
+++ b/Common/Data/VanillaItemData/RottenEgg.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/RoyalGel.json
+++ b/Common/Data/VanillaItemData/RoyalGel.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RoyalScepter.json
+++ b/Common/Data/VanillaItemData/RoyalScepter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/RubyRobe.json
+++ b/Common/Data/VanillaItemData/RubyRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/RubyStaff.json
+++ b/Common/Data/VanillaItemData/RubyStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Ruler.json
+++ b/Common/Data/VanillaItemData/Ruler.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SDMG.json
+++ b/Common/Data/VanillaItemData/SDMG.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SafemanWings.json
+++ b/Common/Data/VanillaItemData/SafemanWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SailfishBoots.json
+++ b/Common/Data/VanillaItemData/SailfishBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SandBoots.json
+++ b/Common/Data/VanillaItemData/SandBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Sandgun.json
+++ b/Common/Data/VanillaItemData/Sandgun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SandstorminaBalloon.json
+++ b/Common/Data/VanillaItemData/SandstorminaBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SandstorminaBottle.json
+++ b/Common/Data/VanillaItemData/SandstorminaBottle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SanguineStaff.json
+++ b/Common/Data/VanillaItemData/SanguineStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/SapphireRobe.json
+++ b/Common/Data/VanillaItemData/SapphireRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SapphireStaff.json
+++ b/Common/Data/VanillaItemData/SapphireStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SawtoothShark.json
+++ b/Common/Data/VanillaItemData/SawtoothShark.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ScourgeoftheCorruptor.json
+++ b/Common/Data/VanillaItemData/ScourgeoftheCorruptor.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ScytheWhip.json
+++ b/Common/Data/VanillaItemData/ScytheWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/Seed.json
+++ b/Common/Data/VanillaItemData/Seed.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Seedler.json
+++ b/Common/Data/VanillaItemData/Seedler.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Sextant.json
+++ b/Common/Data/VanillaItemData/Sextant.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Shackle.json
+++ b/Common/Data/VanillaItemData/Shackle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ShadewoodBow.json
+++ b/Common/Data/VanillaItemData/ShadewoodBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ShadewoodBreastplate.json
+++ b/Common/Data/VanillaItemData/ShadewoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ShadewoodGreaves.json
+++ b/Common/Data/VanillaItemData/ShadewoodGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShadewoodHammer.json
+++ b/Common/Data/VanillaItemData/ShadewoodHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ShadewoodHelmet.json
+++ b/Common/Data/VanillaItemData/ShadewoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShadewoodSword.json
+++ b/Common/Data/VanillaItemData/ShadewoodSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/ShadowFlameBow.json
+++ b/Common/Data/VanillaItemData/ShadowFlameBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ShadowFlameHexDoll.json
+++ b/Common/Data/VanillaItemData/ShadowFlameHexDoll.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ShadowFlameKnife.json
+++ b/Common/Data/VanillaItemData/ShadowFlameKnife.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ShadowGreaves.json
+++ b/Common/Data/VanillaItemData/ShadowGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShadowHelmet.json
+++ b/Common/Data/VanillaItemData/ShadowHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShadowJoustingLance.json
+++ b/Common/Data/VanillaItemData/ShadowJoustingLance.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/ShadowScalemail.json
+++ b/Common/Data/VanillaItemData/ShadowScalemail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ShadowbeamStaff.json
+++ b/Common/Data/VanillaItemData/ShadowbeamStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SharkToothNecklace.json
+++ b/Common/Data/VanillaItemData/SharkToothNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SharkronBalloon.json
+++ b/Common/Data/VanillaItemData/SharkronBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SharpTears.json
+++ b/Common/Data/VanillaItemData/SharpTears.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ShimmerArrow.json
+++ b/Common/Data/VanillaItemData/ShimmerArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/ShimmerCloak.json
+++ b/Common/Data/VanillaItemData/ShimmerCloak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ShimmerFlare.json
+++ b/Common/Data/VanillaItemData/ShimmerFlare.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ShimmerMonolith.json
+++ b/Common/Data/VanillaItemData/ShimmerMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ShinyRedBalloon.json
+++ b/Common/Data/VanillaItemData/ShinyRedBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ShinyStone.json
+++ b/Common/Data/VanillaItemData/ShinyStone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ShoeSpikes.json
+++ b/Common/Data/VanillaItemData/ShoeSpikes.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Shotgun.json
+++ b/Common/Data/VanillaItemData/Shotgun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Shroomerang.json
+++ b/Common/Data/VanillaItemData/Shroomerang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ShroomiteBreastplate.json
+++ b/Common/Data/VanillaItemData/ShroomiteBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/ShroomiteDiggingClaw.json
+++ b/Common/Data/VanillaItemData/ShroomiteDiggingClaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/ShroomiteHeadgear.json
+++ b/Common/Data/VanillaItemData/ShroomiteHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShroomiteHelmet.json
+++ b/Common/Data/VanillaItemData/ShroomiteHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShroomiteLeggings.json
+++ b/Common/Data/VanillaItemData/ShroomiteLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/ShroomiteMask.json
+++ b/Common/Data/VanillaItemData/ShroomiteMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/Shuriken.json
+++ b/Common/Data/VanillaItemData/Shuriken.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Sickle.json
+++ b/Common/Data/VanillaItemData/Sickle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SilverAxe.json
+++ b/Common/Data/VanillaItemData/SilverAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/SilverBow.json
+++ b/Common/Data/VanillaItemData/SilverBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SilverBroadsword.json
+++ b/Common/Data/VanillaItemData/SilverBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SilverBullet.json
+++ b/Common/Data/VanillaItemData/SilverBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/SilverChainmail.json
+++ b/Common/Data/VanillaItemData/SilverChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SilverCoin.json
+++ b/Common/Data/VanillaItemData/SilverCoin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SilverGreaves.json
+++ b/Common/Data/VanillaItemData/SilverGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SilverHammer.json
+++ b/Common/Data/VanillaItemData/SilverHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SilverHelmet.json
+++ b/Common/Data/VanillaItemData/SilverHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SilverPickaxe.json
+++ b/Common/Data/VanillaItemData/SilverPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SilverShortsword.json
+++ b/Common/Data/VanillaItemData/SilverShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SilverWatch.json
+++ b/Common/Data/VanillaItemData/SilverWatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SkeletonBow.json
+++ b/Common/Data/VanillaItemData/SkeletonBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SkiphsWings.json
+++ b/Common/Data/VanillaItemData/SkiphsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SkyBlueString.json
+++ b/Common/Data/VanillaItemData/SkyBlueString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SkyFracture.json
+++ b/Common/Data/VanillaItemData/SkyFracture.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SlapHand.json
+++ b/Common/Data/VanillaItemData/SlapHand.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SlimeStaff.json
+++ b/Common/Data/VanillaItemData/SlimeStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/Smolstar.json
+++ b/Common/Data/VanillaItemData/Smolstar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/SniperRifle.json
+++ b/Common/Data/VanillaItemData/SniperRifle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SniperScope.json
+++ b/Common/Data/VanillaItemData/SniperScope.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Snowball.json
+++ b/Common/Data/VanillaItemData/Snowball.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SnowballCannon.json
+++ b/Common/Data/VanillaItemData/SnowballCannon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SnowmanCannon.json
+++ b/Common/Data/VanillaItemData/SnowmanCannon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SolarEruption.json
+++ b/Common/Data/VanillaItemData/SolarEruption.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/SolarFlareAxe.json
+++ b/Common/Data/VanillaItemData/SolarFlareAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/SolarFlareBreastplate.json
+++ b/Common/Data/VanillaItemData/SolarFlareBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SolarFlareChainsaw.json
+++ b/Common/Data/VanillaItemData/SolarFlareChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/SolarFlareDrill.json
+++ b/Common/Data/VanillaItemData/SolarFlareDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/SolarFlareHammer.json
+++ b/Common/Data/VanillaItemData/SolarFlareHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SolarFlareHelmet.json
+++ b/Common/Data/VanillaItemData/SolarFlareHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SolarFlareLeggings.json
+++ b/Common/Data/VanillaItemData/SolarFlareLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SolarFlarePickaxe.json
+++ b/Common/Data/VanillaItemData/SolarFlarePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SolarMonolith.json
+++ b/Common/Data/VanillaItemData/SolarMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SorcererEmblem.json
+++ b/Common/Data/VanillaItemData/SorcererEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SoulDrain.json
+++ b/Common/Data/VanillaItemData/SoulDrain.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SpaceGun.json
+++ b/Common/Data/VanillaItemData/SpaceGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SparkleGuitar.json
+++ b/Common/Data/VanillaItemData/SparkleGuitar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Spear.json
+++ b/Common/Data/VanillaItemData/Spear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/SpectreBoots.json
+++ b/Common/Data/VanillaItemData/SpectreBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SpectreGoggles.json
+++ b/Common/Data/VanillaItemData/SpectreGoggles.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SpectreHamaxe.json
+++ b/Common/Data/VanillaItemData/SpectreHamaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/SpectreHood.json
+++ b/Common/Data/VanillaItemData/SpectreHood.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpectreMask.json
+++ b/Common/Data/VanillaItemData/SpectreMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpectrePants.json
+++ b/Common/Data/VanillaItemData/SpectrePants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpectrePickaxe.json
+++ b/Common/Data/VanillaItemData/SpectrePickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SpectreRobe.json
+++ b/Common/Data/VanillaItemData/SpectreRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SpectreStaff.json
+++ b/Common/Data/VanillaItemData/SpectreStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SpelunkerFlare.json
+++ b/Common/Data/VanillaItemData/SpelunkerFlare.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SpiderBreastplate.json
+++ b/Common/Data/VanillaItemData/SpiderBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SpiderGreaves.json
+++ b/Common/Data/VanillaItemData/SpiderGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpiderMask.json
+++ b/Common/Data/VanillaItemData/SpiderMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpiderStaff.json
+++ b/Common/Data/VanillaItemData/SpiderStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/SpikyBall.json
+++ b/Common/Data/VanillaItemData/SpikyBall.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SpiritFlame.json
+++ b/Common/Data/VanillaItemData/SpiritFlame.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/SpookyBreastplate.json
+++ b/Common/Data/VanillaItemData/SpookyBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SpookyHelmet.json
+++ b/Common/Data/VanillaItemData/SpookyHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpookyLeggings.json
+++ b/Common/Data/VanillaItemData/SpookyLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SpookyWings.json
+++ b/Common/Data/VanillaItemData/SpookyWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SporeSac.json
+++ b/Common/Data/VanillaItemData/SporeSac.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SquireAltHead.json
+++ b/Common/Data/VanillaItemData/SquireAltHead.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SquireAltPants.json
+++ b/Common/Data/VanillaItemData/SquireAltPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SquireAltShirt.json
+++ b/Common/Data/VanillaItemData/SquireAltShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SquireGreatHelm.json
+++ b/Common/Data/VanillaItemData/SquireGreatHelm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SquireGreaves.json
+++ b/Common/Data/VanillaItemData/SquireGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/SquirePlating.json
+++ b/Common/Data/VanillaItemData/SquirePlating.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/SquireShield.json
+++ b/Common/Data/VanillaItemData/SquireShield.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StaffofEarth.json
+++ b/Common/Data/VanillaItemData/StaffofEarth.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/StaffofRegrowth.json
+++ b/Common/Data/VanillaItemData/StaffofRegrowth.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/StaffoftheFrostHydra.json
+++ b/Common/Data/VanillaItemData/StaffoftheFrostHydra.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/Stake.json
+++ b/Common/Data/VanillaItemData/Stake.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/StakeLauncher.json
+++ b/Common/Data/VanillaItemData/StakeLauncher.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/StalkersQuiver.json
+++ b/Common/Data/VanillaItemData/StalkersQuiver.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StarAnise.json
+++ b/Common/Data/VanillaItemData/StarAnise.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/StarCannon.json
+++ b/Common/Data/VanillaItemData/StarCannon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/StarCloak.json
+++ b/Common/Data/VanillaItemData/StarCloak.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StarVeil.json
+++ b/Common/Data/VanillaItemData/StarVeil.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StarWrath.json
+++ b/Common/Data/VanillaItemData/StarWrath.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/StardustAxe.json
+++ b/Common/Data/VanillaItemData/StardustAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/StardustBreastplate.json
+++ b/Common/Data/VanillaItemData/StardustBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/StardustCellStaff.json
+++ b/Common/Data/VanillaItemData/StardustCellStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/StardustChainsaw.json
+++ b/Common/Data/VanillaItemData/StardustChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/StardustDragonStaff.json
+++ b/Common/Data/VanillaItemData/StardustDragonStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/StardustDrill.json
+++ b/Common/Data/VanillaItemData/StardustDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/StardustHammer.json
+++ b/Common/Data/VanillaItemData/StardustHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/StardustHelmet.json
+++ b/Common/Data/VanillaItemData/StardustHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/StardustLeggings.json
+++ b/Common/Data/VanillaItemData/StardustLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/StardustMonolith.json
+++ b/Common/Data/VanillaItemData/StardustMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StardustPickaxe.json
+++ b/Common/Data/VanillaItemData/StardustPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Starfury.json
+++ b/Common/Data/VanillaItemData/Starfury.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/SteampunkWings.json
+++ b/Common/Data/VanillaItemData/SteampunkWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StickyGrenade.json
+++ b/Common/Data/VanillaItemData/StickyGrenade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/StingerNecklace.json
+++ b/Common/Data/VanillaItemData/StingerNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Stopwatch.json
+++ b/Common/Data/VanillaItemData/Stopwatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/StormTigerStaff.json
+++ b/Common/Data/VanillaItemData/StormTigerStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/StylistKilLaKillScissorsIWish.json
+++ b/Common/Data/VanillaItemData/StylistKilLaKillScissorsIWish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/Stynger.json
+++ b/Common/Data/VanillaItemData/Stynger.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/StyngerBolt.json
+++ b/Common/Data/VanillaItemData/StyngerBolt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SummonerEmblem.json
+++ b/Common/Data/VanillaItemData/SummonerEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SunStone.json
+++ b/Common/Data/VanillaItemData/SunStone.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Sunfury.json
+++ b/Common/Data/VanillaItemData/Sunfury.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/SuperStarCannon.json
+++ b/Common/Data/VanillaItemData/SuperStarCannon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/SweetheartNecklace.json
+++ b/Common/Data/VanillaItemData/SweetheartNecklace.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/SwordWhip.json
+++ b/Common/Data/VanillaItemData/SwordWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/Swordfish.json
+++ b/Common/Data/VanillaItemData/Swordfish.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/Tabi.json
+++ b/Common/Data/VanillaItemData/Tabi.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TackleBox.json
+++ b/Common/Data/VanillaItemData/TackleBox.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TacticalShotgun.json
+++ b/Common/Data/VanillaItemData/TacticalShotgun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TallyCounter.json
+++ b/Common/Data/VanillaItemData/TallyCounter.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TatteredFairyWings.json
+++ b/Common/Data/VanillaItemData/TatteredFairyWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TaxCollectorsStickOfDoom.json
+++ b/Common/Data/VanillaItemData/TaxCollectorsStickOfDoom.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TealString.json
+++ b/Common/Data/VanillaItemData/TealString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TempestStaff.json
+++ b/Common/Data/VanillaItemData/TempestStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/TendonBow.json
+++ b/Common/Data/VanillaItemData/TendonBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TentacleSpike.json
+++ b/Common/Data/VanillaItemData/TentacleSpike.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TerraBlade.json
+++ b/Common/Data/VanillaItemData/TerraBlade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Terragrim.json
+++ b/Common/Data/VanillaItemData/Terragrim.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Terrarian.json
+++ b/Common/Data/VanillaItemData/Terrarian.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TerrasparkBoots.json
+++ b/Common/Data/VanillaItemData/TerrasparkBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TheAxe.json
+++ b/Common/Data/VanillaItemData/TheAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/TheBreaker.json
+++ b/Common/Data/VanillaItemData/TheBreaker.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TheEyeOfCthulhu.json
+++ b/Common/Data/VanillaItemData/TheEyeOfCthulhu.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TheHorsemansBlade.json
+++ b/Common/Data/VanillaItemData/TheHorsemansBlade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TheMeatball.json
+++ b/Common/Data/VanillaItemData/TheMeatball.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "MeleeFlail"
+}

--- a/Common/Data/VanillaItemData/ThePlan.json
+++ b/Common/Data/VanillaItemData/ThePlan.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TheRottedFork.json
+++ b/Common/Data/VanillaItemData/TheRottedFork.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/TheUndertaker.json
+++ b/Common/Data/VanillaItemData/TheUndertaker.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ThornChakram.json
+++ b/Common/Data/VanillaItemData/ThornChakram.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ThornWhip.json
+++ b/Common/Data/VanillaItemData/ThornWhip.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Whip"
+}

--- a/Common/Data/VanillaItemData/ThrowingKnife.json
+++ b/Common/Data/VanillaItemData/ThrowingKnife.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ThunderSpear.json
+++ b/Common/Data/VanillaItemData/ThunderSpear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/ThunderStaff.json
+++ b/Common/Data/VanillaItemData/ThunderStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/TigerClimbingGear.json
+++ b/Common/Data/VanillaItemData/TigerClimbingGear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TikiMask.json
+++ b/Common/Data/VanillaItemData/TikiMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TikiPants.json
+++ b/Common/Data/VanillaItemData/TikiPants.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TikiShirt.json
+++ b/Common/Data/VanillaItemData/TikiShirt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/TinAxe.json
+++ b/Common/Data/VanillaItemData/TinAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/TinBow.json
+++ b/Common/Data/VanillaItemData/TinBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TinBroadsword.json
+++ b/Common/Data/VanillaItemData/TinBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TinChainmail.json
+++ b/Common/Data/VanillaItemData/TinChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/TinGreaves.json
+++ b/Common/Data/VanillaItemData/TinGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TinHammer.json
+++ b/Common/Data/VanillaItemData/TinHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TinHelmet.json
+++ b/Common/Data/VanillaItemData/TinHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TinPickaxe.json
+++ b/Common/Data/VanillaItemData/TinPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TinShortsword.json
+++ b/Common/Data/VanillaItemData/TinShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TinWatch.json
+++ b/Common/Data/VanillaItemData/TinWatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TitanGlove.json
+++ b/Common/Data/VanillaItemData/TitanGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TitaniumBreastplate.json
+++ b/Common/Data/VanillaItemData/TitaniumBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/TitaniumChainsaw.json
+++ b/Common/Data/VanillaItemData/TitaniumChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TitaniumDrill.json
+++ b/Common/Data/VanillaItemData/TitaniumDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TitaniumHeadgear.json
+++ b/Common/Data/VanillaItemData/TitaniumHeadgear.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TitaniumHelmet.json
+++ b/Common/Data/VanillaItemData/TitaniumHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TitaniumLeggings.json
+++ b/Common/Data/VanillaItemData/TitaniumLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TitaniumMask.json
+++ b/Common/Data/VanillaItemData/TitaniumMask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TitaniumPickaxe.json
+++ b/Common/Data/VanillaItemData/TitaniumPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TitaniumRepeater.json
+++ b/Common/Data/VanillaItemData/TitaniumRepeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TitaniumSword.json
+++ b/Common/Data/VanillaItemData/TitaniumSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TitaniumTrident.json
+++ b/Common/Data/VanillaItemData/TitaniumTrident.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/TitaniumWaraxe.json
+++ b/Common/Data/VanillaItemData/TitaniumWaraxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/Toolbelt.json
+++ b/Common/Data/VanillaItemData/Toolbelt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Toolbox.json
+++ b/Common/Data/VanillaItemData/Toolbox.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TopazRobe.json
+++ b/Common/Data/VanillaItemData/TopazRobe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/TopazStaff.json
+++ b/Common/Data/VanillaItemData/TopazStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ToxicFlask.json
+++ b/Common/Data/VanillaItemData/ToxicFlask.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Toxikarp.json
+++ b/Common/Data/VanillaItemData/Toxikarp.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TragicUmbrella.json
+++ b/Common/Data/VanillaItemData/TragicUmbrella.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TreasureMagnet.json
+++ b/Common/Data/VanillaItemData/TreasureMagnet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Trident.json
+++ b/Common/Data/VanillaItemData/Trident.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Spear"
+}

--- a/Common/Data/VanillaItemData/TrifoldMap.json
+++ b/Common/Data/VanillaItemData/TrifoldMap.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Trimarang.json
+++ b/Common/Data/VanillaItemData/Trimarang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TrueExcalibur.json
+++ b/Common/Data/VanillaItemData/TrueExcalibur.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/TrueNightsEdge.json
+++ b/Common/Data/VanillaItemData/TrueNightsEdge.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Tsunami.json
+++ b/Common/Data/VanillaItemData/Tsunami.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TsunamiInABottle.json
+++ b/Common/Data/VanillaItemData/TsunamiInABottle.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TungstenAxe.json
+++ b/Common/Data/VanillaItemData/TungstenAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/TungstenBow.json
+++ b/Common/Data/VanillaItemData/TungstenBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/TungstenBroadsword.json
+++ b/Common/Data/VanillaItemData/TungstenBroadsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TungstenBullet.json
+++ b/Common/Data/VanillaItemData/TungstenBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/TungstenChainmail.json
+++ b/Common/Data/VanillaItemData/TungstenChainmail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/TungstenGreaves.json
+++ b/Common/Data/VanillaItemData/TungstenGreaves.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TungstenHammer.json
+++ b/Common/Data/VanillaItemData/TungstenHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TungstenHelmet.json
+++ b/Common/Data/VanillaItemData/TungstenHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TungstenPickaxe.json
+++ b/Common/Data/VanillaItemData/TungstenPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TungstenShortsword.json
+++ b/Common/Data/VanillaItemData/TungstenShortsword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/TungstenWatch.json
+++ b/Common/Data/VanillaItemData/TungstenWatch.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/TurtleHelmet.json
+++ b/Common/Data/VanillaItemData/TurtleHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TurtleLeggings.json
+++ b/Common/Data/VanillaItemData/TurtleLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/TurtleScaleMail.json
+++ b/Common/Data/VanillaItemData/TurtleScaleMail.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/UltrabrightHelmet.json
+++ b/Common/Data/VanillaItemData/UltrabrightHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/Umbrella.json
+++ b/Common/Data/VanillaItemData/Umbrella.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/UnholyArrow.json
+++ b/Common/Data/VanillaItemData/UnholyArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/UnholyTrident.json
+++ b/Common/Data/VanillaItemData/UnholyTrident.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/UnicornHornHat.json
+++ b/Common/Data/VanillaItemData/UnicornHornHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Uzi.json
+++ b/Common/Data/VanillaItemData/Uzi.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/ValkyrieYoyo.json
+++ b/Common/Data/VanillaItemData/ValkyrieYoyo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/Valor.json
+++ b/Common/Data/VanillaItemData/Valor.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/VampireFrogStaff.json
+++ b/Common/Data/VanillaItemData/VampireFrogStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/VampireKnives.json
+++ b/Common/Data/VanillaItemData/VampireKnives.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/VenomArrow.json
+++ b/Common/Data/VanillaItemData/VenomArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/VenomBullet.json
+++ b/Common/Data/VanillaItemData/VenomBullet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Gun"
+}

--- a/Common/Data/VanillaItemData/VenomStaff.json
+++ b/Common/Data/VanillaItemData/VenomStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/VenusMagnum.json
+++ b/Common/Data/VanillaItemData/VenusMagnum.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/VikingHelmet.json
+++ b/Common/Data/VanillaItemData/VikingHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/Vilethorn.json
+++ b/Common/Data/VanillaItemData/Vilethorn.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/VioletString.json
+++ b/Common/Data/VanillaItemData/VioletString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Vitamins.json
+++ b/Common/Data/VanillaItemData/Vitamins.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/VoidMonolith.json
+++ b/Common/Data/VanillaItemData/VoidMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/VolatileGelatin.json
+++ b/Common/Data/VanillaItemData/VolatileGelatin.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/VortexAxe.json
+++ b/Common/Data/VanillaItemData/VortexAxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/VortexBeater.json
+++ b/Common/Data/VanillaItemData/VortexBeater.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/VortexBreastplate.json
+++ b/Common/Data/VanillaItemData/VortexBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/VortexChainsaw.json
+++ b/Common/Data/VanillaItemData/VortexChainsaw.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/VortexDrill.json
+++ b/Common/Data/VanillaItemData/VortexDrill.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/VortexHammer.json
+++ b/Common/Data/VanillaItemData/VortexHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/VortexHelmet.json
+++ b/Common/Data/VanillaItemData/VortexHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/VortexLeggings.json
+++ b/Common/Data/VanillaItemData/VortexLeggings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/VortexMonolith.json
+++ b/Common/Data/VanillaItemData/VortexMonolith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/VortexPickaxe.json
+++ b/Common/Data/VanillaItemData/VortexPickaxe.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/WaffleIron.json
+++ b/Common/Data/VanillaItemData/WaffleIron.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/WandofFrosting.json
+++ b/Common/Data/VanillaItemData/WandofFrosting.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/WandofSparking.json
+++ b/Common/Data/VanillaItemData/WandofSparking.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/WarAxeoftheNight.json
+++ b/Common/Data/VanillaItemData/WarAxeoftheNight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Battleaxe"
+}

--- a/Common/Data/VanillaItemData/WarriorEmblem.json
+++ b/Common/Data/VanillaItemData/WarriorEmblem.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WaspGun.json
+++ b/Common/Data/VanillaItemData/WaspGun.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/WaterBolt.json
+++ b/Common/Data/VanillaItemData/WaterBolt.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/WaterWalkingBoots.json
+++ b/Common/Data/VanillaItemData/WaterWalkingBoots.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WeatherPain.json
+++ b/Common/Data/VanillaItemData/WeatherPain.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/WeatherRadio.json
+++ b/Common/Data/VanillaItemData/WeatherRadio.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WetRocket.json
+++ b/Common/Data/VanillaItemData/WetRocket.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Launcher"
+}

--- a/Common/Data/VanillaItemData/WhiteHorseshoeBalloon.json
+++ b/Common/Data/VanillaItemData/WhiteHorseshoeBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WhitePhaseblade.json
+++ b/Common/Data/VanillaItemData/WhitePhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/WhitePhasesaber.json
+++ b/Common/Data/VanillaItemData/WhitePhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/WhiteString.json
+++ b/Common/Data/VanillaItemData/WhiteString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WillsWings.json
+++ b/Common/Data/VanillaItemData/WillsWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WilsonBeardLong.json
+++ b/Common/Data/VanillaItemData/WilsonBeardLong.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WilsonBeardMagnificent.json
+++ b/Common/Data/VanillaItemData/WilsonBeardMagnificent.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WilsonBeardShort.json
+++ b/Common/Data/VanillaItemData/WilsonBeardShort.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WingsNebula.json
+++ b/Common/Data/VanillaItemData/WingsNebula.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WingsSolar.json
+++ b/Common/Data/VanillaItemData/WingsSolar.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WingsStardust.json
+++ b/Common/Data/VanillaItemData/WingsStardust.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WingsVortex.json
+++ b/Common/Data/VanillaItemData/WingsVortex.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WinterCape.json
+++ b/Common/Data/VanillaItemData/WinterCape.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/WizardHat.json
+++ b/Common/Data/VanillaItemData/WizardHat.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/WoodBreastplate.json
+++ b/Common/Data/VanillaItemData/WoodBreastplate.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Chestplate"
+}

--- a/Common/Data/VanillaItemData/WoodHelmet.json
+++ b/Common/Data/VanillaItemData/WoodHelmet.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Helmet"
+}

--- a/Common/Data/VanillaItemData/WoodYoyo.json
+++ b/Common/Data/VanillaItemData/WoodYoyo.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/WoodenArrow.json
+++ b/Common/Data/VanillaItemData/WoodenArrow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Bow"
+}

--- a/Common/Data/VanillaItemData/WoodenBoomerang.json
+++ b/Common/Data/VanillaItemData/WoodenBoomerang.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/WoodenBow.json
+++ b/Common/Data/VanillaItemData/WoodenBow.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/WoodenHammer.json
+++ b/Common/Data/VanillaItemData/WoodenHammer.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/WoodenSword.json
+++ b/Common/Data/VanillaItemData/WoodenSword.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/WormScarf.json
+++ b/Common/Data/VanillaItemData/WormScarf.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/XenoStaff.json
+++ b/Common/Data/VanillaItemData/XenoStaff.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Summoner"
+}

--- a/Common/Data/VanillaItemData/Xenopopper.json
+++ b/Common/Data/VanillaItemData/Xenopopper.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Ranged"
+}

--- a/Common/Data/VanillaItemData/Yelets.json
+++ b/Common/Data/VanillaItemData/Yelets.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/YellowCounterweight.json
+++ b/Common/Data/VanillaItemData/YellowCounterweight.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/YellowHorseshoeBalloon.json
+++ b/Common/Data/VanillaItemData/YellowHorseshoeBalloon.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/YellowPhaseblade.json
+++ b/Common/Data/VanillaItemData/YellowPhaseblade.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/YellowPhasesaber.json
+++ b/Common/Data/VanillaItemData/YellowPhasesaber.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Common/Data/VanillaItemData/YellowString.json
+++ b/Common/Data/VanillaItemData/YellowString.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/YoYoGlove.json
+++ b/Common/Data/VanillaItemData/YoYoGlove.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Yoraiz0rDarkness.json
+++ b/Common/Data/VanillaItemData/Yoraiz0rDarkness.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/Yoraiz0rWings.json
+++ b/Common/Data/VanillaItemData/Yoraiz0rWings.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/YoyoBag.json
+++ b/Common/Data/VanillaItemData/YoyoBag.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Accessories"
+}

--- a/Common/Data/VanillaItemData/ZapinatorGray.json
+++ b/Common/Data/VanillaItemData/ZapinatorGray.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/ZapinatorOrange.json
+++ b/Common/Data/VanillaItemData/ZapinatorOrange.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Staff"
+}

--- a/Common/Data/VanillaItemData/Zenith.json
+++ b/Common/Data/VanillaItemData/Zenith.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Melee"
+}

--- a/Common/Data/VanillaItemData/ZombieArm.json
+++ b/Common/Data/VanillaItemData/ZombieArm.json
@@ -1,0 +1,3 @@
+{
+  "ItemType": "Sword"
+}

--- a/Core/Items/ItemDatabase.cs
+++ b/Core/Items/ItemDatabase.cs
@@ -1,6 +1,13 @@
-﻿using PathOfTerraria.Common.Enums;
+﻿using PathOfTerraria.Common.Data.Models;
+using PathOfTerraria.Common.Enums;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Unicode;
 using Terraria.ID;
 
 namespace PathOfTerraria.Core.Items;
@@ -44,6 +51,21 @@ public sealed class ItemDatabase : ModSystem
 	public override void PostSetupContent()
 	{
 		base.PostSetupContent();
+
+		for (int i = 0; i < ItemLoader.ItemCount; i++)
+		{
+			byte[] bytes = Mod.GetFileBytes("Common/Data/VanillaItemData/" + ItemID.Search.GetName(i) + ".json");
+
+			if (bytes is null)
+			{
+				continue;
+			}
+
+			string str = System.Text.Encoding.UTF8.GetString(bytes);
+			VanillaItemData data = JsonSerializer.Deserialize<VanillaItemData>(str);
+
+			RegisterVanillaItemAsGear(i, Enum.Parse<ItemType>(data.ItemType));
+		}
 
 		for (int i = 0; i < ItemLoader.ItemCount; i++)
 		{

--- a/Core/Items/VanillaItemDataExporter.cs
+++ b/Core/Items/VanillaItemDataExporter.cs
@@ -1,0 +1,113 @@
+﻿using PathOfTerraria.Common.Data.Models;
+using PathOfTerraria.Common.Enums;
+using System.IO;
+using System.Text.Json;
+using Terraria.ID;
+
+namespace PathOfTerraria.Core.Items;
+
+internal class VanillaItemDataExporter : ModSystem
+{
+	public override bool IsLoadingEnabled(Mod mod)
+	{
+		return false;
+	}
+
+	public override void SetStaticDefaults()
+	{
+		Directory.CreateDirectory("VanillaItemData");
+		var options = new JsonSerializerOptions() { IncludeFields = true, WriteIndented = true };
+
+		for (int i = 0; i < ItemID.Count; ++i)
+		{
+			Item item = new(i);
+			ItemType type = ItemType.None;
+
+			if (item.accessory && !item.vanity)
+			{
+				type = ItemType.Accessories;
+			}
+			else if (item.defense > 0 && !item.vanity)
+			{
+				if (item.headSlot > 0)
+				{
+					type = ItemType.Helmet;
+				}
+				else if (item.bodySlot > 0)
+				{
+					type = ItemType.Chestplate;
+				}
+				else if (item.legSlot > 0)
+				{
+					type = ItemType.Helmet;
+				}
+			}
+			else if (item.damage > 0)
+			{
+				if (item.CountsAsClass<MeleeDamageClass>())
+				{
+					if (!item.noMelee && item.axe > 0)
+					{
+						type = ItemType.Battleaxe;
+					}
+					else if (item.shoot > ProjectileID.None && ContentSamples.ProjectilesByType[item.shoot].aiStyle == ProjAIStyleID.Spear)
+					{
+						type = ItemType.Spear;
+					}
+					else if (item.shoot > ProjectileID.None && ContentSamples.ProjectilesByType[item.shoot].aiStyle == ProjAIStyleID.Flail)
+					{
+						type = ItemType.MeleeFlail;
+					}
+					else if (!item.noMelee || item.shoot > ProjectileID.None && ContentSamples.ProjectilesByType[item.shoot].aiStyle == ProjAIStyleID.ShortSword)
+					{
+						type = ItemType.Sword;
+					}
+					else
+					{
+						type = ItemType.Melee;
+					}
+				}
+				else if (item.CountsAsClass<RangedDamageClass>())
+				{
+					if (item.ammo == AmmoID.Bullet)
+					{
+						type = ItemType.Gun;
+					}
+					else if (item.ammo == AmmoID.Arrow)
+					{
+						type = ItemType.Bow;
+					}
+					else if (item.ammo == AmmoID.Rocket)
+					{
+						type = ItemType.Launcher;
+					}
+					else
+					{
+						type = ItemType.Ranged;
+					}
+				}
+				else if (item.CountsAsClass<MagicDamageClass>())
+				{
+					type = ItemType.Staff;
+				}
+				else if (item.CountsAsClass<SummonDamageClass>())
+				{
+					if (item.CountsAsClass<SummonMeleeSpeedDamageClass>() && item.shoot > ProjectileID.None)
+					{
+						type = ItemType.Whip;
+					}
+					else
+					{
+						type = ItemType.Summoner;
+					}
+				}
+			}
+
+			if (type != ItemType.None)
+			{
+				using FileStream stream = File.OpenWrite("VanillaItemData\\" + ItemID.Search.GetName(i) + ".json");
+				JsonSerializer.Serialize(stream, new VanillaItemData() { ItemType = type.ToString() }, options);
+			}
+		}
+	}
+}

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -607,7 +607,7 @@ CorruptShard: {
 	Tooltip:
 		'''
 		Chaotic and unstable
-		Has a chance to add in an additional affix and corrupt any item, disabling any future item interactions
+		Has a chance to add an additional affix and corrupt any item, disabling any future item interactions
 		Has a chance to reduce Uniques into Rare items of the same kind, rerolling them at the same level
 		Has a large chance to do nothing
 		'Pulses with malaise'
@@ -679,9 +679,9 @@ EchoingShard: {
 	DisplayName: Echoing Shard
 	Tooltip:
 		'''
-		  	Creates a clone of an item
-		  	Hold an item then right click this Shard to clone
-		  	'I can see myself!'
+		Creates a clone of an item
+		Hold an item then right click this Shard to clone
+		'I can see myself!'
 		'''
 }
 

--- a/PathOfTerraria.csproj
+++ b/PathOfTerraria.csproj
@@ -36,6 +36,9 @@
       <HintPath>lib\NPCUtils.dll</HintPath>
     </Reference>
 	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Common\Data\VanillaItemData\" />
+	</ItemGroup>
 	<Target Name="BuildMod" AfterTargets="Build">
 		<Exec Command="$(BuildCommand) $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)" />
 	</Target>


### PR DESCRIPTION
﻿### Link Issues
Resolves: #777 

### Description of Work
- Adds in data for all vanilla items to have an ItemType (and more in the future if desired)
- Added tool to export this data automatically

### Comments
The only actual changes are at the bottom of the PR. I do ask, though, if it would be better to have 1 file instead of about 1284. Either way works though, and load time isn't brutalized by this.