### PR TITLE
adds in custom spawning conditions for ISpawnInRavencrestNPC

### DIFF
--- a/Common/NPCs/ISpawnInRavencrestNPC.cs
+++ b/Common/NPCs/ISpawnInRavencrestNPC.cs
@@ -9,4 +9,13 @@ internal interface ISpawnInRavencrestNPC : ILoadable
 {
 	public Point16 TileSpawn { get; }
 	public int Type { get; }
+
+	/// <summary>
+	/// Whether this NPC can spawn. Useful for characters that can spawn in Ravencrest, but only under specific conditions.<br/>
+	/// By default, only spawns NPCs during worldgen.
+	/// </summary>
+	public bool CanSpawn(bool worldGen)
+	{
+		return worldGen;
+	}
 }

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode.BoCDomain;
+﻿using PathOfTerraria.Common.NPCs;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode.BoCDomain;
 using PathOfTerraria.Common.Systems.Networking.Handlers;
 using PathOfTerraria.Common.Systems.StructureImprovementSystem;
 using PathOfTerraria.Common.Systems.VanillaModifications;
@@ -22,7 +23,7 @@ public class RavencrestSystem : ModSystem
 {
 	public readonly HashSet<string> HasOverworldNPC = [];
 
-	internal static readonly Dictionary<string, ImprovableStructure> structures = [];
+	internal static readonly Dictionary<string, ImprovableStructure> Structures = [];
 
 	public bool SpawnedRaven = false;
 	public bool SpawnedScout = false;
@@ -32,31 +33,31 @@ public class RavencrestSystem : ModSystem
 
 	public override void Load()
 	{
-		structures.Add("Lodge", new ImprovableStructure(2)
+		Structures.Add("Lodge", new ImprovableStructure(2)
 		{
 			StructurePath = "Assets/Structures/RavencrestBuildings/Lodge_",
 			Position = new Point(259, 95),
 		});
 
-		structures.Add("Forge", new ImprovableStructure(2)
+		Structures.Add("Forge", new ImprovableStructure(2)
 		{
 			StructurePath = "Assets/Structures/RavencrestBuildings/Forge_",
 			Position = new Point(195, 109)
 		});
 
-		structures.Add("Burrow", new ImprovableStructure(2)
+		Structures.Add("Burrow", new ImprovableStructure(2)
 		{
 			StructurePath = "Assets/Structures/RavencrestBuildings/Burrow_",
 			Position = new Point(800, 129)
 		});
     
-		structures.Add("Observatory", new ImprovableStructure(2)
+		Structures.Add("Observatory", new ImprovableStructure(2)
 		{
 			StructurePath = "Assets/Structures/RavencrestBuildings/Observatory_",
 			Position = new Point(107, 122)
 		});
 
-		structures.Add("Library", new ImprovableStructure(2)
+		Structures.Add("Library", new ImprovableStructure(2)
 		{
 			StructurePath = "Assets/Structures/RavencrestBuildings/Library_",
 			Position = new Point(604, 94)
@@ -156,7 +157,7 @@ public class RavencrestSystem : ModSystem
 
 	private void RavencrestOneTimeChecks()
 	{
-		foreach (ImprovableStructure structure in structures.Values)
+		foreach (ImprovableStructure structure in Structures.Values)
 		{
 			structure.Place();
 		}
@@ -194,6 +195,18 @@ public class RavencrestSystem : ModSystem
 				NPC.NewNPC(Entity.GetSource_TownSpawn(), pos.X * 16, pos.Y * 16, type);
 			}
 		}
+
+		foreach (ISpawnInRavencrestNPC npc in ModContent.GetContent<ISpawnInRavencrestNPC>())
+		{
+			if (!npc.CanSpawn(false))
+			{
+				continue;
+			}
+
+			int x = npc.TileSpawn.X * 16;
+			int y = npc.TileSpawn.Y * 16;
+			NPC.NewNPC(Entity.GetSource_TownSpawn(), x, y, npc.Type);
+		}
 	}
 
 	public static void UpgradeBuilding(string name, int level = -1)
@@ -204,7 +217,7 @@ public class RavencrestSystem : ModSystem
 			return;
 		}
 
-		ImprovableStructure structure = structures[name];
+		ImprovableStructure structure = Structures[name];
 		level = level == -1 ? structure.StructureIndex + 1 : level;
 		structure.Change(level);
 	}
@@ -227,7 +240,7 @@ public class RavencrestSystem : ModSystem
 		SpawnedRaven = tag.GetBool("spawnedRaven");
 		EntrancePosition = tag.Get<Point16>("entrance");
 
-		foreach (KeyValuePair<string, ImprovableStructure> structure in structures)
+		foreach (KeyValuePair<string, ImprovableStructure> structure in Structures)
 		{
 			if (tag.TryGet(structure.Key + "Name", out byte index))
 			{
@@ -253,7 +266,7 @@ public class RavencrestSystem : ModSystem
 		tag.Add("spawnedRaven", SpawnedRaven);
 		tag.Add("entrance", EntrancePosition);
 
-		foreach (KeyValuePair<string, ImprovableStructure> structure in structures)
+		foreach (KeyValuePair<string, ImprovableStructure> structure in Structures)
 		{
 			tag.Add(structure.Key + "Name", (byte)structure.Value.StructureIndex);
 		}
@@ -273,7 +286,7 @@ public class RavencrestSystem : ModSystem
 		OneTimeCheckDone = false;
 		SpawnedMorvenPos = null;
 
-		foreach (KeyValuePair<string, ImprovableStructure> item in structures)
+		foreach (KeyValuePair<string, ImprovableStructure> item in Structures)
 		{
 			item.Value.Change(0);
 		}

--- a/Common/Subworlds/RavencrestSubworld.cs
+++ b/Common/Subworlds/RavencrestSubworld.cs
@@ -76,12 +76,15 @@ internal class RavencrestSubworld : MappingWorld
 		Main.spawnTileX = 398;
 		Main.spawnTileY = 141;
 
-		//WorldFile.LoadWorld_Version2(new BinaryReader(new MemoryStream(PoTMod.Instance.GetFileBytes("Assets/Structures/Worlds/RavencrestSubworld.wld"))));
-
 		StructureTools.PlaceByOrigin("Assets/Structures/Worlds/Ravencrest_Structure", new Point16(40, 22), Vector2.Zero);
 
 		foreach (ISpawnInRavencrestNPC npc in ModContent.GetContent<ISpawnInRavencrestNPC>())
 		{
+			if (!npc.CanSpawn(true))
+			{
+				continue;
+			}
+
 			int x = npc.TileSpawn.X * 16;
 			int y = npc.TileSpawn.Y * 16;
 			NPC.NewNPC(Entity.GetSource_TownSpawn(), x, y, npc.Type);

--- a/Content/NPCs/Town/BlacksmithNPC.cs
+++ b/Content/NPCs/Town/BlacksmithNPC.cs
@@ -22,7 +22,7 @@ namespace PathOfTerraria.Content.NPCs.Town;
 [AutoloadHead]
 public class BlacksmithNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverheadDialogueNPC
 {
-	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.structures["Forge"].Position + new Point(20, 20)).ToPoint16();
+	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.Structures["Forge"].Position + new Point(20, 20)).ToPoint16();
 	OverheadDialogueInstance IOverheadDialogueNPC.CurrentDialogue { get; set; }
 
 	public override void SetStaticDefaults()

--- a/Content/NPCs/Town/EldricNPC.cs
+++ b/Content/NPCs/Town/EldricNPC.cs
@@ -1,25 +1,33 @@
+using NPCUtils;
+using PathOfTerraria.Common.NPCs;
 using PathOfTerraria.Common.NPCs.Components;
+using PathOfTerraria.Common.NPCs.Dialogue;
 using PathOfTerraria.Common.NPCs.Effects;
-using Terraria.GameContent;
-using Terraria.ID;
-using Terraria.Localization;
-using PathOfTerraria.Common.Utilities.Extensions;
+using PathOfTerraria.Common.NPCs.OverheadDialogue;
+using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
-using PathOfTerraria.Common.NPCs.OverheadDialogue;
-using PathOfTerraria.Common.NPCs.Dialogue;
-using Terraria.GameContent.Bestiary;
-using NPCUtils;
-using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Utilities.Extensions;
 using PathOfTerraria.Content.Items.Quest;
 using Terraria.DataStructures;
+using Terraria.GameContent;
+using Terraria.GameContent.Bestiary;
+using Terraria.ID;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.NPCs.Town;
 
 [AutoloadHead]
-public sealed class EldricNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC
+public sealed class EldricNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpawnInRavencrestNPC
 {
+	Point16 ISpawnInRavencrestNPC.TileSpawn => RavencrestSystem.Structures["Observatory"].Position.ToPoint16();
 	OverheadDialogueInstance IOverheadDialogueNPC.CurrentDialogue { get; set; }
+
+	bool ISpawnInRavencrestNPC.CanSpawn(bool worldGen)
+	{
+		return NPC.downedSlimeKing && !worldGen;
+	}
 
 	public override void SetStaticDefaults()
 	{
@@ -165,5 +173,15 @@ public sealed class EldricNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC
 	{
 		quest = Quest.GetLocalPlayerInstance<EoCQuest>();
 		return !quest.Completed;
+	}
+
+	public bool ForceSpawnInTavern()
+	{
+		return Quest.GetLocalPlayerInstance<EoCQuest>().Active || QuestUnlockManager.CanStartQuest<EoCQuest>();
+	}
+
+	public float SpawnChanceInTavern()
+	{
+		return NPC.downedBoss1 ? 0.2f : 0f;
 	}
 }

--- a/Content/NPCs/Town/GarrickNPC.cs
+++ b/Content/NPCs/Town/GarrickNPC.cs
@@ -3,7 +3,6 @@ using PathOfTerraria.Common.NPCs.Effects;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
-using PathOfTerraria.Common.Utilities;
 using PathOfTerraria.Common.Utilities.Extensions;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;

--- a/Content/NPCs/Town/HunterNPC.cs
+++ b/Content/NPCs/Town/HunterNPC.cs
@@ -24,7 +24,7 @@ namespace PathOfTerraria.Content.NPCs.Town;
 [AutoloadHead]
 public class HunterNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverheadDialogueNPC
 {
-	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.structures["Lodge"].Position + new Point(18, 28)).ToPoint16();
+	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.Structures["Lodge"].Position + new Point(18, 28)).ToPoint16();
 	OverheadDialogueInstance IOverheadDialogueNPC.CurrentDialogue { get; set; }
 
 	public override void SetStaticDefaults()

--- a/Content/NPCs/Town/MorganaNPC.cs
+++ b/Content/NPCs/Town/MorganaNPC.cs
@@ -22,7 +22,7 @@ namespace PathOfTerraria.Content.NPCs.Town;
 [LegacyName("WitchNPC")]
 public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 {
-	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.structures["Burrow"].Position + new Point(18, 20)).ToPoint16();
+	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.Structures["Burrow"].Position + new Point(18, 20)).ToPoint16();
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/NPCs/Town/WizardNPC.cs
+++ b/Content/NPCs/Town/WizardNPC.cs
@@ -22,7 +22,7 @@ namespace PathOfTerraria.Content.NPCs.Town;
 [AutoloadHead]
 public class WizardNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverheadDialogueNPC
 {
-	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.structures["Library"].Position + new Point(50, 15)).ToPoint16();
+	Point16 ISpawnInRavencrestNPC.TileSpawn => (RavencrestSystem.Structures["Library"].Position + new Point(50, 15)).ToPoint16();
 	OverheadDialogueInstance IOverheadDialogueNPC.CurrentDialogue { get; set; }
 
 	public override void SetStaticDefaults()


### PR DESCRIPTION
﻿### Link Issues
Resolves: #984

### Description of Work
- Adds in spawning conditions to ISpawnRavencrestNPC, defaulting to always on worldgen
- Eldric now spawns in his observatory after beating the King Slime