### PR TITLE
QA changes

### DIFF
--- a/Common/Subworlds/BossDomains/Prehardmode/DeerDomain/DeerclopsSystem.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/DeerDomain/DeerclopsSystem.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.DataStructures;
+﻿using System.IO;
+using Terraria.DataStructures;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode.DeerDomain;
@@ -9,11 +10,25 @@ internal class DeerclopsSystem : ModSystem
 
 	public override void SaveWorldData(TagCompound tag)
 	{
-		tag.Add("antler", AntlerLocation);
+		tag["antler"] = AntlerLocation;
 	}
 
 	public override void LoadWorldData(TagCompound tag)
 	{
 		AntlerLocation = tag.Get<Point16>("antler");
+	}
+
+	public override void NetSend(BinaryWriter writer)
+	{
+		writer.Write((ushort)AntlerLocation.X);
+		writer.Write((ushort)AntlerLocation.Y);
+	}
+
+	public override void NetReceive(BinaryReader reader)
+	{
+		ushort x = reader.ReadUInt16();
+		ushort y = reader.ReadUInt16();
+
+		AntlerLocation = new(x, y);
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/SkillAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/SkillAffixes.cs
@@ -17,7 +17,7 @@ internal class MoltenShellAffix : ItemAffix
 		if (newItem.type == ModContent.ItemType<MoltenDangpa>())
 		{
 			SkillCombatPlayer skillCombatPlayer = self.GetModPlayer<SkillCombatPlayer>();
-			skillCombatPlayer.TryAddSkill(new MoltenShield());
+			skillCombatPlayer.TryAddSkill(new MoltenShield(), true);
 		}
 	}
 }
@@ -34,7 +34,7 @@ internal class BloodSiphonAffix : ItemAffix
 		if (newItem.type == ModContent.ItemType<Bloodclotter>())
 		{
 			SkillCombatPlayer skillCombatPlayer = self.GetModPlayer<SkillCombatPlayer>();
-			skillCombatPlayer.TryAddSkill(new BloodSiphon());
+			skillCombatPlayer.TryAddSkill(new BloodSiphon(), true);
 		}
 	}
 }
@@ -51,7 +51,7 @@ internal class FetidCarapaceAffix : ItemAffix
 		if (newItem.type == ModContent.ItemType<Rottenbone>())
 		{
 			SkillCombatPlayer skillCombatPlayer = self.GetModPlayer<SkillCombatPlayer>();
-			skillCombatPlayer.TryAddSkill(new FetidCarapace());
+			skillCombatPlayer.TryAddSkill(new FetidCarapace(), true);
 		}
 	}
 }

--- a/Common/Systems/ModPlayers/SkillCombatPlayer.cs
+++ b/Common/Systems/ModPlayers/SkillCombatPlayer.cs
@@ -99,20 +99,6 @@ internal class SkillCombatPlayer : ModPlayer
 		}
 	}
 
-	public override void PostUpdate()
-	{
-		for (int i = 0; i < HotbarSkills.Length; i++)
-		{
-			Skill skill = HotbarSkills[i];
-
-			if (skill is not null && !skill.CanEquipSkill(Player, out _))
-			{
-				HotbarSkills[i] = null;
-				continue;
-			}
-		}
-	}
-
 	public override void SaveData(TagCompound tag)
 	{
 		for (int i = 0; i < HotbarSkills.Length; i++)
@@ -185,11 +171,13 @@ internal class SkillCombatPlayer : ModPlayer
 		return false;
 	}
 
-	public bool TryAddSkill(Skill skill)
+	/// <param name="suppress"> Whether to display Main.NewText feedback. </param>
+	public bool TryAddSkill(Skill skill, bool suppress = false)
 	{
-		if (!skill.CanEquipSkill(Player, out string failReason))
+		SkillFailure fail = default;
+		if (!skill.CanEquipSkill(Player, ref fail))
 		{
-			Main.NewText($"Skill cannot be added. ({failReason})");
+			NewText($"Skill cannot be added. ({fail.Description.Value})");
 			return false; // Couldn't equip skill, return false
 		}
 
@@ -197,7 +185,7 @@ internal class SkillCombatPlayer : ModPlayer
 		{
 			if (HotbarSkills[i] != null && HotbarSkills[i].Name == skill.Name)
 			{
-				Main.NewText("Skill already added.");
+				NewText("Skill already added.");
 				return true; // Return true because the skill can be added, it just is equipped already
 			}
 		}
@@ -208,13 +196,22 @@ internal class SkillCombatPlayer : ModPlayer
 			{
 				HotbarSkills[i] = skill;
 				HotbarSkills[i].LevelTo(HotbarSkills[i].Level);
-				Main.NewText("Skill added successfully.");
+
+				NewText("Skill added successfully.");
 				return true; // Equipped skill, return true
 			}
 		}
 
