### PR TITLE
Misc QA

### DIFF
--- a/Common/NPCs/AffixFreeNPCs.cs
+++ b/Common/NPCs/AffixFreeNPCs.cs
@@ -78,6 +78,12 @@ internal class AffixFreeNPCs : GlobalNPC
 		ArpgNPC.NoAffixesSet.Add(NPCID.SeekerHead);
 		ArpgNPC.NoAffixesSet.Add(NPCID.SeekerBody);
 		ArpgNPC.NoAffixesSet.Add(NPCID.SeekerTail);
+		ArpgNPC.NoAffixesSet.Add(NPCID.TombCrawlerHead);
+		ArpgNPC.NoAffixesSet.Add(NPCID.TombCrawlerBody);
+		ArpgNPC.NoAffixesSet.Add(NPCID.TombCrawlerTail);
+		ArpgNPC.NoAffixesSet.Add(NPCID.DuneSplicerHead);
+		ArpgNPC.NoAffixesSet.Add(NPCID.DuneSplicerBody);
+		ArpgNPC.NoAffixesSet.Add(NPCID.DuneSplicerTail);
 		ArpgNPC.NoAffixesSet.Add(NPCID.MoonLordFreeEye); // All moon lord parts should be affixless
 		ArpgNPC.NoAffixesSet.Add(NPCID.MoonLordHand);
 		ArpgNPC.NoAffixesSet.Add(NPCID.MoonLordHead);

--- a/Common/Systems/Affixes/ItemTypes/DefenseAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/DefenseAffixes.cs
@@ -27,7 +27,7 @@ internal class ResistanceHelmetAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.DebuffResistance *= Value / 100;
+		modifier.DebuffResistance *= 1 + Value / 100f;
 	}
 }
 
@@ -35,7 +35,7 @@ internal class BuffBoostHelmetAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.BuffBonus *= Value / 100;
+		modifier.BuffBonus *= 1 + Value / 100f;
 	}
 }
 

--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -154,7 +154,7 @@ internal class ArpgNPC : GlobalNPC
 	{
 		//We only want to trigger these changes on hostile non-boss, mortal & damageable non-critter NPCs that aren't in NoAffixesSet
 		if (npc.IsABestiaryIconDummy || npc.friendly || npc.boss || Main.gameMenu || npc.immortal || npc.dontTakeDamage || NPCID.Sets.ProjectileNPC[npc.type]
-			|| npc.CountsAsACritter || NoAffixesSet.Contains(npc.type))
+			|| npc.CountsAsACritter || npc.realLife != -1 || NoAffixesSet.Contains(npc.type))
 		{
 			return;
 		}

--- a/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
@@ -17,6 +17,8 @@ namespace PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 
 internal class HunterStartQuest : Quest
 {
+	public static readonly HashSet<int> FloatingEyes = [NPCID.DemonEye, NPCID.DemonEye2, NPCID.DemonEyeOwl, NPCID.DemonEyeSpaceship, NPCID.CataractEye, NPCID.CataractEye2, NPCID.DialatedEye, NPCID.DialatedEye2, NPCID.GreenEye, NPCID.GreenEye2, NPCID.PurpleEye, NPCID.PurpleEye2, NPCID.SleepyEye, NPCID.SleepyEye2, NPCID.WanderingEye];
+
 	public override QuestTypes QuestType => QuestTypes.MainStoryQuestAct1;
 	public override int NPCQuestGiver => ModContent.NPCType<HunterNPC>();
 
@@ -53,7 +55,7 @@ internal class HunterStartQuest : Quest
 				Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<WoodenBow>());
 				return true;
 			}),
-			new KillCount(npc => npc.type is NPCID.DemonEye or NPCID.Crimera or NPCID.EaterofSouls, 10, this.GetLocalization("Kill.FloatingMisc")),
+			new KillCount(npc => npc.type is NPCID.Crimera or NPCID.EaterofSouls || FloatingEyes.Contains(npc.type) || NPCID.Sets.DemonEyes[npc.type], 10, this.GetLocalization("Kill.FloatingMisc")),
 			new InteractWithNPC(ModContent.NPCType<HunterNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.HunterNPC.Dialogue.Quest3"),
 			[
 				new GiveItem(40, ItemID.Wood), new(10, ItemID.Gel), new(20, ItemID.IronBar, ItemID.LeadBar)

--- a/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
@@ -17,8 +17,6 @@ namespace PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 
 internal class HunterStartQuest : Quest
 {
-	public static readonly HashSet<int> FloatingEyes = [NPCID.DemonEye, NPCID.DemonEye2, NPCID.DemonEyeOwl, NPCID.DemonEyeSpaceship, NPCID.CataractEye, NPCID.CataractEye2, NPCID.DialatedEye, NPCID.DialatedEye2, NPCID.GreenEye, NPCID.GreenEye2, NPCID.PurpleEye, NPCID.PurpleEye2, NPCID.SleepyEye, NPCID.SleepyEye2, NPCID.WanderingEye];
-
 	public override QuestTypes QuestType => QuestTypes.MainStoryQuestAct1;
 	public override int NPCQuestGiver => ModContent.NPCType<HunterNPC>();
 
@@ -55,7 +53,7 @@ internal class HunterStartQuest : Quest
 				Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<WoodenBow>());
 				return true;
 			}),
