### PR TITLE
More misc qa fixes

### DIFF
--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -26,10 +26,11 @@ internal sealed class NewHotbar : SmartUiState
 	{
 		public override bool PreDraw(SpriteBatch spriteBatch, int type, int buffIndex, ref BuffDrawParams drawParams)
 		{
-			// TODO: Make constant when a good value is found.
-			int buffPositionOffsetY = 20;
-			drawParams.Position = new Vector2(drawParams.Position.X, drawParams.Position.Y + buffPositionOffsetY);
-			drawParams.MouseRectangle.Y += buffPositionOffsetY;
+			const int Offset = 24;
+
+			drawParams.Position = new Vector2(drawParams.Position.X, drawParams.Position.Y + Offset);
+			drawParams.MouseRectangle.Y += Offset;
+			drawParams.TextPosition.Y += Offset;
 			return true;
 		}
 	}

--- a/Common/UI/PlayerStats/PlayerStatUIState.cs
+++ b/Common/UI/PlayerStats/PlayerStatUIState.cs
@@ -13,6 +13,14 @@ internal class PlayerStatUIState : CloseableSmartUi
 
 	private PlayerStatInnerPanel statPanel = null;
 
+	public override void SafeUpdate(GameTime gameTime)
+	{
+		if (!Main.playerInventory)
+		{
+			Toggle();
+		}
+	}
+
 	public void Toggle()
 	{
 		if (IsVisible)

--- a/Common/UI/Quests/QuestsUIState.cs
+++ b/Common/UI/Quests/QuestsUIState.cs
@@ -21,7 +21,8 @@ public class QuestsUIState : CloseableSmartUi
 	protected override int LeftPadding => 0;
 	protected override int PanelWidth => 750;
 	protected override bool IsCentered => true;
-	
+	public override int DepthPriority => 3;
+
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{
 		return layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
@@ -35,7 +36,13 @@ public class QuestsUIState : CloseableSmartUi
 #endif
 	}
 
-	public override int DepthPriority => 3;
+	public override void SafeUpdate(GameTime gameTime)
+	{
+		if (!Main.playerInventory)
+		{
+			Toggle();
+		}
+	}
 
 	public void Toggle()
 	{

--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -37,6 +37,15 @@ internal class TreeState : TabsUiState
 		return layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
 	}
 
+	public override void SafeUpdate(GameTime gameTime)
+	{
+		if (Panel is not null)
+		{
+			Panel.Left = StyleDimension.FromPixels(ShrinkX);
+			Panel.Top = StyleDimension.FromPixels(ShrinkY);
+		}
+	}
+
 	public void Toggle()
 	{
 		if (IsVisible)
@@ -78,7 +87,6 @@ internal class TreeState : TabsUiState
 		Panel.Append(CloseButton);
 	}
 
-
 	private void ResetTree()
 	{
 		_passiveTreeInner.RemoveAllChildren();
@@ -108,15 +116,6 @@ internal class TreeState : TabsUiState
 			Main.isMouseLeftConsumedByUI = true;
 			Main.LocalPlayer.mouseInterface = true;
 			Main.mouseText = false;
-		}
-	}
-
-	public override void SafeUpdate(GameTime gameTime)
-	{
-		if (Panel is not null)
-		{
-			Panel.Left = StyleDimension.FromPixels(ShrinkX);
-			Panel.Top = StyleDimension.FromPixels(ShrinkY);
 		}
 	}
 
@@ -152,11 +151,8 @@ internal class TreeState : TabsUiState
 			{
 				if (Player.controlInv && Player.releaseInventory)
 				{
-					SmartUiLoader.GetUiState<TreeState>().DefaultClose();
+					SmartUiLoader.GetUiState<TreeState>().Toggle();
 				}
-
-				Player.controlInv = false;
-				Player.releaseInventory = false;
 			}
 		}
 	}