-		Main.NewText("No available space to add the skill.");
+		NewText("No available space to add the skill.");
 		return false; // No space, fail
+
+		void NewText(string value)
+		{
+			if (!suppress)
+			{
+				Main.NewText(value);
+			}
+		}
 	}
 
 	public bool TryRemoveSkill(Skill skill)

--- a/Common/UI/Armor/VanillaUIEdits.cs
+++ b/Common/UI/Armor/VanillaUIEdits.cs
@@ -19,22 +19,7 @@ internal class VanillaUIEdits : ModSystem
 		{
 			ILCursor c = new(il);
 
-			MethodInfo method = typeof(SpriteBatch).GetMethod
-			(
-				nameof(SpriteBatch.Draw),
-				BindingFlags.Public | BindingFlags.Instance,
-				[typeof(Texture2D), typeof(Vector2), typeof(Rectangle?), typeof(Color), typeof(float), typeof(Vector2), typeof(Vector2), typeof(SpriteEffects), typeof(float)]
-			);
-
-			if (!c.TryGotoNext(x => x.MatchCallvirt(method)))
-			{
-				return;
-			}
-
-			if (!c.TryGotoPrev(x => x.MatchLdsfld<Main>(nameof(Main.spriteBatch))))
-			{
-				return;
-			}
+			c.GotoNext(MoveType.After, x => x.MatchStloc2());
 
 			c.Emit(OpCodes.Ldloca_S, (byte)1);
 			c.Emit(OpCodes.Ldloca_S, (byte)2);

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -333,6 +333,11 @@ public sealed class NewHotbar : SmartUiState
 		if (skillRect.Contains(Main.MouseScreen.ToPoint()))
 		{
 			DrawSkillHoverTooltips(skill, skillIndex);
+
+			if (Main.mouseRight && Main.mouseRightRelease)
+			{
+				skillCombatPlayer.HotbarSkills[skillIndex] = null;
+			}
 		}
 	}
 
@@ -356,13 +361,13 @@ public sealed class NewHotbar : SmartUiState
 		if (skill.WeaponType != ItemID.None)
 		{
 			Color color = canUse && failure.WeaponRejected ? Color.Red : Color.White;
-			string text = Language.GetText("Mods.PathOfTerraria.Skills.WeaponLine").WithFormatArgs(skill.WeaponType).Value;
+			string text = Language.GetText("Mods.PathOfTerraria.SkillFailReasons.NeedsWeapon").WithFormatArgs(skill.WeaponType).Value;
 			tooltips.Add(new("WeaponType", $"[c/{color.Hex3()}:{text}]", 0.5f));
 		}
 		
 		if (!canUse && failure.Reason == SkillFailReason.Other)
 		{
-			tooltips.Add(new("OtherDenial", $"[c/FF0000:{failure.OtherReason.Value}]", 0.5f));
+			tooltips.Add(new("Denial", $"[c/FF0000:{failure.Description.Value}]", 0.5f));
 		}
 
 		SkillTooltip noKeybindName = new("NoKeybind", Language.GetText("Mods.PathOfTerraria.Skills.NoKeybindLine").Value, 0);

--- a/Common/UI/SkillsTree/SkillSelectionElement.cs
+++ b/Common/UI/SkillsTree/SkillSelectionElement.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
-using PathOfTerraria.Common.Mechanics;
+﻿using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.UI.Guide;
 using PathOfTerraria.Common.UI.Hotbar;
@@ -31,6 +30,7 @@ internal class SkillSelectionElement : UIElement
 		base.Draw(spriteBatch);
 
 		Texture2D tex = ModContent.Request<Texture2D>(_skill.Texture).Value;
