### PR TITLE
Augmentations as Allocatables

### DIFF
--- a/Common/Mechanics/Allocatable.cs
+++ b/Common/Mechanics/Allocatable.cs
@@ -22,7 +22,7 @@ public abstract class Allocatable
 	}
 
 	private Vector2 _size;
-	public Vector2 Size
+	public virtual Vector2 Size
 	{
 		get
 		{
@@ -54,13 +54,13 @@ public abstract class Allocatable
 	/// <summary> Should check <see cref="CanAllocate"/> before being called. </summary>
 	public virtual void OnAllocate(Player player)
 	{
-		Level++;
+		Level = Math.Min(Level + 1, MaxLevel);
 	}
 
 	/// <summary> Should check <see cref="CanDeallocate"/> before being called. </summary>
 	public virtual void OnDeallocate(Player player)
 	{
-		Level--;
+		Level = Math.Max(Level - 1, 0);
 	}
 
 	public virtual bool CanAllocate(Player player)

--- a/Common/Mechanics/Skill.Stats.cs
+++ b/Common/Mechanics/Skill.Stats.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Systems.Skills;
+using System.Linq;
 
 namespace PathOfTerraria.Common.Mechanics;
 
@@ -47,7 +48,7 @@ public abstract partial class Skill
 			}
 		}
 
