### PR TITLE
Spawn record check

### DIFF
--- a/Common/Subworlds/ArenaEnemyNPC.cs
+++ b/Common/Subworlds/ArenaEnemyNPC.cs
@@ -14,7 +14,6 @@ internal class ArenaEnemyNPC : GlobalNPC
 	public override bool InstancePerEntity => true;
 	protected override bool CloneNewInstances => true;
 
-	public byte? SpawnerIndex;
 	public bool Arena = false;
 	public bool StillDropStuff = false;
 

--- a/Common/Systems/MiscUtilities/SpawnerSystem.cs
+++ b/Common/Systems/MiscUtilities/SpawnerSystem.cs
@@ -18,10 +18,18 @@ internal class SpawnerSystem : ModSystem
 	public static readonly Dictionary<int, TileData> SpawnerRecord = [];
 
 	/// <summary> Resets a spawner corresponding to an NPC index. </summary>
-	public static void ResetSpawner(int key)
+	/// <returns> Whether the record of <paramref name="key"/> was removed. </returns>
+	public static bool ResetSpawner(int key)
 	{
-		ResetSingle(key);
-		SpawnerRecord.Remove(key);
+		if (SpawnerRecord.ContainsKey(key))
+		{
+			ResetSingle(key);
+			SpawnerRecord.Remove(key);
+
+			return true;
+		}
+
+		return false;
 	}
 
 	public static void ResetSpawners()


### PR DESCRIPTION
### Description of Work
- Prevents arena NPCs from attempting to reset spawners when they have none
- Removed unused variable `ArenaEnemyNPC.SpawnerIndex`