### PR TITLE
swap fix, nerf codex stuff, remove morgana shop

### DIFF
--- a/Common/Systems/Affixes/ItemTypes/SkillAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/SkillAffixes.cs
@@ -9,7 +9,7 @@ internal class MoltenShellAffix : ItemAffix
 {
 	public override void OnLoad()
 	{
-		OnSwapPlayer.OnSwapMainItem += EnableMoltenShellIfOpen;
+		OnSwapPlayer.LateSwapMainItem += EnableMoltenShellIfOpen;
 	}
 
 	private void EnableMoltenShellIfOpen(Player self, Item newItem, Item oldItem)
@@ -26,7 +26,7 @@ internal class BloodSiphonAffix : ItemAffix
 {
 	public override void OnLoad()
 	{
-		OnSwapPlayer.OnSwapMainItem += EnableBloodSiphonIfOpen;
+		OnSwapPlayer.LateSwapMainItem += EnableBloodSiphonIfOpen;
 	}
 
 	private void EnableBloodSiphonIfOpen(Player self, Item newItem, Item oldItem)
@@ -43,7 +43,7 @@ internal class FetidCarapaceAffix : ItemAffix
 {
 	public override void OnLoad()
 	{
-		OnSwapPlayer.OnSwapMainItem += EnableFetidCarapaceIfOpen;
+		OnSwapPlayer.LateSwapMainItem += EnableFetidCarapaceIfOpen;
 	}
 
 	private void EnableFetidCarapaceIfOpen(Player self, Item newItem, Item oldItem)

--- a/Content/Items/Gear/Weapons/Tome/Codex.cs
+++ b/Content/Items/Gear/Weapons/Tome/Codex.cs
@@ -17,5 +17,6 @@ internal class Codex : Spellbook
 		base.SetDefaults();
 
 		Item.damage = 50;
+		Item.mana = 18;
 	}
 }

--- a/Content/Items/Gear/Weapons/Tome/Lexicon.cs
+++ b/Content/Items/Gear/Weapons/Tome/Lexicon.cs
@@ -17,5 +17,6 @@ internal class Lexicon : Spellbook
 		base.SetDefaults();
 
 		Item.damage = 35;
+		Item.mana = 14;
 	}
 }

--- a/Content/Items/Gear/Weapons/Tome/Manuscript.cs
+++ b/Content/Items/Gear/Weapons/Tome/Manuscript.cs
@@ -16,6 +16,7 @@ internal class Manuscript : Spellbook
 	{
 		base.SetDefaults();
 
-		Item.damage = 20;
+		Item.damage = 16;
+		Item.mana = 8;
 	}
 }

--- a/Content/Items/Gear/Weapons/Tome/Spellbook.cs
+++ b/Content/Items/Gear/Weapons/Tome/Spellbook.cs
@@ -24,7 +24,7 @@ internal class Spellbook : Gear
 	{
 		base.SetDefaults();
 
-		Item.damage = 10;
+		Item.damage = 8;
 		Item.width = Item.height = 40;
 		Item.useTime = Item.useAnimation = 20;
 		Item.useStyle = ItemUseStyleID.Shoot;
@@ -33,6 +33,7 @@ internal class Spellbook : Gear
 		Item.knockBack = 1;
 		Item.UseSound = SoundID.Item20;
 		Item.shootSpeed = 25f;
+		Item.mana = 3;
 
 		PoTInstanceItemData data = this.GetInstanceData();
 		data.ItemType = ItemType.Wand;

--- a/Content/NPCs/Town/MorganaNPC.cs
+++ b/Content/NPCs/Town/MorganaNPC.cs
@@ -82,7 +82,7 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 
 	public override void SetChatButtons(ref string button, ref string button2)
 	{
-		button = Language.GetTextValue("LegacyInterface.28");
+		//button = Language.GetTextValue("LegacyInterface.28");
 
 		Quest quest = DetermineNewestQuest();
 		button2 = !quest.CanBeStarted ? "" : Language.GetOrRegister($"Mods.{PoTMod.ModName}.NPCs.Quest").Value;
@@ -102,7 +102,7 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 	{
 		if (firstButton)
 		{
-			shopName = "Shop";
+			//shopName = "Shop";
 			return;
 		}
 
@@ -121,13 +121,13 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 		}
 	}
 
-	public override void AddShops()
-	{
-		new NPCShop(Type)
-			.Add<WoodenBow>()
-			.Add<WoodenShortBow>()
-			.Register();
-	}
+	//public override void AddShops()
+	//{
+	//	new NPCShop(Type)
+	//		.Add<WoodenBow>()
+	//		.Add<WoodenShortBow>()
+	//		.Register();
+	//}
 
 	public override ITownNPCProfile TownNPCProfile()
 	{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #970
Resolves: #974 

### Description of Work
- Nerfs Manuscript and all other of its unfinished book brethren, adding mana and reducing damage slightly
- Removes Morganas shop entirely
- Made equipping something like the Molten Dangpa, getting the affix, removing the Molten Shell skill manually, exiting, re-entering the world not say "Couldn't equip skill" and instead equipping the skill successfully

### Comments
I removed Morgana's shop as I don't know what she could sell. This is trivial to change in the future.
The skill equip change could be seen as making it harder to disable a skill you don't want, which is fair - I made it because players would be confused as to why they need to equip the skill manually, and/or why the chat says "can't equip" randomly. I could make it so that the first "swap" marks itself as such (i.e. joining the world and going from no prior item to any item), and for skills to not be modified on the first swap for ease of use.