### PR TITLE
Update structure placement, fix ravencrest in mp

### DIFF
--- a/Common/Subworlds/BossDomains/Hardmode/PrimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/PrimeDomain.cs
@@ -160,11 +160,11 @@ internal class PrimeDomain : BossDomainSubworld
 
 		string spawn = $"Assets/Structures/SkelePrimeDomain/{(!LeftSpawn ? "Left" : "Right")}Start_" + GenRandom.Next(3);
 		Point16 size = StructureTools.GetSize(spawn);
-		StructureTools.PlaceByOrigin(spawn, new Point16(spawnX, spawnY + size.Y % 2), new Vector2(0.5f), noSync: true);
+		StructureTools.PlaceByOrigin(spawn, new Point16(spawnX, spawnY + size.Y % 2), new Vector2(0.5f));
 
 		string arena = "Assets/Structures/SkelePrimeDomain/Arena_0";
 		Point16 arenaSize = StructureTools.GetSize(arena);
-		Point16 pos = StructureTools.PlaceByOrigin(arena, new Point16(!LeftSpawn ? 180 : Width - 180, Height / 2 + 2), new Vector2(0.5f), noSync: true);
+		Point16 pos = StructureTools.PlaceByOrigin(arena, new Point16(!LeftSpawn ? 180 : Width - 180, Height / 2 + 2), new Vector2(0.5f));
 
 		Arena = new Rectangle((pos.X + 5) * 16, pos.Y * 16, (arenaSize.X - 10) * 16, arenaSize.Y * 16);
 	}
@@ -284,7 +284,7 @@ internal class PrimeDomain : BossDomainSubworld
 
 			if (GenVars.structures.CanPlace(new Rectangle(x, y - size.Y / 2, size.X, size.Y), 6) && CanPlaceHallStructureHere(x, y, size))
 			{
-				Point16 pos = StructureTools.PlaceByOrigin(name, new Point16(x, y), new Vector2(0, 0.5f), noSync: true);
+				Point16 pos = StructureTools.PlaceByOrigin(name, new Point16(x, y), new Vector2(0, 0.5f));
 				GenVars.structures.AddProtectedStructure(new Rectangle(pos.X, pos.Y, size.X, size.Y), 6);
 			}
 			else

--- a/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
@@ -52,7 +52,7 @@ internal class QueenSlimeDomain : BossDomainSubworld
 		int y = 160;
 
 		ArenaPos = new Point16(x, y);
-		StructureTools.PlaceByOrigin("Assets/Structures/QueenSlimeDomain/Arena_0", ArenaPos, new Vector2(0.5f, 0.3f), noSync: true);
+		StructureTools.PlaceByOrigin("Assets/Structures/QueenSlimeDomain/Arena_0", ArenaPos, new Vector2(0.5f, 0.3f));
 		ArenaPos = new Point16(ArenaPos.X - 4, ArenaPos.Y + 30);
 	}
 
@@ -155,7 +155,7 @@ internal class QueenSlimeDomain : BossDomainSubworld
 			{
 				string str = "Assets/Structures/QueenSlimeDomain/Crystal_" + Main.rand.Next(16);
 
-				StructureTools.PlaceByOrigin(str, position, new Vector2(0.5f), noSync: true);
+				StructureTools.PlaceByOrigin(str, position, new Vector2(0.5f));
 				return;
 			}
 		}
@@ -318,7 +318,7 @@ internal class QueenSlimeDomain : BossDomainSubworld
 			}
 			else
 			{
-				StructureTools.PlaceByOrigin("Assets/Structures/QueenSlimeDomain/Cove_" + Main.rand.Next(3), end.ToPoint16(), new Vector2(0.5f), noSync: true);
+				StructureTools.PlaceByOrigin("Assets/Structures/QueenSlimeDomain/Cove_" + Main.rand.Next(3), end.ToPoint16(), new Vector2(0.5f));
 			}
 		}
 	}
@@ -380,7 +380,7 @@ internal class QueenSlimeDomain : BossDomainSubworld
 		foreach ((int, int) pair in crystalPositions)
 		{
 			string str = "Assets/Structures/QueenSlimeDomain/Crystal_" + pair.Item2;
-			StructureTools.PlaceByOrigin(str, new Point16(pos.X, pair.Item1), new Vector2(0.5f), noSync: true);
+			StructureTools.PlaceByOrigin(str, new Point16(pos.X, pair.Item1), new Vector2(0.5f));
 		}
 	}
 

--- a/Common/Subworlds/BossDomains/Prehardmode/DeerclopsDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/DeerclopsDomain.cs
@@ -152,7 +152,7 @@ public class DeerclopsDomain : BossDomainSubworld
 				pos = new Point16(pos.X, pos.Y - 2);
 			}
 
