### PR TITLE
Fixed %inc minion damage node doing nothing

### DIFF
--- a/Common/Data/Passives/Passives.json
+++ b/Common/Data/Passives/Passives.json
@@ -229,7 +229,7 @@
 		}
 	},
 	{
-		"internalIdentifier": "IncreasedMinionDamagePassive",
+		"internalIdentifier": "IncreasedSummonDamagePassive",
 		"referenceId": 17,
 		"maxLevel": 3,
 		"connections": [

--- a/Content/Passives/SummonPassives.cs
+++ b/Content/Passives/SummonPassives.cs
@@ -6,8 +6,19 @@ namespace PathOfTerraria.Content.Passives;
 
 internal class IncreasedMinionDamagePassive : Passive
 {
-	public override void BuffPlayer(Player player)
+	public override void OnLoad()
 	{
+		PathOfTerrariaPlayerEvents.ModifyHitNPCWithProjEvent += BuffMinions;
+	}
+
+	private void BuffMinions(Player player, Projectile proj, NPC target, ref NPC.HitModifiers modifiers)
+	{
+		int level = player.GetModPlayer<PassiveTreePlayer>().GetCumulativeLevel(Name);
+		
+		if (proj.minion)
+		{
+			modifiers.FinalDamage += 0.1f * level;
+		}
 	}
 }
 
@@ -35,6 +46,7 @@ internal class IncreasedWhipDamage : Passive
 
 internal class IncreasedWhipSpeed : Passive
 {
+	
 }
 
 internal class WhipModsItem : GlobalItem


### PR DESCRIPTION
﻿### Link Issues
Resolves:
The old minion damage node was not coded to do anything
### Description of Work
The %inc minion damage node now increases only minion damage, not whip. This should result in a decent buff for summoners.

### Comments
Copied the ballista code mostly for increasing specifically minion damage. 