-		foreach (SkillAugment a in tree.Augments)
+		foreach (SkillAugment a in tree.Augments.Select(x => x.Augment))
 		{
 			if (a is null)
 			{

--- a/Common/Mechanics/SkillNode.cs
+++ b/Common/Mechanics/SkillNode.cs
@@ -16,7 +16,7 @@ public abstract class SkillNode(SkillTree tree) : Allocatable
 		return base.CanDeallocate(player) && Connections < 2;
 	}
 
-	private int Connections
+	protected int Connections
 	{
 		get
 		{

--- a/Common/Mechanics/SkillSpecial.cs
+++ b/Common/Mechanics/SkillSpecial.cs
@@ -51,25 +51,25 @@ public abstract class SkillSpecial(SkillTree tree) : SkillNode(tree)
 
 	public override void OnAllocate(Player player)
 	{
-		Level++;
+		base.OnAllocate(player);
 		Tree.Specialization = this;
 	}
 
 	public override void OnDeallocate(Player player)
 	{
-		Level--;
+		base.OnDeallocate(player);
 		Tree.Specialization = null;
 	}
 
 	/// <summary> Whether this skill specialization can be used. </summary>
 	public override bool CanAllocate(Player player)
 	{
-		return base.CanAllocate(player) && Tree.Specialization is null;
+		return Connections > 0 && Tree.Specialization is null;
 	}
 
 	/// <summary> Whether this skill specialization can be refunded. </summary>
 	public override bool CanDeallocate(Player player)
 	{
-		return base.CanDeallocate(player) && Tree.Specialization == this;
+		return Connections < 2 && Tree.Specialization == this;
 	}
 }

--- a/Common/UI/AllocatableElement.cs
+++ b/Common/UI/AllocatableElement.cs
@@ -14,12 +14,12 @@ internal class AllocatableElement : SmartUiElement
 	public static Asset<Texture2D> GlowAlpha = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/GlowAlpha");
 	public static Asset<Texture2D> StarAlpha = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/StarAlpha");
 
-	public readonly Allocatable Node;
+	public readonly SkillNode Node;
 
 	private int _flashTimer;
 	private int _redFlashTimer;
 
-	public AllocatableElement(Allocatable node)
+	public AllocatableElement(SkillNode node)
 	{
 		var size = node.Size.ToPoint();
 

--- a/Common/UI/SkillsTree/SkillSelectionPanel.cs
+++ b/Common/UI/SkillsTree/SkillSelectionPanel.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.Skills;
+using PathOfTerraria.Content.SkillAugments;
 using PathOfTerraria.Core.UI.SmartUI;
 using System.Collections.Generic;
 using Terraria.Localization;
@@ -62,19 +63,20 @@ internal class SkillSelectionPanel : SmartUiElement
 		Append(_skillTreeInnerPanel);
 
 		List<SkillNode> list = SkillTree.Current.Nodes;
+		int spareSlotCounter = 0;
+
+		for (int i = 0; i < SkillTree.DefaultAugmentCount; i++)
+		{
+			_skillTreeInnerPanel.Append(new AugmentSlotElement(spareSlotCounter++, SkillTree.Current.Augments[i].Unlocked));
+		}
+
 		foreach (SkillNode node in list)
 		{
-			var element = new AllocatableElement(node);
+			UIElement element = (node is SpareSlot) ? new AugmentSlotElement(spareSlotCounter++, true, node) : new AllocatableElement(node);
 			element.Left.Set(node.TreePos.X - node.Size.X / 2, 0.5f);
 			element.Top.Set(node.TreePos.Y - node.Size.Y / 2, 0.5f);
 
 			_skillTreeInnerPanel.AppendAsDraggable(element);
-		}
-
-		int augmentSlots = SelectedSkill.Tree.Augments.Length;
-		for (int i = 0; i < augmentSlots; i++)
-		{
-			_skillTreeInnerPanel.Append(new AugmentSlotElement(i));
 		}
 
 		UIButton<string> closeButton = new(Language.GetTextValue("Mods.PathOfTerraria.UI.SkillUI.Back"))

--- a/Content/SkillAugments/SpareSlot.cs
+++ b/Content/SkillAugments/SpareSlot.cs
@@ -1,0 +1,14 @@
+﻿using PathOfTerraria.Common.Mechanics;
+using PathOfTerraria.Common.Systems.Skills;
+using PathOfTerraria.Common.UI.SkillsTree;
+
+namespace PathOfTerraria.Content.SkillAugments;
+
+public sealed class SpareSlot(SkillTree tree) : SkillNode(tree)
+{
+	public override string TexturePath => $"{PoTMod.ModName}/Assets/UI/AugmentFrame";
+	public override string DisplayName => string.Empty;
+	public override string DisplayTooltip => string.Empty;
+
+	public override Vector2 Size => new(AugmentSlotElement.SquareSize);
+}

--- a/Content/SkillSpecials/FireNova.cs
+++ b/Content/SkillSpecials/FireNova.cs
@@ -3,6 +3,4 @@ using PathOfTerraria.Common.Systems.Skills;
 
 namespace PathOfTerraria.Content.SkillSpecials;
 
-internal class FireNova(SkillTree tree) : SkillSpecial(tree)
-{
-}
+internal class FireNova(SkillTree tree) : SkillSpecial(tree);

--- a/Content/SkillSpecials/IceNova.cs
+++ b/Content/SkillSpecials/IceNova.cs
@@ -3,6 +3,4 @@ using PathOfTerraria.Common.Systems.Skills;
 
 namespace PathOfTerraria.Content.SkillSpecials;
 
-internal class IceNova(SkillTree tree) : SkillSpecial(tree)
-{
-}
+internal class IceNova(SkillTree tree) : SkillSpecial(tree);

--- a/Content/SkillSpecials/LightningNova.cs
+++ b/Content/SkillSpecials/LightningNova.cs
@@ -3,6 +3,4 @@ using PathOfTerraria.Common.Systems.Skills;
 
 namespace PathOfTerraria.Content.SkillSpecials;
 
-internal class LightningNova(SkillTree tree) : SkillSpecial(tree)
-{
-}
+internal class LightningNova(SkillTree tree) : SkillSpecial(tree);

--- a/Content/SkillTrees/NovaTree.cs
+++ b/Content/SkillTrees/NovaTree.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Systems.Skills;
+using PathOfTerraria.Content.SkillAugments;
 using PathOfTerraria.Content.SkillPassives;
 using PathOfTerraria.Content.Skills.Magic;
 using PathOfTerraria.Content.SkillSpecials;
@@ -24,8 +25,9 @@ internal class NovaTree : SkillTree
 		var flashFire = new FlashFire(this) { TreePos = new Vector2(-200, -100) };
 		var combustive = new Combustive(this) { TreePos = new Vector2(-300, -100) };
 		var scorching = new ScorchingTouch(this) { TreePos = new Vector2(-340, 100) };
+		var slot = new SpareSlot(this) { TreePos = new Vector2(0, -170) };
 
-		AddNodes(anchor, novaFire, novaIce, novaLightning, efficiency);
+		AddNodes(anchor, novaFire, novaIce, novaLightning, efficiency, slot);
 		AddNodes(novaLightning, thunderClaps);
 		AddNodes(novaFire, igniteChance, flashFire, combustive, scorching);
 		AddNodes(novaLightning, shockChance);


### PR DESCRIPTION
﻿### Link Issues
Resolves: #876

### Description of Work
- Allows augmentation slots to be placed as nodes in skill trees
- Fixes incorrect visuals when certain skill tree nodes are loaded
