### PR TITLE
fix(#957): Updates text to pair of bat wings for quest condition

### DIFF
--- a/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
@@ -549,7 +549,7 @@ FireMaw: {
 
 MorganaNPC: {
 	DisplayName: Morgana
-	QuestCondition: Collect 2 Owl Feathers and 1 Bat Wing
+	QuestCondition: Collect 2 Owl Feathers and 1 Pair of Bat Wings
 	SummonCondition: Summon the Owl with the Grimoire
 
 	Dialogue: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #957 

### Description of Work
* Fixes incorrect text displayed for quest step

### Comments
* This should probably be improved to just pull the name from the quest requirements instead of being translations, otherwise this will become a message