### PR TITLE
make experience less laggy, misc fixes

### DIFF
--- a/Common/Subworlds/BossDomains/Hardmode/EoLDomain/EoLDomainSpawns.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/EoLDomain/EoLDomainSpawns.cs
@@ -1,0 +1,27 @@
+﻿using SubworldLibrary;
+using System.Collections.Generic;
+
+namespace PathOfTerraria.Common.Subworlds.BossDomains.Hardmode.EoLDomain;
+
+internal class EoLDomainSpawns : GlobalNPC
+{
+	public override void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns)
+	{
+		if (SubworldSystem.Current is not EmpressDomain)
+		{
+			return;
+		}
+
+		spawnRate = int.MaxValue / 4;
+	}
+
+	public override void EditSpawnPool(IDictionary<int, float> pool, NPCSpawnInfo spawnInfo)
+	{
+		if (SubworldSystem.Current is not EmpressDomain)
+		{
+			return;
+		}
+
+		pool.Clear();
+	}
+}

--- a/Common/Subworlds/BossDomains/Prehardmode/QueenBeeDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/QueenBeeDomain.cs
@@ -21,7 +21,7 @@ public class QueenBeeDomain : BossDomainSubworld
 {
 	public override int Width => 800;
 	public override int Height => 1600;
-	public override int[] WhitelistedCutTiles => [TileID.BeeHive, TileID.JungleVines, ModContent.TileType<RoyalHoneyClumpTile>()];
+	public override int[] WhitelistedCutTiles => [TileID.BeeHive, TileID.JungleVines, TileID.JunglePlants, TileID.JunglePlants2, ModContent.TileType<RoyalHoneyClumpTile>()];
 	public override int[] WhitelistedMiningTiles => [ModContent.TileType<RoyalHoneyClumpTile>()];
 	public override (int time, bool isDay) ForceTime => ((int)Main.dayLength / 2, true);
 
@@ -146,7 +146,7 @@ public class QueenBeeDomain : BossDomainSubworld
 		var original = new Point16(x, y);
 
 		Vector2[] positions = Tunnel.GeneratePoints([new(x, y), Vector2.Lerp(new(x, y), new(Width / 2, Main.spawnTileY), 0.7f)
-			+ new Vector2(WorldGen.genRand.Next(-2, 3), WorldGen.genRand.Next(-2, 3)), new(Width / 2, Main.spawnTileY)], 6, 4);
+			+ new Vector2(WorldGen.genRand.Next(-2, 3), WorldGen.genRand.Next(-2, 3)), new(Width / 2, Main.spawnTileY)], 6, 4, 0.1f);
 
 		FastNoiseLite noise = new(WorldGen._genRandSeed);
 		int breakTime = -1;

