### PR TITLE
Item affix value fix

### DIFF
--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -108,8 +108,8 @@ public static class PoTItemHelper
 	    }
 	}
 
-	///  <summary>
-	/// 		Adds a new random affix to an item. This is used for things like the ascendant shard.
+	///  <summary> 
+	///  Adds a new random affix to an item. This is used for things like the ascendant shard. 
 	///  </summary>
 	///  <param name="item"></param>
 	///  <param name="data"></param>
@@ -134,6 +134,11 @@ public static class PoTItemHelper
 		}
 
 		affix.Value = AffixRegistry.GetRandomAffixValue(affix, GetItemLevel.Invoke(item));
+		if (affix.Value == 0)
+		{
+			return; //If the affix has no value, don't add it. This usually happens when there's no TierData associated with the given item
+		}
+
 		data.Affixes.Add(affix);
 	}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #794

### Description of Work
- Prevented affixes with no value from being applied to items, most notably maps that are too low level to meet any affix tiers