### PR TITLE
Critical strike multiplier calculation fixed

### DIFF
--- a/Content/Passives/CriticalPassives.cs
+++ b/Content/Passives/CriticalPassives.cs
@@ -48,7 +48,7 @@ internal class IncreasedCriticalStrikeMultiplier : Passive
 
 		if (level > 0)
 		{
-			modifiers.CritDamage *= level * AmountPerLevel;
+			modifiers.CritDamage *= 1f + (AmountPerLevel - 1f) * level;
 		}
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1219 

### Description of Work
- Changed it to be 1.05 * level of node to 1 + (0.05) * level to ensure its 5% 10% and 15% crit multi and not 5%, 105% and 205%

### Comments
This will result in a very big nerf for player power, so we will need to watch for player feedback. But this will help power creep alot.