+		SkillFailure fail = default;
 
 		if (tex == null)
 		{
@@ -39,18 +39,18 @@ internal class SkillSelectionElement : UIElement
 
 		if (ContainsPoint(Main.MouseScreen))
 		{
-			if (_skill.CanEquipSkill(Main.LocalPlayer, out string failReason))
+			if (Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>().HasSkill(_skill.Name) || _skill.CanEquipSkill(Main.LocalPlayer, ref fail))
 			{
 				NewHotbar.DrawSkillHoverTooltips(_skill, null, true);
 			}
 			else
 			{
-				Tooltip.SetName(Language.GetTextValue("Mods.PathOfTerraria.Skills.CantEquip", failReason));
+				Tooltip.SetName(Language.GetTextValue("Mods.PathOfTerraria.Skills.CantEquip", fail.Description));
 			}
 		}
 
 		Vector2 position = GetDimensions().Position() + new Vector2(Width.Pixels / 2, Height.Pixels / 2);
-		spriteBatch.Draw(tex, position, null, _skill.CanEquipSkill(Main.LocalPlayer, out _) ? Color.White : Color.Gray, 0f, tex.Size() / 2f, 1f, SpriteEffects.None, 0f);
+		spriteBatch.Draw(tex, position, null, _skill.CanEquipSkill(Main.LocalPlayer, ref fail) ? Color.White : Color.Gray, 0f, tex.Size() / 2f, 1f, SpriteEffects.None, 0f);
 
 		if (Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>().HasSkill(_skill.Name))
 		{

--- a/Content/Skills/Melee/MoltenShield.cs
+++ b/Content/Skills/Melee/MoltenShield.cs
@@ -3,7 +3,6 @@ using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Content.Buffs;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Skills.Melee;
 
@@ -40,11 +39,14 @@ public class MoltenShield : Skill
 		return base.CanUseSkill(player, ref failReason, true);
 	}
 
-	protected override bool ProtectedCanEquip(Player player, out string failReason)
+	protected override bool ProtectedCanEquip(Player player, ref SkillFailure failReason)
 	{
-		// TODO: If this needs to be equippable without the affix, figure out that system
-		bool canEquip = player.GetModPlayer<AffixPlayer>().StrengthOf<MoltenShellAffix>() > 0;
-		failReason = canEquip ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NeedsAffix");
-		return canEquip;
+		if (player.GetModPlayer<AffixPlayer>().StrengthOf<MoltenShellAffix>() <= 0)
+		{
+			failReason = new SkillFailure(SkillFailReason.Other, "MissingAffix");
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/Content/Skills/Ranged/BloodSiphon.cs
+++ b/Content/Skills/Ranged/BloodSiphon.cs
@@ -64,12 +64,15 @@ public class BloodSiphon : Skill
 		return base.CanUseSkill(player, ref failReason, justChecking);
 	}
 
-	protected override bool ProtectedCanEquip(Player player, out string failReason)
+	protected override bool ProtectedCanEquip(Player player, ref SkillFailure failReason)
 	{
-		// TODO: If this needs to be equippable without the affix, figure out that system
-		bool canEquip = player.GetModPlayer<AffixPlayer>().StrengthOf<BloodSiphonAffix>() > 0;
-		failReason = canEquip ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NeedsAffix");
-		return canEquip;
+		if (player.GetModPlayer<AffixPlayer>().StrengthOf<BloodSiphonAffix>() <= 0)
+		{
+			failReason = new SkillFailure(SkillFailReason.Other, "MissingAffix");
+			return false;
+		}
+
+		return true;
 	}
 }
 

--- a/Content/Skills/Ranged/FetidCarapace.cs
+++ b/Content/Skills/Ranged/FetidCarapace.cs
@@ -65,12 +65,15 @@ public class FetidCarapace : Skill
 		return canUse;
 	}
 
-	protected override bool ProtectedCanEquip(Player player, out string failReason)
+	protected override bool ProtectedCanEquip(Player player, ref SkillFailure failReason)
 	{
-		// TODO: If this needs to be equippable without the affix, figure out that system
-		bool canEquip = player.GetModPlayer<AffixPlayer>().StrengthOf<FetidCarapaceAffix>() > 0;
-		failReason = canEquip ? "" : Language.GetTextValue("Mods.PathOfTerraria.Skills.Denials.NeedsAffix");
-		return canEquip;
+		if (player.GetModPlayer<AffixPlayer>().StrengthOf<FetidCarapaceAffix>() <= 0)
+		{
+			failReason = new SkillFailure(SkillFailReason.Other, "MissingAffix");
+			return false;
+		}
+
+		return true;
 	}
 
 	internal class CarapaceChunk : SkillProjectile<FetidCarapace>