-			new KillCount(npc => npc.type is NPCID.Crimera or NPCID.EaterofSouls || FloatingEyes.Contains(npc.type) || NPCID.Sets.DemonEyes[npc.type], 10, this.GetLocalization("Kill.FloatingMisc")),
+			new KillCount(npc => npc.type is NPCID.Crimera or NPCID.EaterofSouls || NPCID.Sets.DemonEyes[npc.type], 10, this.GetLocalization("Kill.FloatingMisc")),
 			new InteractWithNPC(ModContent.NPCType<HunterNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.HunterNPC.Dialogue.Quest3"),
 			[
 				new GiveItem(40, ItemID.Wood), new(10, ItemID.Gel), new(20, ItemID.IronBar, ItemID.LeadBar)

--- a/Content/Items/Gear/Weapons/Staff/StaffProjectile.cs
+++ b/Content/Items/Gear/Weapons/Staff/StaffProjectile.cs
@@ -127,7 +127,7 @@ internal abstract class StaffProjectile : ModProjectile
 			{
 				ReleaseProjectile();
 			}
-			else // Don't play sound when empowered, it's annoying
+			else if (Owner.CheckMana(Owner.HeldItem.mana)) // Don't play sound when empowered, it's annoying
 			{
 				SoundEngine.PlaySound(SoundID.MaxMana, Projectile.Center);
 			}

--- a/Content/Items/Gear/Weapons/Staff/StaffProjectile.cs
+++ b/Content/Items/Gear/Weapons/Staff/StaffProjectile.cs
@@ -127,9 +127,9 @@ internal abstract class StaffProjectile : ModProjectile
 			{
 				ReleaseProjectile();
 			}
-			else if (Owner.CheckMana(Owner.HeldItem.mana)) // Don't play sound when empowered, it's annoying
+			else if (Owner.CheckMana(Owner.HeldItem.mana)) // Don't play the sound if the user is lacking mana
 			{
-				SoundEngine.PlaySound(SoundID.MaxMana, Projectile.Center);
+				SoundEngine.PlaySound(SoundID.MaxMana, Projectile.Center); // Don't play sound when empowered, it's annoying
 			}
 
 			for (int i = 0; i < 4; ++i)

--- a/Content/Tiles/ArcaneObeliskTile.cs
+++ b/Content/Tiles/ArcaneObeliskTile.cs
@@ -25,7 +25,6 @@ public class ArcaneObeliskTile : ModTile
 		TileID.Sets.HasOutlines[Type] = true;
 
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style3x4);
-		TileObjectData.newTile.Origin = new(1, 3);
 
 		TileObjectData.newTile.DrawYOffset = 4;
 		TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook((int i, int j, int _, int _, int _, int _) =>
@@ -38,7 +37,7 @@ public class ArcaneObeliskTile : ModTile
 		TileObjectData.newTile.Height = 5;
 		TileObjectData.newTile.CoordinateHeights = [16, 16, 16, 16, 16];
 
-		TileObjectData.newTile.Origin = Point16.Zero;
+		TileObjectData.newTile.Origin = new(1, 4);
 
 		TileObjectData.addTile(Type);
 

--- a/Content/Tiles/ArcaneObeliskTile.cs
+++ b/Content/Tiles/ArcaneObeliskTile.cs
@@ -25,6 +25,7 @@ public class ArcaneObeliskTile : ModTile
 		TileID.Sets.HasOutlines[Type] = true;
 
 		TileObjectData.newTile.CopyFrom(TileObjectData.Style3x4);
+		TileObjectData.newTile.Origin = new(1, 3);
 
 		TileObjectData.newTile.DrawYOffset = 4;
 		TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook((int i, int j, int _, int _, int _, int _) =>


### PR DESCRIPTION
﻿### Link Issues
Resolves: #956
Resolves: #967
Resolves: #959
Resolves: #977
Resolves: #972
Resolves #980

### Description of Work
- Prevents NPCs that share a health pool from being magical, such as worms
- Corrected Arcane Obelisk tile anchor
- Fixed "+% longer beneficial buffs" affix reducing the amount of time you get
- Fixed Demon Eye variations not counting for "Drawing the Bow"
- Prevented staves from playing a charge sound if they don't have enough mana to cast
- Changed Ephemeral Raven to vanish after reaching the Ravencrest entrance