-			StructureTools.PlaceByOrigin("Assets/Structures/DeerclopsDomain/Surface_" + id, new Point16(pos.X, pos.Y + 2), origin, null, true);
+			StructureTools.PlaceByOrigin("Assets/Structures/DeerclopsDomain/Surface_" + id, new Point16(pos.X, pos.Y + 2), origin);
 		}
 	}
 
@@ -165,7 +165,7 @@ public class DeerclopsDomain : BossDomainSubworld
 		Main.spawnTileY = (int)(Height * 0.7f);
 
 		string startPath = "Assets/Structures/DeerclopsDomain/Start_" + WorldGen.genRand.Next(4);
-		StructureTools.PlaceByOrigin(startPath, new Point16(Main.spawnTileX, Main.spawnTileY), new(0.5f, 0.6f), null, false);
+		StructureTools.PlaceByOrigin(startPath, new Point16(Main.spawnTileX, Main.spawnTileY), new(0.5f, 0.6f), null);
 
 		int firstTunnelXStart = Main.spawnTileX + WorldGen.genRand.Next(40, 80) * (WorldGen.genRand.NextBool() ? -1 : 1);
 		StartTunnel(noise, firstTunnelXStart, out Vector2[] points, out Vector2 last);

--- a/Common/Subworlds/BossDomains/Prehardmode/EaterDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/EaterDomain.cs
@@ -129,7 +129,7 @@ public class EaterDomain : BossDomainSubworld
 			Vector2 angleOffset = -new Vector2(0, -10).RotatedBy(angle);
 			var placePos = new Point16(position.X + (int)angleOffset.X, position.Y + (int)angleOffset.Y);
 
-			StructureTools.PlaceByOrigin("Assets/Structures/EaterDomain/Egg" + WorldGen.genRand.Next(3), placePos, new Vector2(0.5f, 0.5f), null);
+			StructureTools.PlaceByOrigin("Assets/Structures/EaterDomain/Egg" + WorldGen.genRand.Next(3), placePos, new Vector2(0.5f, 0.5f));
 		}
 
 		HashSet<Point16> grasses = [];
@@ -238,7 +238,7 @@ public class EaterDomain : BossDomainSubworld
 
 		if (CanPlaceGraveyard(position) && WorldGen.genRand.NextBool(12) && position.Y > 300)
 		{
-			StructureTools.PlaceByOrigin("Assets/Structures/EaterDomain/UGGraveyard" + WorldGen.genRand.Next(3), position, new Vector2(0f, 1f), null, true);
+			StructureTools.PlaceByOrigin("Assets/Structures/EaterDomain/UGGraveyard" + WorldGen.genRand.Next(3), position, new Vector2(0f, 1f));
 			return;
 		}
 

--- a/Common/Subworlds/BossDomains/Prehardmode/EyeDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/EyeDomain.cs
@@ -108,7 +108,7 @@ public class EyeDomain : BossDomainSubworld
 					}
 
 					Point16 size = StructureTools.GetSize(type);
-					pos = StructureTools.PlaceByOrigin(type, pos, new Vector2(0.5f, 1f), null, true);
+					pos = StructureTools.PlaceByOrigin(type, pos, new Vector2(0.5f, 1f));
 					structureX = pos.X;
 				}
 

--- a/Common/Subworlds/BossDomains/Prehardmode/SkeleDomain/RoomData.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/SkeleDomain/RoomData.cs
@@ -34,7 +34,7 @@ public readonly struct RoomData(WireColor color, OpeningType opening, Point open
 
 	public void PlaceRoom(int x, int y, int id, Vector2 origin)
 	{
-		Point16 position = StructureTools.PlaceByOrigin("Assets/Structures/SkeletronDomain/Room_" + id, new Point16(x, y), origin, null, false);
+		Point16 position = StructureTools.PlaceByOrigin("Assets/Structures/SkeletronDomain/Room_" + id, new Point16(x, y), origin);
 		AddSpawns(x, y);
 	}
 
@@ -44,7 +44,7 @@ public readonly struct RoomData(WireColor color, OpeningType opening, Point open
 		y -= origin.Y;
 
 		string structure = "Assets/Structures/SkeletronDomain/Room_" + id;
-		Point16 position = StructureTools.PlaceByOrigin(structure, new Point16(x, y), Vector2.Zero, null, false);
+		Point16 position = StructureTools.PlaceByOrigin(structure, new Point16(x, y), Vector2.Zero);
 		Point16 size = StructureHelper.API.Generator.GetStructureDimensions(structure, PoTMod.Instance);
 		AddSpawns(x, y);
 

--- a/Common/Subworlds/BossDomains/Prehardmode/WallOfFleshDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/WallOfFleshDomain.cs
@@ -299,7 +299,7 @@ public class WallOfFleshDomain : BossDomainSubworld
 			}
 		}
 
