### PR TITLE
Even more qa

### DIFF
--- a/Common/Mechanics/Skill.Stats.cs
+++ b/Common/Mechanics/Skill.Stats.cs
@@ -7,7 +7,7 @@ public abstract partial class Skill
 	public SkillBuff Stats = new();
 
 	/// <summary> The final cooldown of this skill affected by modifications. </summary>
-	public int TotalCooldown => (int)Stats.Cooldown.ApplyTo(Cooldown);
+	public int TotalCooldown => (int)Stats.Cooldown.ApplyTo(MaxCooldown);
 	/// <summary> The final mana cost of this skill affected by modifications. </summary>
 	public int TotalManaCost => (int)Stats.ManaCost.ApplyTo(ManaCost);
 

--- a/Common/Mechanics/Skill.cs
+++ b/Common/Mechanics/Skill.cs
@@ -137,7 +137,7 @@ public abstract partial class Skill
 	public virtual void UseSkill(Player player)
 	{
 		player.CheckMana(TotalManaCost, true);
-		Cooldown = MaxCooldown;
+		Cooldown = TotalCooldown;
 	}
 
 	/// <summary>
@@ -147,7 +147,7 @@ public abstract partial class Skill
 	/// <returns>If the skill can be used or not</returns>
 	public virtual bool CanUseSkill(Player player)
 	{
-		return Cooldown <= 0 && player.CheckMana(ManaCost);
+		return Cooldown <= 0 && player.CheckMana(TotalManaCost);
 	}
 
 	/// <summary>

--- a/Common/Mechanics/Skill.cs
+++ b/Common/Mechanics/Skill.cs
@@ -137,7 +137,7 @@ public abstract partial class Skill
 	public virtual void UseSkill(Player player)
 	{
 		player.CheckMana(TotalManaCost, true);
-		Cooldown = TotalCooldown;
+		Cooldown = MaxCooldown;
 	}
 
 	/// <summary>
@@ -152,14 +152,33 @@ public abstract partial class Skill
 
 	/// <summary>
 	/// Whether the player can have the current skill equipped or not.<br/>
-	/// This will remove the skill automatically if they have it equipped but the condition is false.
-	/// Returns true by default.
+	/// This will also remove the skill automatically if they have it equipped but the condition is false.
+	/// Returns true by default.<br/>
+	/// If you need to check if a skill can be equipped, use <see cref="CanEquipSkill(Player)"/> instead.
 	/// </summary>
-	/// <param name="player">The player who is trying to equip or has the skill equipped.</param>
+	/// <param name="player">The player who is trying to equip the skill, or has the skill equipped.</param>
 	/// <returns>If the player can have this skill equipped.</returns>
-	public virtual bool CanEquipSkill(Player player)
+	protected virtual bool ProtectedCanEquip(Player player, out string failReason)
 	{
+		failReason = string.Empty;
 		return true;
+	}
+
+	/// <summary>
+	/// Whether the skill can be equipped. Runs <see cref="ProtectedCanEquip(Player)"/> and checks if the player has enough mana to use the skill.
+	/// </summary>
+	/// <param name="player">The player who is trying to equip the skill, or has the skill equipped.</param>
+	/// <returns>If the player can have this skill equipped.</returns>
+	public bool CanEquipSkill(Player player, out string failReason)
+	{
+		if (!ProtectedCanEquip(player, out failReason))
+		{
+			return false;
+		}
+
+		bool hasMana = player.statManaMax2 > TotalManaCost;
+		failReason = hasMana ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NotEnoughMana");
+		return hasMana;
 	}
 
 	public virtual void LoadData(TagCompound tag)

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -160,6 +160,27 @@ public class RavencrestSystem : ModSystem
 			structure.Place();
 		}
 
