### PR TITLE
Fix for ItemSlots tooltips

### DIFF
--- a/Common/UI/Armor/Elements/UIDefaultArmor.cs
+++ b/Common/UI/Armor/Elements/UIDefaultArmor.cs
@@ -21,7 +21,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 		Width = StyleDimension.FromPixels(UIArmorInventory.ArmorPageWidth);
 		Height = StyleDimension.FromPixels(UIArmorInventory.ArmorPageHeight);
 
-		var wings = new UIHoverImageItemSlot(DefaultFrameTexture, WingsIconTexture, ref Player.armor, 4, ItemSlot.Context.EquipAccessory)
+		var wings = new UIHoverImageItemSlot(DefaultFrameTexture, WingsIconTexture, ref Player.armor, 4, $"Mods.{PoTMod.ModName}.UI.Slots.10", ItemSlot.Context.EquipAccessory)
 		{
 			ActiveScale = 1.15f,
 			ActiveRotation = MathHelper.ToRadians(1f)
@@ -34,7 +34,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(wings);
 
-		var helmet = new UIHoverImageItemSlot(DefaultFrameTexture, HelmetIconTexture, ref Player.armor, 0, ItemSlot.Context.EquipArmor)
+		var helmet = new UIHoverImageItemSlot(DefaultFrameTexture, HelmetIconTexture, ref Player.armor, 0, $"Mods.{PoTMod.ModName}.UI.Slots.0", ItemSlot.Context.EquipArmor)
 		{
 			HAlign = 0.5f,
 			VAlign = 0f,
@@ -49,7 +49,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(helmet);
 
-		var necklace = new UIHoverImageItemSlot(DefaultFrameTexture, NecklaceIconTexture, ref Player.armor, 5, ItemSlot.Context.EquipAccessory)
+		var necklace = new UIHoverImageItemSlot(DefaultFrameTexture, NecklaceIconTexture, ref Player.armor, 5, $"Mods.{PoTMod.ModName}.UI.Slots.5", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 1f,
 			VAlign = 0f,
@@ -64,7 +64,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(necklace);
 		
-		var weapon = new UIHoverImageItemSlot(DefaultFrameTexture, WeaponIconTexture, ref Player.inventory, 0)
+		var weapon = new UIHoverImageItemSlot(DefaultFrameTexture, WeaponIconTexture, ref Player.inventory, 0, $"Mods.{PoTMod.ModName}.UI.Slots.4")
 		{
 			HAlign = 0f,
 			VAlign = 0.33f,
@@ -79,7 +79,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(weapon);
 
-		var chest = new UIHoverImageItemSlot(DefaultFrameTexture, ChestIconTexture, ref Player.armor, 1, ItemSlot.Context.EquipArmor)
+		var chest = new UIHoverImageItemSlot(DefaultFrameTexture, ChestIconTexture, ref Player.armor, 1, $"Mods.{PoTMod.ModName}.UI.Slots.1", ItemSlot.Context.EquipArmor)
 		{
 			HAlign = 0.5f,
 			VAlign = 0.33f,
@@ -94,7 +94,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(chest);
 
-		var offhand = new UIHoverImageItemSlot(DefaultFrameTexture, OffhandIconTexture, ref Player.armor, 6, ItemSlot.Context.EquipAccessory)
+		var offhand = new UIHoverImageItemSlot(DefaultFrameTexture, OffhandIconTexture, ref Player.armor, 6, $"Mods.{PoTMod.ModName}.UI.Slots.6", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 1f,
 			VAlign = 0.33f,
@@ -109,7 +109,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(offhand);
 
-		var leftRing = new UIHoverImageItemSlot(DefaultFrameTexture, RingIconTexture, ref Player.armor, 7, ItemSlot.Context.EquipAccessory)
+		var leftRing = new UIHoverImageItemSlot(DefaultFrameTexture, RingIconTexture, ref Player.armor, 7, $"Mods.{PoTMod.ModName}.UI.Slots.7", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 0f,
 			VAlign = 0.66f,
@@ -124,7 +124,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(leftRing);
 
-		var legs = new UIHoverImageItemSlot(DefaultFrameTexture, LegsIconTexture, ref Player.armor, 2, ItemSlot.Context.EquipArmor)
+		var legs = new UIHoverImageItemSlot(DefaultFrameTexture, LegsIconTexture, ref Player.armor, 2, $"Mods.{PoTMod.ModName}.UI.Slots.2", ItemSlot.Context.EquipArmor)
 		{
 			HAlign = 0.5f,
 			VAlign = 0.66f,
@@ -139,7 +139,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(legs);
 
-		var rightRing = new UIHoverImageItemSlot(DefaultFrameTexture, RingIconTexture, ref Player.armor, 8, ItemSlot.Context.EquipAccessory)
+		var rightRing = new UIHoverImageItemSlot(DefaultFrameTexture, RingIconTexture, ref Player.armor, 8, $"Mods.{PoTMod.ModName}.UI.Slots.8", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 1f,
 			VAlign = 0.66f,
@@ -154,7 +154,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 
 		Append(rightRing);
 
-		var leftMiscellaneous = new UIHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture, ref Player.armor, 9, ItemSlot.Context.EquipAccessory)
+		var leftMiscellaneous = new UIHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture, ref Player.armor, 9, $"Mods.{PoTMod.ModName}.UI.Slots.9", ItemSlot.Context.EquipAccessory)
 		{
 			VAlign = 1f,
 			ActiveScale = 1.15f,
@@ -166,7 +166,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 		
 		Append(leftMiscellaneous);
 		
-		var middleMiscellaneous = new UIHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture, ref Player.armor, 3, ItemSlot.Context.EquipAccessory)
+		var middleMiscellaneous = new UIHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture, ref Player.armor, 3, $"Mods.{PoTMod.ModName}.UI.Slots.3", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 0.5f,
 			VAlign = 1f,

--- a/Common/UI/Armor/Elements/UIDyeArmor.cs
+++ b/Common/UI/Armor/Elements/UIDyeArmor.cs
@@ -17,7 +17,7 @@ public sealed class UIDyeArmor : UIArmorPage
 		Width = StyleDimension.FromPixels(UIArmorInventory.ArmorPageWidth);
 		Height = StyleDimension.FromPixels(UIArmorInventory.ArmorPageHeight);
 
-		var wings = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 4, ItemSlot.Context.EquipDye)
+		var wings = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 4, $"Mods.{PoTMod.ModName}.UI.Slots.10", ItemSlot.Context.EquipDye)
 		{
 			ActiveScale = 1.15f,
 			ActiveRotation = MathHelper.ToRadians(1f)
@@ -30,7 +30,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(wings);
 
-		var helmet = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 0, ItemSlot.Context.EquipDye)
+		var helmet = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 0, $"Mods.{PoTMod.ModName}.UI.Slots.0", ItemSlot.Context.EquipDye)
 		{
 			HAlign = 0.5f,
 			VAlign = 0f,
@@ -45,7 +45,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(helmet);
 
-		var necklace = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 5, ItemSlot.Context.EquipDye)
+		var necklace = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 5, $"Mods.{PoTMod.ModName}.UI.Slots.5", ItemSlot.Context.EquipDye)
 		{
 			HAlign = 1f,
 			VAlign = 0f,
@@ -60,7 +60,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(necklace);
 
-		var chest = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 1, ItemSlot.Context.EquipDye)
+		var chest = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 1, $"Mods.{PoTMod.ModName}.UI.Slots.1", ItemSlot.Context.EquipDye)
 		{
 			HAlign = 0.5f,
 			VAlign = 0.33f,
@@ -75,7 +75,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(chest);
 
-		var offhand = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 6, ItemSlot.Context.EquipAccessory)
+		var offhand = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 6, $"Mods.{PoTMod.ModName}.UI.Slots.6", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 1f,
 			VAlign = 0.33f,
@@ -90,7 +90,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(offhand);
 
-		var leftRing = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 7, ItemSlot.Context.EquipDye)
+		var leftRing = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 7, $"Mods.{PoTMod.ModName}.UI.Slots.7", ItemSlot.Context.EquipDye)
 		{
 			HAlign = 0f,
 			VAlign = 0.66f,
@@ -105,7 +105,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(leftRing);
 		
-		var legs = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 2, ItemSlot.Context.EquipDye)
+		var legs = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 2, $"Mods.{PoTMod.ModName}.UI.Slots.2", ItemSlot.Context.EquipDye)
 		{
 			HAlign = 0.5f,
 			VAlign = 0.66f,
@@ -120,7 +120,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(legs);
 
-		var rightRing = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 8, ItemSlot.Context.EquipDye)
+		var rightRing = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.dye, 8, $"Mods.{PoTMod.ModName}.UI.Slots.8", ItemSlot.Context.EquipDye)
 		{
 			HAlign = 1f,
 			VAlign = 0.66f,
@@ -135,7 +135,7 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(rightRing);
 		
-		var leftMiscellaneous = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.armor, 9, ItemSlot.Context.EquipAccessory)
+		var leftMiscellaneous = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.armor, 9, $"Mods.{PoTMod.ModName}.UI.Slots.9", ItemSlot.Context.EquipAccessory)
 		{
 			VAlign = 1f,
 			ActiveScale = 1.15f,
@@ -147,7 +147,7 @@ public sealed class UIDyeArmor : UIArmorPage
 		
 		Append(leftMiscellaneous);
 		
-		var middleMiscellaneous = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.armor, 3, ItemSlot.Context.EquipAccessory)
+		var middleMiscellaneous = new UIHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, ref Player.armor, 3, $"Mods.{PoTMod.ModName}.UI.Slots.3", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 0.5f,
 			VAlign = 1f,

