### PR TITLE
Fixed stat sheet button not being clickable

### DIFF
--- a/Common/UI/QuestPanelButton.cs
+++ b/Common/UI/QuestPanelButton.cs
@@ -77,7 +77,8 @@ public class QuestPanelButton : SmartUiState
 		Texture2D texture = BookTexture.Value;
 		Vector2 pos = new(GetTextureXPosition(), 80);
 
-		var bounding = new Rectangle((int)(pos.X - texture.Width / 1.125f), (int)pos.Y, texture.Width, texture.Height);
+		//Uses just a 64/64 texture size
+		var bounding = new Rectangle((int)(pos.X - texture.Width / 1.125f), (int)pos.Y, 64, 64);
 
 		if (!bounding.Contains(Main.MouseScreen.ToPoint()))
 		{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1131

### Description of Work
- Changed the bounding box of the safe click to be 64x64 as previous params were drawing 2.5x length vertically down.

### Comments