+		for (int i = 0; i < Main.maxTilesX; ++i)
+		{
+			for (int j = 0; j < Main.maxTilesY; ++j)
+			{
+				WorldGen.TileFrame(i, j, true);
+				int sign = Sign.ReadSign(i, j, true);
+
+				if (sign != -1)
+				{
+					string text = i switch
+					{
+						< 220 => "the Iron Anvil",
+						< 360 => "The Lodge",
+						_ => "<-- Lodge, Forge\nLibrary, Hovel -->"
+					};
+
+					Sign.TextSign(sign, text);
+				}
+			}
+		}
+
 		foreach (string npcName in HasOverworldNPC)
 		{
 			int type = ModContent.Find<ModNPC>(npcName).Type;

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -3,6 +3,7 @@ using PathOfTerraria.Common.Systems.Networking.Handlers;
 using PathOfTerraria.Common.Systems.StructureImprovementSystem;
 using PathOfTerraria.Common.Systems.VanillaModifications;
 using PathOfTerraria.Common.UI;
+using PathOfTerraria.Common.World.Generation.Tools;
 using PathOfTerraria.Content.Tiles.BossDomain;
 using ReLogic.Graphics;
 using SubworldLibrary;
@@ -180,6 +181,8 @@ public class RavencrestSystem : ModSystem
 				}
 			}
 		}
+
+		GenerationUtilities.ManuallyPopulateChests();
 
 		foreach (string npcName in HasOverworldNPC)
 		{

--- a/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
@@ -4,7 +4,7 @@ internal class IncreasedAttackSpeedAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Attackspeed += Value;
+		modifier.AttackSpeed += Value / 100f;
 	}
 
 	public override void ApplyTooltip(Player player, Item item, AffixTooltipsHandler handler)
@@ -17,7 +17,7 @@ internal class AddedAttackSpeedAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Attackspeed.Base += Value;
+		modifier.AttackSpeed.Base += Value;
 	}
 }
 

--- a/Common/Systems/EntityModifier.cs
+++ b/Common/Systems/EntityModifier.cs
@@ -22,7 +22,7 @@ public partial class EntityModifier : EntityModifierSegment
 	public StatModifier ProjectileSpeed = new();
 	public StatModifier ProjectileCount = new(); // would be neat
 	public StatModifier Damage = new();
-	public StatModifier Attackspeed = new();
+	public StatModifier AttackSpeed = new();
 	public StatModifier ArmorPenetration = new();
 	public StatModifier Knockback = new();
 	public StatModifier CriticalChance = new();
@@ -84,7 +84,7 @@ public partial class EntityModifier : EntityModifierSegment
 		player.endurance *= (int)DamageReduction.ApplyTo(player.endurance); // i think this is right..?
 		player.moveSpeed = MovementSpeed.ApplyTo(player.moveSpeed);
 		player.GetDamage(DamageClass.Generic) = player.GetDamage(DamageClass.Generic).CombineWith(Damage);
-		player.GetAttackSpeed(DamageClass.Generic) = Attackspeed.ApplyTo(player.GetAttackSpeed(DamageClass.Generic));
+		player.GetAttackSpeed(DamageClass.Generic) = AttackSpeed.ApplyTo(player.GetAttackSpeed(DamageClass.Generic));
 
 		player.GetKnockback(DamageClass.Generic) = player.GetKnockback(DamageClass.Generic).CombineWith(Knockback);
 		player.GetArmorPenetration(DamageClass.Generic) =

--- a/Common/Systems/ModPlayers/SkillCombatPlayer.cs
+++ b/Common/Systems/ModPlayers/SkillCombatPlayer.cs
@@ -99,15 +99,10 @@ internal class SkillCombatPlayer : ModPlayer
 		{
 			Skill skill = HotbarSkills[i];
 
-			if (skill is not null)
+			if (skill is not null && !skill.CanEquipSkill(Player, out _))
 			{
-				//skill.UpdateEquipped(Player);
-
-				if (!skill.CanEquipSkill(Player))
-				{
-					HotbarSkills[i] = null;
-					continue;
-				}
+				HotbarSkills[i] = null;
+				continue;
 			}
 		}
 	}