--- a/Common/UI/Armor/Elements/UIVanityArmor.cs
+++ b/Common/UI/Armor/Elements/UIVanityArmor.cs
@@ -15,7 +15,7 @@ public sealed class UIVanityArmor : UIArmorPage
 		Width = StyleDimension.FromPixels(UIArmorInventory.ArmorPageWidth);
 		Height = StyleDimension.FromPixels(UIArmorInventory.ArmorPageHeight);
 
-		var wings = new UIHoverImageItemSlot(VanityFrameTexture, WingsIconTexture, ref Player.armor, 14, ItemSlot.Context.EquipAccessoryVanity)
+		var wings = new UIHoverImageItemSlot(VanityFrameTexture, WingsIconTexture, ref Player.armor, 14, $"Mods.{PoTMod.ModName}.UI.Slots.10", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			ActiveScale = 1.15f,
 			ActiveRotation = MathHelper.ToRadians(1f)
@@ -28,7 +28,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(wings);
 
-		var helmet = new UIHoverImageItemSlot(VanityFrameTexture, HelmetIconTexture, ref Player.armor, 10, ItemSlot.Context.EquipArmorVanity)
+		var helmet = new UIHoverImageItemSlot(VanityFrameTexture, HelmetIconTexture, ref Player.armor, 10, $"Mods.{PoTMod.ModName}.UI.Slots.0", ItemSlot.Context.EquipArmorVanity)
 		{
 			HAlign = 0.5f,
 			VAlign = 0f,
@@ -43,7 +43,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(helmet);
 
-		var necklace = new UIHoverImageItemSlot(VanityFrameTexture, NecklaceIconTexture, ref Player.armor, 15, ItemSlot.Context.EquipAccessoryVanity)
+		var necklace = new UIHoverImageItemSlot(VanityFrameTexture, NecklaceIconTexture, ref Player.armor, 15, $"Mods.{PoTMod.ModName}.UI.Slots.5", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 1f,
 			VAlign = 0f,
@@ -58,7 +58,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(necklace);
 
-		var chest = new UIHoverImageItemSlot(VanityFrameTexture, ChestIconTexture, ref Player.armor, 11, ItemSlot.Context.EquipArmorVanity)
+		var chest = new UIHoverImageItemSlot(VanityFrameTexture, ChestIconTexture, ref Player.armor, 11, $"Mods.{PoTMod.ModName}.UI.Slots.1", ItemSlot.Context.EquipArmorVanity)
 		{
 			HAlign = 0.5f,
 			VAlign = 0.33f,
@@ -73,7 +73,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(chest);
 
-		var offhand = new UIHoverImageItemSlot(VanityFrameTexture, OffhandIconTexture, ref Player.armor, 16, ItemSlot.Context.EquipAccessoryVanity)
+		var offhand = new UIHoverImageItemSlot(VanityFrameTexture, OffhandIconTexture, ref Player.armor, 16, $"Mods.{PoTMod.ModName}.UI.Slots.6", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 1f,
 			VAlign = 0.33f,
@@ -88,7 +88,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(offhand);
 
-		var leftRing = new UIHoverImageItemSlot(VanityFrameTexture, RingIconTexture, ref Player.armor, 17, ItemSlot.Context.EquipAccessoryVanity)
+		var leftRing = new UIHoverImageItemSlot(VanityFrameTexture, RingIconTexture, ref Player.armor, 17, $"Mods.{PoTMod.ModName}.UI.Slots.7", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 0f,
 			VAlign = 0.66f,
@@ -103,7 +103,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(leftRing);
 
-		var legs = new UIHoverImageItemSlot(VanityFrameTexture, LegsIconTexture, ref Player.armor, 12, ItemSlot.Context.EquipArmorVanity)
+		var legs = new UIHoverImageItemSlot(VanityFrameTexture, LegsIconTexture, ref Player.armor, 12, $"Mods.{PoTMod.ModName}.UI.Slots.2", ItemSlot.Context.EquipArmorVanity)
 		{
 			HAlign = 0.5f,
 			VAlign = 0.66f,
@@ -118,7 +118,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(legs);
 
-		var rightRing = new UIHoverImageItemSlot(VanityFrameTexture, RingIconTexture, ref Player.armor, 18, ItemSlot.Context.EquipAccessoryVanity)
+		var rightRing = new UIHoverImageItemSlot(VanityFrameTexture, RingIconTexture, ref Player.armor, 18, $"Mods.{PoTMod.ModName}.UI.Slots.8", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 1f,
 			VAlign = 0.66f,
@@ -133,7 +133,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		Append(rightRing);
 		
-		var leftMiscellaneous = new UIHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, ref Player.armor, 9, ItemSlot.Context.EquipAccessory)
+		var leftMiscellaneous = new UIHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, ref Player.armor, 9, $"Mods.{PoTMod.ModName}.UI.Slots.9", ItemSlot.Context.EquipAccessory)
 		{
 			VAlign = 1f,
 			ActiveScale = 1.15f,
@@ -145,7 +145,7 @@ public sealed class UIVanityArmor : UIArmorPage
 		
 		Append(leftMiscellaneous);
 		
-		var middleMiscellaneous = new UIHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, ref Player.armor, 3, ItemSlot.Context.EquipAccessory)
+		var middleMiscellaneous = new UIHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, ref Player.armor, 3, $"Mods.{PoTMod.ModName}.UI.Slots.3", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 0.5f,
 			VAlign = 1f,

--- a/Common/UI/Elements/UIHoverImageItemSlot.cs
+++ b/Common/UI/Elements/UIHoverImageItemSlot.cs
@@ -54,6 +54,17 @@ public class UIHoverImageItemSlot : UIImageItemSlot
 	{
 	}
 
+	public UIHoverImageItemSlot(
+		Asset<Texture2D> backgroundTexture,
+		Asset<Texture2D> iconTexture,
+		ref Item[]? inventory,
+		int slot,
+		string key,
+		int context = ItemSlot.Context.InventoryItem	
+	) : base(backgroundTexture, iconTexture, ref inventory, slot, context, key)
+	{
+	}
+
 	public override void Update(GameTime gameTime)
 	{
 		base.Update(gameTime);

--- a/Common/UI/Elements/UIImageItemSlot.cs
+++ b/Common/UI/Elements/UIImageItemSlot.cs
@@ -1,8 +1,10 @@
 using ReLogic.Content;
+using System.Xml.Linq;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
 using Terraria.GameInput;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.Elements;
@@ -95,6 +97,15 @@ public class UIImageItemSlot : UIElement
 	/// </remarks>
 	public int Slot;
 
+
+	/// <summary>
+	///    The key to look for in Localization for tooltip hover
+	/// </summary>
+	/// <remarks>
+	///     Will not have any effect if <see cref="Key" /> is <c>null</c> or not provided.
+	/// </remarks>
+	public string Key;
+
 	public UIImageItemSlot(
 		Asset<Texture2D> backgroundTexture,
 		Asset<Texture2D> iconTexture,
@@ -121,6 +132,25 @@ public class UIImageItemSlot : UIElement
 		Inventory = inventory;
 		Slot = slot;
 		Context = context;
+	}
+
+	public UIImageItemSlot(
+		Asset<Texture2D> backgroundTexture,
+		Asset<Texture2D> iconTexture,
+		ref Item[]? inventory,
+		int slot,
+		int context = ItemSlot.Context.InventoryItem,
+		string key = null
+	)
+	{
+		BackgroundTexture = backgroundTexture;
+		IconTexture = iconTexture;
+
+		Inventory = inventory;
+		Slot = slot;
+		Context = context;
+
+		Key = key;
 	}
 
 	/// <summary>
@@ -223,6 +253,13 @@ public class UIImageItemSlot : UIElement
 		if (WrapsAroundInventory)
 		{
 			ItemSlot.Handle(Inventory, Context, Slot);
+
+			if (Key != null)
+			{
+				Main.hoverItemName = Language.GetTextValue(Key);
+				Main.HoverItem = Inventory[Slot].Clone();
+				Main.HoverItem.tooltipContext = Context;
+			}	
 		}
 		else
 		{
@@ -232,7 +269,7 @@ public class UIImageItemSlot : UIElement
 
 			Item = item;
 		}
-
+		
 		Main.LocalPlayer.mouseInterface = true;
 	}
 

--- a/Localization/en-US/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.UI.hjson
@@ -11,6 +11,20 @@ Gear: {
 	}
 }
 
+Slots: {
+	0: Helmet
+	1: Chest
+	2: Legs
+	3: Accessory 2
+	4: Weapon
+	5: Necklace
+	6: Offhand
+	7: Left Ring
+	8: Right Ring
+	9: Accessory 1
+	10: Wings
+}
+
 BaseDamage: Base Damage: {0}
 Lives: lives left
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: https://github.com/Path-of-Terraria/PathOfTerraria/issues/1091

### Description of Work
Added new constructor for UIImageSlots which takes a key for custom localized tooltip
Added important keys and localization for item slots
Added Functionality to display custom tooltip instead of vanilla ones

### Comments
<img width="378" height="529" alt="image" src="https://github.com/user-attachments/assets/417ef7cf-af52-4671-baa1-ba6d7eec95ae" />
