### PR TITLE
Even more misc fixes

### DIFF
--- a/Common/ItemDropping/ItemSpawner.cs
+++ b/Common/ItemDropping/ItemSpawner.cs
@@ -5,6 +5,7 @@ using PathOfTerraria.Common.Enums;
 using Terraria.DataStructures;
 using Terraria.ID;
 using PathOfTerraria.Content.Items.Consumables.Maps;
+using static AssGen.Assets;
 
 namespace PathOfTerraria.Common.ItemDropping;
 
@@ -154,12 +155,10 @@ internal class ItemSpawner
 	/// Used by the SpawnMap command. This seems useless, but I've ported it if only for posterity.
 	/// </summary>
 	/// <param name="pos"></param>
-	public static void SpawnMap<T>(Vector2 pos, int tier) where T : Map
+	public static void SpawnMap(Vector2 pos, int tier)
 	{
-		var item = new Item();
-		item.SetDefaults(ModContent.ItemType<T>());
-		//(item.ModItem as Map).Tier = tier;
+		int type = DropTable.RollMobDrops(tier, 0, 0, 0, 1).Item.type;
 
-		Item.NewItem(null, pos, Vector2.Zero, item);
+		SpawnItem(type, pos, tier);
 	}
 }

--- a/Common/NPCs/AffixFreeNPCs.cs
+++ b/Common/NPCs/AffixFreeNPCs.cs
@@ -19,5 +19,6 @@ internal class AffixFreeNPCs : GlobalNPC
 		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeSaw);
 		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeLaser);
 		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeCannon);
+		ArpgNPC.NoAffixesSet.Add(NPCID.Creeper); // Stops the BoC healthbar from bugging
 	}
 }

--- a/Common/NPCs/AffixFreeNPCs.cs
+++ b/Common/NPCs/AffixFreeNPCs.cs
@@ -7,15 +7,15 @@ internal class AffixFreeNPCs : GlobalNPC
 {
 	public override void SetStaticDefaults()
 	{
-		ArpgNPC.NoAffixesSet.Add(NPCID.Golem);
+		ArpgNPC.NoAffixesSet.Add(NPCID.Golem); // Most of these break if sped up or are extremely tanky
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemFistLeft);
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemFistRight);
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemHead);
 		ArpgNPC.NoAffixesSet.Add(NPCID.GolemHeadFree);
-		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimeOld);
+		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimeOld); // All bound slimes aren't really enemies
 		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimePurple);
 		ArpgNPC.NoAffixesSet.Add(NPCID.BoundTownSlimeYellow);
-		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeVice);
+		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeVice); // Buffed prime arms are needlessly tanky and difficult
 		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeSaw);
 		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeLaser);
 		ArpgNPC.NoAffixesSet.Add(NPCID.PrimeCannon);

--- a/Common/Systems/ModPlayers/UniversalBuffingPlayer.cs
+++ b/Common/Systems/ModPlayers/UniversalBuffingPlayer.cs
@@ -4,6 +4,7 @@ using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Common.Systems.ModPlayers;
+
 internal class UniversalBuffingPlayer : ModPlayer
 {
 	public EntityModifier UniversalModifier;
@@ -11,9 +12,11 @@ internal class UniversalBuffingPlayer : ModPlayer
 
 	public override void PostUpdateEquips()
 	{
-		if (!Player.inventory[0].IsAir)
+		int mainItem = Main.mouseItem.IsAir ? 0 : 58;
+
+		if (!Player.inventory[mainItem].IsAir)
 		{
-			PoTItemHelper.ApplyAffixes(Player.inventory[0], UniversalModifier, Player);
+			PoTItemHelper.ApplyAffixes(Player.inventory[mainItem], UniversalModifier, Player);
 		}
 
 		UniversalModifier.ApplyTo(Player);

--- a/Core/Commands/SpawnMapCommand.cs
+++ b/Core/Commands/SpawnMapCommand.cs
@@ -10,15 +10,25 @@ public sealed class SpawnMapCommand : ModCommand
 
 	public override CommandType Type => CommandType.Chat;
 
-	public override string Usage => "[c/ff6a00:Usage: /spawnmap ]";
+	public override string Usage => "[c/ff6a00:Usage: /spawnmap <count> <tier>]";
 
 	public override string Description => "Spawns a few maps for testing";
 
 	public override void Action(CommandCaller caller, string input, string[] args)
 	{
-		for (int i = 0; i < 4; i++)
+		if (args.Length == 0 || !int.TryParse(args[0], out int count))
 		{
-			ItemSpawner.SpawnMap<ForestMap>(caller.Player.Center, 5);
+			count = 1;
+		}
+
+		if (args.Length < 2 || !int.TryParse(args[1], out int tier))
+		{
+			tier = 1;
+		}
+
+		for (int i = 0; i < count; i++)
+		{
+			ItemSpawner.SpawnMap(caller.Player.Center, tier);
 		}
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #793

### Description of Work
- Makes the Main Item (in terms of affixes) switch from the first inventory item to the mouse item when holding a mouse item
- Stops BoC's Creeper adds from having affixes, causing issues with the boss health bar
- Increased flexibility of `spawnmap` command