@@ -186,9 +181,9 @@ internal class SkillCombatPlayer : ModPlayer
 
 	public bool TryAddSkill(Skill skill)
 	{
-		if (!skill.CanEquipSkill(Player))
+		if (!skill.CanEquipSkill(Player, out string failReason))
 		{
-			Main.NewText("Skill cannot be added.");
+			Main.NewText($"Skill cannot be added. ({failReason})");
 			return false;
 		}
 

--- a/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
@@ -1,16 +1,14 @@
-﻿using System.Collections.Generic;
-using PathOfTerraria.Common.Enums;
+﻿using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.ItemDropping;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
-using PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 using PathOfTerraria.Content.Items.Gear.Weapons.Bow;
-using PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 using PathOfTerraria.Content.NPCs.Town;
 using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Core.Items;
+using System.Collections.Generic;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
@@ -27,20 +25,11 @@ internal class HunterStartQuest : Quest
 		new ActionRewards((p, v) =>
 			{
 				p.GetModPlayer<ExpModPlayer>().Exp += 500;
-				int sword = ItemSpawner.SpawnItemFromCategory<Sword>(v);
+				int sword = ItemSpawner.SpawnItemFromCategory<Bow>(v);
 
 				if (sword != -1)
 				{
 					Item item = Main.item[sword];
-					item.GetInstanceData().Rarity = ItemRarity.Magic;
-					PoTItemHelper.Roll(item, Main.rand.Next(6, 11));
-				}
-				
-				int axe = ItemSpawner.SpawnItemFromCategory<Battleaxe>(v);
-
-				if (axe != -1)
-				{
-					Item item = Main.item[axe];
 					item.GetInstanceData().Rarity = ItemRarity.Magic;
 					PoTItemHelper.Roll(item, Main.rand.Next(6, 11));
 				}

--- a/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
+++ b/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
@@ -15,7 +15,7 @@ using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.GrimoireSelection;
 
-internal class GrimoireSelectionUIState : CloseableSmartUi
+internal class GrimoireSelectionUIState : CloseableSmartUi, IMutuallyExclusiveUI
 {
 	public static readonly Point MainPanelSize = new(900, 550);
 
@@ -50,7 +50,6 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 	public override void SafeUpdate(GameTime gameTime)
 	{
 		base.SafeUpdate(gameTime);
-
 		bool offItem = Main.LocalPlayer.HeldItem.ModItem is not GrimoireItem && !Main.LocalPlayer.controlTorch;
 		if (IsVisible && (offItem || !Main.playerInventory))
 		{
@@ -66,7 +65,7 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 		Main.inventoryScale = invSize;
 	}
 
-	internal void Toggle()
+	public void Toggle()
 	{
 		RemoveAllChildren();
 
@@ -87,6 +86,8 @@ internal class GrimoireSelectionUIState : CloseableSmartUi
 			_storageGrid = null;
 			return;
 		}
+
+		ModContent.GetInstance<SmartUiLoader>().ClearMutuallyExclusive<GrimoireSelectionUIState>();
 
 		Main.playerInventory = true;
 

--- a/Common/UI/Guide/TutorialPlayer.cs
+++ b/Common/UI/Guide/TutorialPlayer.cs
@@ -15,6 +15,7 @@ public enum TutorialCheck : byte
 	OpenedCharSheet,
 	OpenedQuestBook,
 	FinishedTutorial,
+	FreeDayGone,
 }
 
 /// <summary>
@@ -24,6 +25,7 @@ internal class TutorialPlayer : ModPlayer
 {
 	/// <summary> Whether the player has completed the tutorial (<see cref="TutorialCheck.FinishedTutorial"/>). </summary>
 	public bool CompletedTutorial => TutorialChecks.Contains(TutorialCheck.FinishedTutorial);
+	public bool HasFreeDay => !TutorialChecks.Contains(TutorialCheck.FreeDayGone);
 
 	public HashSet<TutorialCheck> TutorialChecks = [];
 	public byte TutorialStep = 0;
@@ -36,6 +38,14 @@ internal class TutorialPlayer : ModPlayer
 		if (!CompletedTutorial)
 		{
 			UIManager.Register("Tutorial UI", "Vanilla: Player Chat", new TutorialUIState(), 0, Terraria.UI.InterfaceScaleType.UI);
+		}
+	}
+
+	public override void UpdateEquips()
+	{
+		if (!Main.dayTime)
+		{
+			TutorialChecks.Add(TutorialCheck.FreeDayGone);
 		}
 	}
 

--- a/Common/UI/Guide/TutorialSystem.cs
+++ b/Common/UI/Guide/TutorialSystem.cs
@@ -11,4 +11,13 @@ internal class TutorialSystem : ModSystem
 			UIManager.Data.RemoveAll(x => x.Identifier == "Tutorial UI");
 		}
 	}
+
+	public override void ModifyTimeRate(ref double timeRate, ref double tileUpdateRate, ref double eventUpdateRate)
+	{
+		TutorialPlayer plr = Main.LocalPlayer.GetModPlayer<TutorialPlayer>();
+		if (!plr.CompletedTutorial && plr.HasFreeDay)
+		{
+			timeRate /= 3;
+		}
+	}
 }

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -283,7 +283,8 @@ public sealed class NewHotbar : SmartUiState
 		Tooltip.SetName(skill.DisplayName.Value + " " + level);
 
 		List<SkillTooltip> tooltips = [];
-		SkillTooltip manaCost = new("Mana", Language.GetText("Mods.PathOfTerraria.Skills.ManaLine").WithFormatArgs(skill.TotalManaCost).Value, 2);
+		SkillTooltip manaCost = new("Mana", Language.GetText("Mods.PathOfTerraria.Skills." 
+			+ (Main.LocalPlayer.statManaMax2 <= skill.TotalManaCost ? "NotEnoughMana" : "ManaLine")).WithFormatArgs(skill.TotalManaCost).Value, 2);
 		SkillTooltip weapon = skill.WeaponType != ItemID.None
 			? new("WeaponType", Language.GetText("Mods.PathOfTerraria.Skills.WeaponLine").WithFormatArgs(skill.WeaponType).Value, 3)
 			: new("NoWeapon", Language.GetText("Mods.PathOfTerraria.Skills.NoWeaponLine").Value, 3);

--- a/Common/UI/PlayerStats/PlayerStatUIState.cs
+++ b/Common/UI/PlayerStats/PlayerStatUIState.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.UI.Guide;
+using PathOfTerraria.Core.UI.SmartUI;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
@@ -6,7 +7,7 @@ using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.PlayerStats;
 
-internal class PlayerStatUIState : CloseableSmartUi
+internal class PlayerStatUIState : CloseableSmartUi, IMutuallyExclusiveUI
 {
 	public override int DepthPriority => 3;
 	protected override bool IsCentered => true;
@@ -40,6 +41,7 @@ internal class PlayerStatUIState : CloseableSmartUi
 			VAlign = 0.4f;
 
 			RemoveAllChildren();
+			ModContent.GetInstance<SmartUiLoader>().ClearMutuallyExclusive<PlayerStatUIState>();
 
 			base.CreateMainPanel(false, new Point(512, 660), false, true);
 

--- a/Common/UI/Quests/QuestsUIState.cs
+++ b/Common/UI/Quests/QuestsUIState.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.UI.Guide;
+using PathOfTerraria.Core.UI.SmartUI;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
@@ -9,7 +10,7 @@ using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.Quests;
 
-public class QuestsUIState : CloseableSmartUi
+public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 {
 	private QuestDetailsPanel _questDetails;
 	public const float SelectedOpacity = 0.25f;
@@ -54,6 +55,7 @@ public class QuestsUIState : CloseableSmartUi
 		}
 
 		Main.LocalPlayer.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.OpenedQuestBook);
+		ModContent.GetInstance<SmartUiLoader>().ClearMutuallyExclusive<QuestsUIState>();
 
 		RemoveAllChildren();
 		base.CreateMainPanel(false, new Point(970, 715), false, true);

--- a/Common/UI/SkillsTree/AugmentSlotElement.cs
+++ b/Common/UI/SkillsTree/AugmentSlotElement.cs
@@ -1,5 +1,4 @@
-﻿using Humanizer;
-using PathOfTerraria.Common.Mechanics;
+﻿using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Skills;
 using PathOfTerraria.Content.Items.Currency;
@@ -117,11 +116,11 @@ internal class AugmentSlotElement : UIElement
 
 				if (Main.LocalPlayer.HasItem(ModContent.ItemType<AugmentationOrb>()))
 				{
-					tooltip = Language.GetTextValue(common + ".Unlock").FormatWith(ModContent.GetInstance<AugmentationOrb>().DisplayName.Value);
+					tooltip = Language.GetTextValue(common + ".Unlock", ModContent.GetInstance<AugmentationOrb>().DisplayName.Value);
 				}
 				else
 				{
-					tooltip = Language.GetTextValue(common + ".CostLine").FormatWith(ModContent.GetInstance<AugmentationOrb>().DisplayName.Value);
+					tooltip = Language.GetTextValue(common + ".CostLine", ModContent.GetInstance<AugmentationOrb>().DisplayName.Value);
 				}
 
 				Tooltip.SetName(Language.GetTextValue(common + ".SlotLine"));
@@ -133,6 +132,7 @@ internal class AugmentSlotElement : UIElement
 	private void AddRadial()
 	{
 		int index = 0;
+
 		foreach (string key in SkillAugment.LoadedAugments.Keys)
 		{
 			SkillAugment augment = SkillAugment.LoadedAugments[key];
@@ -148,7 +148,8 @@ internal class AugmentSlotElement : UIElement
 
 		static bool CanBeApplied(SkillAugment augment)
 		{
-			Skill skill = Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>().HotbarSkills.Where(x => x.GetType() == SkillTree.Current.ParentSkill).FirstOrDefault();
+			Skill skill = Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>().HotbarSkills
+				.Where(x => x is not null && x.GetType() == SkillTree.Current.ParentSkill).FirstOrDefault();
 			return skill != default && augment.CanBeApplied(skill);
 		}
 	}

--- a/Common/UI/SkillsTree/SkillSelectionElement.cs
+++ b/Common/UI/SkillsTree/SkillSelectionElement.cs
@@ -38,18 +38,18 @@ internal class SkillSelectionElement : UIElement
 
 		if (ContainsPoint(Main.MouseScreen))
 		{
-			if (_skill.CanEquipSkill(Main.LocalPlayer))
+			if (_skill.CanEquipSkill(Main.LocalPlayer, out string failReason))
 			{
 				NewHotbar.DrawSkillHoverTooltips(_skill);
 			}
 			else
 			{
-				Tooltip.SetName(Language.GetTextValue("Mods.PathOfTerraria.Skills.CantEquip"));
+				Tooltip.SetName(Language.GetTextValue("Mods.PathOfTerraria.Skills.CantEquip", failReason));
 			}
 		}
 
 		Vector2 position = GetDimensions().Position() + new Vector2(Width.Pixels / 2, Height.Pixels / 2);
-		spriteBatch.Draw(tex, position, null, _skill.CanEquipSkill(Main.LocalPlayer) ? Color.White : Color.Gray, 0f, tex.Size() / 2f, 1f, SpriteEffects.None, 0f);
+		spriteBatch.Draw(tex, position, null, _skill.CanEquipSkill(Main.LocalPlayer, out _) ? Color.White : Color.Gray, 0f, tex.Size() / 2f, 1f, SpriteEffects.None, 0f);
 
 		if (Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>().HasSkill(_skill.Name))
 		{
@@ -63,12 +63,14 @@ internal class SkillSelectionElement : UIElement
 	public override void LeftClick(UIMouseEvent evt)
 	{
 		SkillCombatPlayer skillCombatPlayer = Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>();
-		skillCombatPlayer.TryAddSkill(_skill);
-		_parentPanel.SelectedSkill = _skill;
 
-        _parentPanel.RebuildTree();
+		if (skillCombatPlayer.TryAddSkill(_skill))
+		{
+			_parentPanel.SelectedSkill = _skill;
+			_parentPanel.RebuildTree();
 
-        Main.LocalPlayer.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.SelectedSkill);
+			Main.LocalPlayer.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.SelectedSkill);
+		}
 	}
 
 	public override void RightClick(UIMouseEvent evt)

--- a/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Bloodclotter.cs
@@ -1,12 +1,10 @@
-﻿using PathOfTerraria.Content.Buffs;
-using PathOfTerraria.Content.Projectiles.Ranged.Javelin;
-using System.Collections.Generic;
-
-using PathOfTerraria.Common.Systems;
+﻿using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+using PathOfTerraria.Content.Buffs;
+using PathOfTerraria.Content.Projectiles.Ranged.Javelin;
 using PathOfTerraria.Core.Items;
-
+using System.Collections.Generic;
 using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Javelins;

--- a/Content/Items/Gear/Weapons/Javelins/Javelin.cs
+++ b/Content/Items/Gear/Weapons/Javelins/Javelin.cs
@@ -145,7 +145,7 @@ internal abstract class Javelin : Gear
 
 			foreach (NPC npc in Main.ActiveNPCs)
 			{
-				if (npc.Hitbox.Intersects(Player.Hitbox))
+				if (npc.Hitbox.Intersects(Player.Hitbox) && npc.CanBeChasedBy())
 				{
 					npc.SimpleStrikeNPC((int)(Player.HeldItem.damage * 1.5f), Math.Sign(StoredVelocity.X), true);
 

--- a/Content/RoomTypes/Tavern.cs
+++ b/Content/RoomTypes/Tavern.cs
@@ -1,6 +1,5 @@
 ﻿using HousingAPI.Common;
 using HousingAPI.Common.Helpers;
-using Humanizer;
 using PathOfTerraria.Common.NPCs;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,23 +104,23 @@ public class Tavern : ModRoomType
 		{
 			if (objects.Count == 1)
 			{
-				ErrorLog = Language.GetTextValue(path + "Common.Missing1").FormatWith(objects[0]);
+				ErrorLog = Language.GetTextValue(path + "Common.Missing1", objects[0]);
 			}
 			else if (objects.Count == 2)
 			{
-				ErrorLog = Language.GetTextValue(path + "Common.Missing2").FormatWith(objects[0], objects[1]);
+				ErrorLog = Language.GetTextValue(path + "Common.Missing2", objects[0], objects[1]);
 			}
 			else
 			{
-				string listText = Language.GetTextValue(path + "Common.MissingList");
+				string listText = Language.GetTextValue(path + "Common.MissingList", objects[..^2]);
 				string init = string.Empty;
 
 				for (int i = 0; i < objects.Count - 2; i++)
 				{
-					init += listText.FormatWith(objects[i]);
+					init += Language.GetTextValue(path + "Common.MissingList", objects[i]);
 				}
 
-				ErrorLog = Language.GetTextValue(path + "Common.Missing3").FormatWith(init, objects[^2], objects[^1]);
+				ErrorLog = Language.GetTextValue(path + "Common.Missing3", init, objects[^2], objects[^1]);
 			}
 
 			return false;

--- a/Content/Skills/Magic/Fireball.cs
+++ b/Content/Skills/Magic/Fireball.cs
@@ -28,8 +28,9 @@ public class Fireball : Skill
 		var source = new EntitySource_UseSkill(player, this);
 		float knockback = 2f;
 		int type = ModContent.ProjectileType<FireballProj>();
-
-		Projectile.NewProjectile(source, player.Center, player.DirectionTo(Main.MouseWorld).RotatedByRandom(0.05f) * 8, type, damage, knockback, player.whoAmI, Level);
+		Vector2 velocity = player.DirectionTo(Main.MouseWorld).RotatedByRandom(0.05f) * 8 * Main.rand.NextFloat(0.9f, 1.1f);
+		
+		Projectile.NewProjectile(source, player.Center - new Vector2(0, 12), velocity, type, damage, knockback, player.whoAmI, Level);
 		SoundEngine.PlaySound(SoundID.Item20 with { PitchRange = (-0.8f, 0.2f) }, player.Center);
 	}
 
@@ -47,19 +48,25 @@ public class Fireball : Skill
 		public override void SetDefaults()
 		{
 			Projectile.friendly = true;
-			Projectile.width = 50;
-			Projectile.height = 50;
 			Projectile.timeLeft = 240;
 			Projectile.penetrate = 1;
 			Projectile.aiStyle = -1;
+			Projectile.scale = 0f;
 		}
 
 		public override void AI()
 		{
 			Projectile.rotation = Projectile.velocity.ToRotation();
-			Projectile.frame = (int)(Projectile.frameCounter++ / 6f) % 5;
-			Projectile.velocity.Y += 0.01f;
+			Projectile.frame = (int)(Projectile.frameCounter++ / 5f) % 5;
 			Projectile.Opacity = (Projectile.velocity.Length() - 2) / 8f * 0.25f + 0.75f;
+			Projectile.scale = Math.Min(1, Projectile.scale + 0.025f);
+			Projectile.width = (int)(36 * Projectile.scale);
+			Projectile.height = (int)(36 * Projectile.scale); 
+
+			if (Projectile.scale == 1)
+			{
+				Projectile.velocity.Y += 0.01f;
+			}
 
 			SpawnDust(1, 0.4f);
 		}
@@ -117,8 +124,9 @@ public class Fireball : Skill
 			var src = new Rectangle(0, frameHeight * Projectile.frame, tex.Width, frameHeight);
 			Color col = lightColor * Projectile.Opacity;
 			Vector2 position = Projectile.Center - Main.screenPosition;
+			Vector2 origin = src.Size() / new Vector2(1.5f, 2);
 			
-			Main.EntitySpriteDraw(tex, position, src, col, Projectile.rotation, src.Size() / new Vector2(1.5f, 2), 1f, SpriteEffects.None, 0);
+			Main.EntitySpriteDraw(tex, position, src, col * Projectile.scale, Projectile.rotation, origin, Projectile.scale, SpriteEffects.None, 0);
 			return false;
 		}
 	}

--- a/Content/Skills/Melee/MoltenShield.cs
+++ b/Content/Skills/Melee/MoltenShield.cs
@@ -3,6 +3,7 @@ using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Content.Buffs;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Skills.Melee;
 
@@ -28,9 +29,11 @@ public class MoltenShield : Skill
 		player.GetModPlayer<MoltenShieldBuff.MoltenShieldPlayer>().SetBuff(Level, Duration);
 	}
 
