### PR TITLE
Fixed fishron map domain being queen bee instead

### DIFF
--- a/Content/Items/Consumables/Maps/BossMaps/FishronMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/FishronMap.cs
@@ -1,4 +1,4 @@
-﻿using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+﻿using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Core.Items;
 using SubworldLibrary;
 using Terraria.Localization;
@@ -26,7 +26,7 @@ internal class FishronMap : Map
 
 	protected override void OpenMapInternal()
 	{
-		SubworldSystem.Enter<QueenBeeDomain>();
+		SubworldSystem.Enter<FishronDomain>();
 	}
 
 	public override string GenerateName(string defaultName)


### PR DESCRIPTION
﻿### Link Issues
Resolves: Fishron map being queen bee domain instead.

### Description of Work
	protected override void OpenMapInternal()
	{
		SubworldSystem.Enter<FishronDomain>();
	}
Change the above to FishronDomain instead.

### Comments
