### PR TITLE
stat panel is now a scrolling list

### DIFF
--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -1199,7 +1199,7 @@ MechChip: {
 
 DestroyerMap: {
 	DisplayName: Destroyer Map
-	Tooltip: 		
+	Tooltip:
 		'''
 		{$MapCommon.BossBase}
 		'The map smells of sulfur and rust'
@@ -1213,7 +1213,7 @@ MechChestItem: {
 
 PlanteraMap: {
 	DisplayName: Plantera Map
-	Tooltip: 
+	Tooltip:
 		'''
 		{$MapCommon.BossBase}
 		'The map smells of mildew and dirt'
@@ -1232,7 +1232,7 @@ LihzahrdGuardItem: {
 
 GolemMap: {
 	DisplayName: Golem Map
-	Tooltip: 
+	Tooltip:
 		'''
 		{$MapCommon.BossBase}
 		'The map smells of brick and smoke'


### PR DESCRIPTION
﻿### Link Issues
Resolves: #896 

### Description of Work
- Makes player stats scrollable

### Comments
The way I implemented this uses a scrollbar that is invisible and not interactable, because the scrollbar was both really ugly and also didn't work at all for some reason. This might be a little awkward, but it works.