-	public override bool CanEquipSkill(Player player)
+	protected override bool ProtectedCanEquip(Player player, out string failReason)
 	{
 		// TODO: If this needs to be equippable without the affix, figure out that system
-		return player.GetModPlayer<AffixPlayer>().StrengthOf<MoltenShellAffix>() > 0;
+		bool canEquip = player.GetModPlayer<AffixPlayer>().StrengthOf<MoltenShellAffix>() > 0;
+		failReason = canEquip ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NeedsAffix");
+		return canEquip;
 	}
 }

--- a/Content/Skills/Ranged/BloodSiphon.cs
+++ b/Content/Skills/Ranged/BloodSiphon.cs
@@ -7,6 +7,7 @@ using PathOfTerraria.Common.Systems.Skills;
 using PathOfTerraria.Content.Buffs;
 using ReLogic.Content;
 using Terraria.ID;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Skills.Ranged;
 
@@ -52,10 +53,12 @@ public class BloodSiphon : Skill
 		}
 	}
 
-	public override bool CanEquipSkill(Player player)
+	protected override bool ProtectedCanEquip(Player player, out string failReason)
 	{
 		// TODO: If this needs to be equippable without the affix, figure out that system
-		return player.GetModPlayer<AffixPlayer>().StrengthOf<BloodSiphonAffix>() > 0;
+		bool canEquip = player.GetModPlayer<AffixPlayer>().StrengthOf<BloodSiphonAffix>() > 0;
+		failReason = canEquip ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NeedsAffix");
+		return canEquip;
 	}
 }
 