--- a/Common/Systems/DisableBuilding/StopCuttingProjectile.cs
+++ b/Common/Systems/DisableBuilding/StopCuttingProjectile.cs
@@ -8,7 +8,7 @@ namespace PathOfTerraria.Common.Systems.DisableBuilding;
 
 internal class StopCuttingProjectile : GlobalProjectile
 {
-	private static bool Cutting = false;
+	private static Projectile CuttingProjectile = null;
 
 	public override void Load()
 	{
@@ -50,9 +50,9 @@ internal class StopCuttingProjectile : GlobalProjectile
 	{
 		bool vanilla = orig(x, y);
 
-		if (Cutting && SubworldSystem.Current is BossDomainSubworld domain)
+		if (CuttingProjectile is not null && SubworldSystem.Current is BossDomainSubworld domain && Main.tile[x, y].HasTile && Main.tileCut[Main.tile[x, y].TileType])
 		{
-			return vanilla && BuildingWhitelist.InCuttingWhitelist(Main.tile[x, y].TileType);
+			return vanilla && CanCutTile(CuttingProjectile, x, y);
 		}
 
 		return vanilla;
@@ -60,9 +60,9 @@ internal class StopCuttingProjectile : GlobalProjectile
 
 	private void AddCutCheck(On_Projectile.orig_CutTiles orig, Projectile self)
 	{
-		Cutting = true;
+		CuttingProjectile = self;
 		orig(self);
-		Cutting = false;
+		CuttingProjectile = null;
 	}
 
 	public override bool PreKill(Projectile projectile, int timeLeft)

--- a/Common/Systems/MobSystem/MobExperienceGlobalNPC.cs
+++ b/Common/Systems/MobSystem/MobExperienceGlobalNPC.cs
@@ -1,6 +1,6 @@
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Subworlds;
-using PathOfTerraria.Common.Systems.Experience;
+using PathOfTerraria.Common.Systems.ExperienceSystem;
 using SubworldLibrary;
 using Terraria.ID;
 

--- a/Common/Systems/Networking/Handlers/ExperienceHandler.cs
+++ b/Common/Systems/Networking/Handlers/ExperienceHandler.cs
@@ -1,4 +1,4 @@
-using PathOfTerraria.Common.Systems.Experience;
+using PathOfTerraria.Common.Systems.ExperienceSystem;
 using System.IO;
 
 namespace PathOfTerraria.Common.Systems.Networking.Handlers;

--- a/Common/UI/Map/CustomHeadIconMapLayer.cs
+++ b/Common/UI/Map/CustomHeadIconMapLayer.cs
@@ -40,8 +40,20 @@ internal class CustomHeadIconMapLayer : ModMapLayer, INeedRenderTargetContent
 			{
 				_drawData.Clear();
 
-				ref Vector2 mapPosition = ref GetMapPosition(ref context);
+				Vector2 mapPosition = GetMapPosition(ref context);
 				Vector2 position = (npc.Center.ToTileCoordinates().ToVector2() - mapPosition) * GetMapScale(ref context) + GetMapOffset(ref context);
+				Rectangle? clippingRect = GetClippingRectangle(ref context);
+
+				if (clippingRect.HasValue)
+				{
+					Rectangle rect = clippingRect.Value;
+					rect.Inflate(-16, -16);
+
+					if (!rect.Contains(position.ToPoint()))
+					{
+						continue;
+					}
+				}
 
 				PlayerHeadDrawRenderTargetContent playerHeadDrawRenderTargetContent = _containerHeadRenderers[npc.whoAmI];
 				playerHeadDrawRenderTargetContent.UsePlayer(cNPC.DrawDummy);
@@ -76,6 +88,9 @@ internal class CustomHeadIconMapLayer : ModMapLayer, INeedRenderTargetContent
 
 	[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_drawScale")]
 	static extern ref float GetDrawScale(ref MapOverlayDrawContext context);
+
+	[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_clippingRect")]
+	static extern ref Rectangle? GetClippingRectangle(ref MapOverlayDrawContext context);
 
 	private void RenderDrawData(Player drawPlayer)
 	{

--- a/Core/Commands/SpawnOrbsCommand.cs
+++ b/Core/Commands/SpawnOrbsCommand.cs
@@ -1,4 +1,4 @@
-using PathOfTerraria.Common.Systems.Experience;
+using PathOfTerraria.Common.Systems.ExperienceSystem;
 
 namespace PathOfTerraria.Core.Commands;
 

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -1292,7 +1292,7 @@ AncientTablet: {
 
 CultistMap: {
 	DisplayName: Lunatic Cultist Map
-	Tooltip: 
+	Tooltip:
 		'''
 		{$MapCommon.BossBase}
 		'The map smells of soot and space'


### PR DESCRIPTION
### Description of Work
- Fixed the new Ranger/Warrior NPC head icons drawing outside of the bounds of the minimap
- Streamline some experience functionality, namespaces
- Allow experience to combine together in order to reduce lag when kiting (see comment)
- Fixed Empress Domain having natural spawns
- Extra fixed Queen Bee domain sometimes having blocked entrances
- Improved disable cut system that was inconsistent in some domains

### Comments
I found that it's fairly common to kite for enough time around event or boss domain adds for long enough to be hit by a very, very large FPS drop. I understand wanting the big cloud of experience for the visual dopamine, and while I did add scaling past the maximum sprite size so there's still some of that, it is a different sensation. That being said, I cannot even intentionally abuse experience to cause FPS drops, which I think is worth the tradeoff.