### PR TITLE
Added chance for bat wings to drop from all types of pre-hardmode bats

### DIFF
--- a/Content/Items/Pickups/GrimoirePickups/BatWings.cs
+++ b/Content/Items/Pickups/GrimoirePickups/BatWings.cs
@@ -9,9 +9,23 @@ internal class BatWings : GrimoirePickup
 
 	public override void AddDrops(NPC npc, ref NPCLoot loot)
 	{
-		if (npc.type == NPCID.CaveBat || npc.type == NPCID.JungleBat)
+		switch (npc.type)
 		{
-			loot.AddCommon<BatWings>(npc.type == NPCID.JungleBat ? 15 : 20);
+			case NPCID.CaveBat:
+				loot.AddCommon<BatWings>(20);
+				break;
+			case NPCID.JungleBat:
+				loot.AddCommon<BatWings>(15);
+				break;
+			case NPCID.IceBat:
+				loot.AddCommon<BatWings>(15);
+				break;
+			case NPCID.SporeBat:
+				loot.AddCommon<BatWings>(15);
+				break;
+			case NPCID.Hellbat:
+				loot.AddCommon<BatWings>(10);
+				break;
 		}
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: Adding consistency with all bat types dropping bat wings.

### Description of Work
Made a switch statement which has 5 cases, CaveBat, JungleBat, IceBat, SporeBat, and Hellbat. 

### Comments
Hellbat is a higher chance due to being harder to kill.