--- a/Content/Skills/Ranged/FetidCarapace.cs
+++ b/Content/Skills/Ranged/FetidCarapace.cs
@@ -4,6 +4,7 @@ using PathOfTerraria.Common.Projectiles;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using Terraria.ID;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Skills.Ranged;
 
@@ -58,10 +59,12 @@ public class FetidCarapace : Skill
 		return canUse;
 	}
 
-	public override bool CanEquipSkill(Player player)
+	protected override bool ProtectedCanEquip(Player player, out string failReason)
 	{
 		// TODO: If this needs to be equippable without the affix, figure out that system
-		return player.GetModPlayer<AffixPlayer>().StrengthOf<FetidCarapaceAffix>() > 0;
+		bool canEquip = player.GetModPlayer<AffixPlayer>().StrengthOf<FetidCarapaceAffix>() > 0;
+		failReason = canEquip ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NeedsAffix");
+		return canEquip;
 	}
 
 	internal class CarapaceChunk : SkillProjectile<FetidCarapace>

--- a/Core/UI/SmartUI/IMutuallyExclusiveUI.cs
+++ b/Core/UI/SmartUI/IMutuallyExclusiveUI.cs
@@ -1,0 +1,14 @@
+﻿namespace PathOfTerraria.Core.UI.SmartUI;
+
+/// <summary>
+/// Defines a UI state that cannot be opened alongside another mutually exclusive UI.<br/>
+/// This requires that UI define a Toggle method, which is widely used in this codebase but manually and implicitly.<br/>
+/// Most non-exclusive UI will also have a Toggle.
+/// </summary>
+internal interface IMutuallyExclusiveUI
+{
+	/// <summary>
+	/// Toggles the given UI.
+	/// </summary>
+	public void Toggle();
+}

