### PR TITLE
Minor fixes

### DIFF
--- a/Common/Systems/ModPlayers/ExpModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExpModPlayer.cs
@@ -1,7 +1,4 @@
-﻿using PathOfTerraria.Common.Subworlds.RavencrestContent;
-using PathOfTerraria.Common.Systems.PassiveTreeSystem;
-using PathOfTerraria.Common.World.Passes;
-using SubworldLibrary;
+﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using Terraria.Audio;
 using Terraria.Localization;
 using Terraria.ModLoader.IO;
@@ -26,13 +23,16 @@ public class ExpModPlayer : ModPlayer
 			return;
 		}
 
-		SoundEngine.PlaySound(new SoundStyle($"{PoTMod.ModName}/Assets/Sounds/Tier5"));
-
 		Exp -= NextLevel;
 		Level++;
 
-		Main.NewText(Language.GetText("Mods.PathOfTerraria.Misc.Experience.LevelUp").WithFormatArgs(Level).Value, new Color(145, 255, 160));
-		Main.NewText(Language.GetText("Mods.PathOfTerraria.Misc.Experience.SkillUp"), new Color(255, 255, 160));
+		if (Main.myPlayer == Player.whoAmI && !Main.dedServ) //Only use level up text and sounds on the local client, despite progress being otherwise synced
+		{
+			SoundEngine.PlaySound(new SoundStyle($"{PoTMod.ModName}/Assets/Sounds/Tier5"));
+
+			Main.NewText(Language.GetText("Mods.PathOfTerraria.Misc.Experience.LevelUp").WithFormatArgs(Level).Value, new Color(145, 255, 160));
+			Main.NewText(Language.GetText("Mods.PathOfTerraria.Misc.Experience.SkillUp"), new Color(255, 255, 160));
+		}
 
 		Player.GetModPlayer<PassiveTreePlayer>().Points++;
 	}

--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -105,24 +105,28 @@ internal class TutorialUIState : UIState
 		bool canGoNext = CanGotoNextStep();
 		DrawBacked(spriteBatch, pos + new Vector2(-168, 110), Localize("Next"), true, !canGoNext ? null : new Action(IncrementStep), !canGoNext);
 		DrawBacked(spriteBatch, pos + new Vector2(-56, 110), Localize("SkipStep"), true, new Action(IncrementStep));
-		DrawBacked(spriteBatch, pos + new Vector2(56, 110), Localize("SkipGuide"), true, () =>
+		
+		if (Step < 12) //Don't allow "SkipGuide" if not applicable anymore
 		{
-			Step = 12;
-
-			if (!Quest.GetLocalPlayerInstance<FirstQuest>().CanBeStarted)
+			DrawBacked(spriteBatch, pos + new Vector2(56, 110), Localize("SkipGuide"), true, () =>
 			{
-				Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<FirstQuest>();
-			}
+				Step = 12;
 
-			if (Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Level == 0)
-			{
-				Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Exp += Main.LocalPlayer.GetModPlayer<ExpModPlayer>().NextLevel + 1;
-			}
-			
-			Item.NewItem(new EntitySource_Misc("Quest"), Main.LocalPlayer.Bottom, ModContent.ItemType<ArcaneObeliskItem>());
+				if (!Quest.GetLocalPlayerInstance<FirstQuest>().CanBeStarted)
+				{
+					Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<FirstQuest>();
+				}
 
-			IncrementStep();
-		});
+				if (Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Level == 0)
+				{
+					Main.LocalPlayer.GetModPlayer<ExpModPlayer>().Exp += Main.LocalPlayer.GetModPlayer<ExpModPlayer>().NextLevel + 1;
+				}
+
+				Main.LocalPlayer.QuickSpawnItem(new EntitySource_Misc("Quest"), ModContent.ItemType<ArcaneObeliskItem>());
+
+				IncrementStep();
+			});
+		}
 
 		if (!_hide && !skipSecondHideButton)
 		{
@@ -211,7 +215,7 @@ internal class TutorialUIState : UIState
 		}
 		else if (Step == 12)
 		{
-			plr.QuickSpawnItem(Entity.GetSource_NaturalSpawn(), ModContent.ItemType<ArcaneObeliskItem>());
+			plr.QuickSpawnItem(new EntitySource_Misc("Quest"), ModContent.ItemType<ArcaneObeliskItem>());
 		}
 		else if (Step == 13)
 		{

--- a/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
+++ b/Content/Items/Gear/Weapons/Grimoire/GrimoireItem.cs
@@ -4,7 +4,6 @@ using PathOfTerraria.Common.UI.GrimoireSelection;
 using PathOfTerraria.Content.Projectiles.Summoner;
 using PathOfTerraria.Core.Items;
 using PathOfTerraria.Core.UI.SmartUI;
-using System.Collections.Generic;
 using Terraria.DataStructures;
 using Terraria.ID;
 
@@ -42,6 +41,8 @@ internal class GrimoireItem : Gear
 		Item.shoot = ProjectileID.PurificationPowder; // The value here is irrelevant
 		Item.channel = true;
 		Item.noMelee = true;
+
+		Item.shopCustomPrice = Item.buyPrice(silver: 10);
 
 		PoTInstanceItemData data = this.GetInstanceData();
 		data.ItemType = ItemType.Grimoire;

--- a/Content/NPCs/Town/MorganaNPC.cs
+++ b/Content/NPCs/Town/MorganaNPC.cs
@@ -82,7 +82,11 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 
 	public override void SetChatButtons(ref string button, ref string button2)
 	{
-		//button = Language.GetTextValue("LegacyInterface.28");
+		WitchStartQuest startQuest = Quest.GetLocalPlayerInstance<WitchStartQuest>();
+		if (startQuest.Active || startQuest.Completed) //Don't display the shop until the player has received the first quest
+		{
+			button = Language.GetTextValue("LegacyInterface.28"); //Shop
+		}
 
 		Quest quest = DetermineNewestQuest();
 		button2 = !quest.CanBeStarted ? "" : Language.GetOrRegister($"Mods.{PoTMod.ModName}.NPCs.Quest").Value;
@@ -102,7 +106,7 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 	{
 		if (firstButton)
 		{
-			//shopName = "Shop";
+			shopName = "Shop";
 			return;
 		}
 
@@ -110,7 +114,7 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 
 		if (quest is WitchStartQuest)
 		{
-			Item.NewItem(new EntitySource_Gift(NPC), NPC.Hitbox, ModContent.ItemType<GrimoireItem>());
+			Main.LocalPlayer.QuickSpawnItem(new EntitySource_Gift(NPC), ModContent.ItemType<GrimoireItem>());
 			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.Quest");
 			Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<WitchStartQuest>();
 		}
@@ -121,13 +125,12 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 		}
 	}
 
-	//public override void AddShops()
-	//{
-	//	new NPCShop(Type)
-	//		.Add<WoodenBow>()
-	//		.Add<WoodenShortBow>()
-	//		.Register();
-	//}
+	public override void AddShops()
+	{
+		new NPCShop(Type)
+			.Add<GrimoireItem>()
+			.Register();
+	}
 
 	public override ITownNPCProfile TownNPCProfile()
 	{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1030
Resolves: #1026
Resolves: #1025
Resolves: #1024

### Description of Work
- Prevented the "Skip all" tutorial prompt from appearing if the player is already on the last step
- Fixed player level message and sounds activating for all clients
- Added the Grimoire to Morgana's shop after the initial is awarded
- Fixed Arcane Obelisk not being awarded when the "Skip all" tutorial prompt is used in multiplayer
- Fixed the Grimoire not being awarded by Morgana in multiplayer