--- a/Content/Skills/Ranged/RainOfArrows.cs
+++ b/Content/Skills/Ranged/RainOfArrows.cs
@@ -104,19 +104,19 @@ public class RainOfArrows : Skill
 
 		if (player.HeldItem.consumable)
 		{
-			failReason = new SkillFailure(SkillFailReason.Other, "Other.RangedWeaponConsumable");
+			failReason = new SkillFailure(SkillFailReason.Other, "RangedWeaponConsumable");
 			return false;
 		}
 
 		if (WeaponBlacklist.Contains(player.HeldItem.type))
 		{
-			failReason = new SkillFailure(SkillFailReason.Other, "Other.WeaponInvalid");
+			failReason = new SkillFailure(SkillFailReason.Other, "WeaponInvalid");
 			return false;
 		}
 
 		if (!Main.LocalPlayer.PickAmmo(Main.LocalPlayer.HeldItem, out int _, out float _, out int _, out float _, out int _, true))
 		{
-			failReason = new SkillFailure(SkillFailReason.Other, "Other.NoAmmo");
+			failReason = new SkillFailure(SkillFailReason.Other, "NoAmmo");
 			return false;
 		}
 

--- a/Localization/en-US/Mods.PathOfTerraria.SkillFailReasons.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.SkillFailReasons.hjson
@@ -1,11 +1,6 @@
 NotEnoughMana: Not enough mana to cast
-NeedsMelee: Needs a melee weapon to use
-NeedsRanged: Needs a ranged weapon to use
-NeedsMagic: Needs a magic weapon to use
-NeedsSummon: Needs a summon weapon to use
-
-Other: {
-	RangedWeaponConsumable: Needs a non-consumable weapon
-	WeaponInvalid: Held weapon is invalid for this skill
-	NoAmmo: Needs ammo
-}
+NeedsWeapon: Needs a {0} weapon to use
+RangedWeaponConsumable: Needs a non-consumable weapon
+WeaponInvalid: Held weapon is invalid for this skill
+NoAmmo: Needs ammo
+MissingAffix: Needs affix strength

--- a/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
@@ -2,7 +2,6 @@
 LevelLine: (Level {0}/{1})
 ManaLine: Costs {0} mana
 NotEnoughMana: Costs [c/FF6666:{0} mana]
-WeaponLine: Must use a {0} weapon
 NoWeaponLine: No weapon required
 NoKeybindLine: No keybind detected
 DurationLine: Lasts {0} seconds
@@ -12,11 +11,6 @@ NeedsWeapon: Requires a {0} item to be held
 BaseDamage: Deals {0} base damage
 # This is for the hover text in the skills menu.
 CantEquip: Can't equip skill: {0}
-
-Denials: {
-	NotEnoughMana: "[c/999999:Not enough mana]"
-	NeedsAffix: "[c/999999:Needs affix strength]"
-}
 
 # These are the actual localization lines for skills.
 Nova: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.SkillFailReasons.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.SkillFailReasons.hjson
@@ -1,11 +1,6 @@
 NotEnoughMana: Not enough mana to cast
-NeedsMelee: Needs a melee weapon to use
-NeedsRanged: Needs a ranged weapon to use
-NeedsMagic: Needs a magic weapon to use
-NeedsSummon: Needs a summon weapon to use
-
-Other: {
-	RangedWeaponConsumable: Требуется неконсумное оружие
-	WeaponInvalid: Экипированное оружие не подходит для этого навыка
-	NoAmmo: Требуются боеприпасы
-}
+// NeedsWeapon: Needs a {0} weapon to use
+// RangedWeaponConsumable: Needs a non-consumable weapon
+// WeaponInvalid: Held weapon is invalid for this skill
+// NoAmmo: Needs ammo
+// MissingAffix: Needs affix strength

--- a/Localization/ru-RU/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Skills.hjson
@@ -2,7 +2,6 @@
 LevelLine: (Level {0}/{1})
 ManaLine: Costs {0} mana
 NotEnoughMana: Costs [c/FF6666:{0} mana]
-WeaponLine: Must use a {0} weapon
 NoWeaponLine: No weapon required
 NoKeybindLine: No keybind detected
 DurationLine: Lasts {0} seconds
@@ -12,11 +11,6 @@ NeedsWeapon: Requires a {0} item to be held
 BaseDamage: Deals {0} base damage
 # This is for the hover text in the skills menu.
 CantEquip: Can't equip skill: {0}
-
-Denials: {
-	NotEnoughMana: "[c/999999:Not enough mana]"
-	NeedsAffix: "[c/999999:Needs affix strength]"
-}
 
 # These are the actual localization lines for skills.
 Nova: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1147
Resolves: #1143
Resolves: #1129
Resolves: #1121

### Description of Work
- Prevented boomerangs from traveling through walls unless they're returning to the player
- Skills no longer automatically unspec when `CanEquipSkill` isn't true. Instead, the skill's use is prevented for a reason provided by `SkillFailure`
- Fixed Deerclops compass coordinates not being synced in multiplayer
- Fixed the PvP button not being interactable from the proper position