--- a/Core/UI/SmartUI/SmartUiLoader.cs
+++ b/Core/UI/SmartUI/SmartUiLoader.cs
@@ -98,4 +98,19 @@ internal sealed partial class SmartUiLoader : ModSystem
 			);
 		}
 	}
+
+	/// <summary>
+	/// Clears all <see cref="IMutuallyExclusiveUI"/> that aren't of type <typeparamref name="T"/>.
+	/// </summary>
+	/// <typeparam name="T">The type to NOT call Toggle on.</typeparam>
+	public void ClearMutuallyExclusive<T>() where T : IMutuallyExclusiveUI
+	{
+		foreach (SmartUiState ui in uiStates)
+		{
+			if (ui is not T && ui.Visible && ui is IMutuallyExclusiveUI toggle)
+			{
+				toggle.Toggle();
+			}
+		}
+	}
 }

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -170,7 +170,7 @@ Staff: {
 
 Sword: {
 	Name: Sword
-	AltUse: Summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+	AltUse: Right click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
 
 	Prefixes: {
 		0: Sharp
@@ -254,7 +254,7 @@ Whip: {
 
 Javelin: {
 	Name: Javelin
-	AltUse: Dash towards the cursor, stabbing the first enemy you hit for high damage.
+	AltUse: Right click to dash towards the cursor, stabbing the first enemy you hit for high damage.
 
 	Prefixes: {
 		0: Piercing

--- a/Localization/en-US/Mods.PathOfTerraria.Items.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Items.hjson
@@ -297,7 +297,7 @@ GrimoireItem: {
 }
 
 BatWings: {
-	DisplayName: Bat Wings
+	DisplayName: Pair of Bat Wings
 	Tooltip:
 		'''
 		{$Mods.PathOfTerraria.Misc.GrimoireMaterial}

--- a/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
@@ -1,6 +1,7 @@
 # These are used for the hotbar hover in NewHotbar.cs.
 LevelLine: (Level {0}/{1})
 ManaLine: Costs {0} mana
+NotEnoughMana: Costs [c/FF6666:{0} mana]
 WeaponLine: Must use a {0} weapon
 NoWeaponLine: No weapon required
 NoKeybindLine: No keybind detected
@@ -10,7 +11,12 @@ KeybindLine: Press {0} to use
 NeedsWeapon: "[c/999999:Needs a {0} item]"
 BaseDamage: Deals {0} base damage
 # This is for the hover text in the skills menu.
-CantEquip: Can't equip skill
+CantEquip: Can't equip skill: {0}
+
+Denials: {
+	NotEnoughMana: "[c/999999:Not enough mana]"
+	NeedsAffix: "[c/999999:Needs affix strength]"
+}
 
 # These are the actual localization lines for skills.
 Nova: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #953
Resolves: #952
Resolves: #951
Resolves: #948
Resolves: #946
Resolves: #944
Resolves: #943
Resolves: #942
Resolves: #941
Resolves: #940
Resolves: #939
Resolves: #932

### Description of Work
- Renamed Bat Wings to Pair of Bat Wings to differentiate between itself and vanilla Bat Wings
- Fix skills not having cooldowns
- Split skill CanEquipSkill to itself and ProtectedCanEquip, the latter being the hook - CanEquipSkill checks for mana consistently
- Added failReason for CanEquipSkill for clarity & user experience
- Fixed chests and signs in Ravencrest, giving text to signs
- Renamed EntityModifier.Attackspeed to AttackSpeed
- Fixed IncreasedAttackSpeedAffix being 100x stronger than it should lol
- Made Drawing the Bow quest reward a bow instead of two melee weapons
- Added IMutuallyExclusiveUI to stop multiple of themselves being visible at once
- Fix crash with skill augments
- Fix Javelin alt use hitting friendly npcs
- Added "free day" so players have much more time to complete the tutorial and still prepare in-game
- Stopped skill passive trees from being opened if the skill can't be added
- Added a ton of polish to Fireball projectiles, mostly so it's easier to use on flat ground
- Added "Right click to..." to Sword and Javelin alt use text

### Comments
Whew!