### PR TITLE
add space between "domain" and "and"

### DIFF
--- a/Common/Systems/DisableBuilding/StopCuttingProjectile.cs
+++ b/Common/Systems/DisableBuilding/StopCuttingProjectile.cs
@@ -52,7 +52,7 @@ internal class StopCuttingProjectile : GlobalProjectile
 	{
 		bool vanilla = orig(x, y);
 
-		if (CuttingProjectile is not null && SubworldSystem.Current is BossDomainSubworld domainand not MoonLordDomain && Main.tile[x, y].HasTile && Main.tileCut[Main.tile[x, y].TileType])
+		if (CuttingProjectile is not null && SubworldSystem.Current is BossDomainSubworld domain and not MoonLordDomain && Main.tile[x, y].HasTile && Main.tileCut[Main.tile[x, y].TileType])
 		{
 			return vanilla && CanCutTile(CuttingProjectile, x, y);
 		}

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -1271,6 +1271,7 @@ MoonMap: {
 		'''
 		{$MapCommon.BossBase}
 		'The map smells of shimmer'
+		'''
 }
 
 AncientTabletFour: {


### PR DESCRIPTION
### Description of Work
- I forgot to add a space between a variable name and "and", now develop doesn't compile