-		StructureTools.PlaceByOrigin("Assets/Structures/WoFDomain/Arena_" + id, new Point16(x, (int)(Height * 0.48f) - size.Y / 2), Vector2.Zero, null, false);
+		StructureTools.PlaceByOrigin("Assets/Structures/WoFDomain/Arena_" + id, new Point16(x, (int)(Height * 0.48f) - size.Y / 2), Vector2.Zero);
 	}
 
 	private void SettleLiquids(GenerationProgress progress, GameConfiguration configuration)
@@ -462,7 +462,7 @@ public class WallOfFleshDomain : BossDomainSubworld
 			}
 		}
 
-		StructureTools.PlaceByOrigin("Assets/Structures/WoFDomain/Spawn", new Point16(Main.spawnTileX, Main.spawnTileY), new Vector2(0.5f, 0), null, false);
+		StructureTools.PlaceByOrigin("Assets/Structures/WoFDomain/Spawn", new Point16(Main.spawnTileX, Main.spawnTileY), new Vector2(0.5f, 0));
 		return;
 
 		static int GetWallType(FastNoiseLite wallTypeNoise, int i, int j)
@@ -516,7 +516,7 @@ public class WallOfFleshDomain : BossDomainSubworld
 		}
 
 		crucibleY -= 10;
-		StructureTools.PlaceByOrigin("Assets/Structures/WoFDomain/Crucible", new Point16(crucibleX, crucibleY), new Vector2(0.5f, 0.5f), null, false);
+		StructureTools.PlaceByOrigin("Assets/Structures/WoFDomain/Crucible", new Point16(crucibleX, crucibleY), new Vector2(0.5f, 0.5f));
 
 		crucibleX--;
 		crucibleY -= 10;

--- a/Common/Subworlds/MappingAreas/ForestArea.cs
+++ b/Common/Subworlds/MappingAreas/ForestArea.cs
@@ -169,7 +169,7 @@ internal class ForestArea : MappingWorld, IOverrideOcean
 		{
 			y += StructureTools.AverageHeights(x, y, size.X, 2000, 2, out bool valid, [], []);
 
-			Point16 pos = StructureTools.PlaceByOrigin(path, new Point16(x, y + offsetY), origin, null, false, true);
+			Point16 pos = StructureTools.PlaceByOrigin(path, new Point16(x, y + offsetY), origin);
 
 			structures.Add(type);
 			GenVars.structures.AddProtectedStructure(new Rectangle(pos.X, pos.Y, size.X, size.Y), 10);
@@ -480,7 +480,7 @@ internal class ForestArea : MappingWorld, IOverrideOcean
 		foreach (int x in trees)
 		{
 			string path = "Assets/Structures/MapAreas/ForestArea/Tree_" + WorldGen.genRand.Next(2);
-			Point16 pos = StructureTools.PlaceByOrigin(path, new Point16(x, FloorY - 10), new Vector2(0.5f, 0.75f), noSync: true);
+			Point16 pos = StructureTools.PlaceByOrigin(path, new Point16(x, FloorY - 10), new Vector2(0.5f, 0.75f));
 			Point16 size = StructureTools.GetSize(path);
 			GenVars.structures.AddProtectedStructure(new Rectangle(pos.X + 20, pos.Y, size.X - 40, size.Y), 10);
 		}

--- a/Common/World/Generation/StructureTools.cs
+++ b/Common/World/Generation/StructureTools.cs
@@ -29,7 +29,7 @@ internal static class StructureTools
 	/// <param name="noSync">Stops StructureHelper from sending a sync packet if desired.</param>
 	/// <returns></returns>
 	public static Point16 PlaceByOrigin(string structure, Point16 position, Vector2 origin, Mod mod = null, bool cullAbove = false, 
-		bool noSync = false, GenFlags flags = GenFlags.None)
+		bool noSync = true, GenFlags flags = GenFlags.None)
 	{
 		mod ??= ModContent.GetInstance<PoTMod>();
 		Point16 dims = GetSize(structure);


### PR DESCRIPTION
### Description of Work
- Stops Ravencrest from crashing in MP
- Sets noSync to default to true in StructureTools.PlaceByOrigin, removes redundancies

### Comments
While this fixes Ravencrest generation, this also infinitely hangs the server, requiring a force close. This may or may not be related, I have no idea.