--- a/Content/Items/Gear/Weapons/Battleaxe/Battleaxe.cs
+++ b/Content/Items/Gear/Weapons/Battleaxe/Battleaxe.cs
@@ -34,6 +34,7 @@ internal abstract class Battleaxe : Gear
 		Item.knockBack = 8;
 		Item.crit = 12;
 		Item.UseSound = SoundID.Item1;
+		Item.useTurn = true;
 
 		PoTInstanceItemData data = this.GetInstanceData();
 		data.ItemType = ItemType.Battleaxe;

--- a/Content/Items/Gear/Weapons/Sword/Broadsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/Broadsword.cs
@@ -11,5 +11,6 @@ internal class Broadsword : Sword
 		Item.damage = 15;
 		Item.useTime = 60;
 		Item.useAnimation = 65;
+		Item.useTurn = true;
 	}
 }

--- a/Content/Items/Gear/Weapons/Sword/Sword.cs
+++ b/Content/Items/Gear/Weapons/Sword/Sword.cs
@@ -37,6 +37,7 @@ internal abstract class Sword : Gear
 		Item.crit = 6;
 		Item.UseSound = SoundID.Item1;
 		Item.shoot = ProjectileID.PurificationPowder;
+		Item.useTurn = true;
 		Item.shootSpeed = 10f;
 
 		PoTInstanceItemData data = this.GetInstanceData();

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -118,6 +118,7 @@ partial class PoTGlobalItem
 		var oldStats = tooltips.Where(x => x.Name.StartsWith("Stat")).ToList();
 		TooltipLine setBonusLine = tooltips.FirstOrDefault(x => x.Name == "SetBonus");
 		TooltipLine nameLine = tooltips.FirstOrDefault(x => x.Name == "ItemName");
+		TooltipLine priceLine = tooltips.FirstOrDefault(x => x.FullName == "Terraria/Price");
 
 		if (setBonusLine is not null)
 		{
@@ -253,6 +254,11 @@ partial class PoTGlobalItem
 		AffixTooltipsHandler.DefaultColor = Color.White; // Resets color
 
 		tooltips.AddRange(oldTooltips);
+
+		if (priceLine is not null)
+		{
+			tooltips.Add(priceLine);
+		}
 	}
 
 	private static string HighlightNumbers(string input, string numColor = "CCCCFF", string baseColor = "A0A0A0")

--- a/Core/Items/PoTGlobalItem.Tooltips.cs
+++ b/Core/Items/PoTGlobalItem.Tooltips.cs
@@ -116,9 +116,11 @@ partial class PoTGlobalItem
 		base.ModifyTooltips(item, tooltips);
 		var oldTooltips = tooltips.Where(x => x.Name.StartsWith("Tooltip")).ToList();
 		var oldStats = tooltips.Where(x => x.Name.StartsWith("Stat")).ToList();
+
 		TooltipLine setBonusLine = tooltips.FirstOrDefault(x => x.Name == "SetBonus");
 		TooltipLine nameLine = tooltips.FirstOrDefault(x => x.Name == "ItemName");
 		TooltipLine priceLine = tooltips.FirstOrDefault(x => x.FullName == "Terraria/Price");
+		TooltipLine materialLine = tooltips.FirstOrDefault(x => x.FullName == "Terraria/Material");
 
 		if (setBonusLine is not null)
 		{
@@ -255,6 +257,11 @@ partial class PoTGlobalItem
 
 		tooltips.AddRange(oldTooltips);
 
+		if (materialLine is not null)
+		{
+			tooltips.Add(materialLine);
+		}
+		
 		if (priceLine is not null)
 		{
 			tooltips.Add(priceLine);


### PR DESCRIPTION
﻿### Link Issues
Resolves: #786 
Resolves: #784
Resolves: #783
Resolves: #781

### Description of Work
- Adjusts buff time left text to display properly
- Adds useTurn to all battleaxes, broadswords
- Add price & material tooltips to all items who use them
- Allows Quest, Tree, Stats UIs to be closed by hitting Escape
