### PR TITLE
fix: Respawn Ravencrest NPCs if they die.

### DIFF
--- a/Common/NPCs/ISpawnInRavencrestNPC.cs
+++ b/Common/NPCs/ISpawnInRavencrestNPC.cs
@@ -3,7 +3,7 @@
 namespace PathOfTerraria.Common.NPCs;
 
 /// <summary>
-/// Spawns the given NPC at <see cref="TileSpawn"/> when Ravencrest is first generated. Otherwise, does nothing.
+/// Spawns the given NPC at <see cref="TileSpawn"/> in Ravencrest.
 /// </summary>
 internal interface ISpawnInRavencrestNPC : ILoadable
 {
@@ -12,10 +12,10 @@ internal interface ISpawnInRavencrestNPC : ILoadable
 
 	/// <summary>
 	/// Whether this NPC can spawn. Useful for characters that can spawn in Ravencrest, but only under specific conditions.<br/>
-	/// By default, only spawns NPCs during worldgen, and not a duplicate just in case.
+	/// By default, only spawns NPCs during worldgen and respawning logic, as long as there is no duplicate NPC.
 	/// </summary>
-	public bool CanSpawn(bool worldGen, bool alreadyExists)
+	public bool CanSpawn(NPCSpawnTimeframe timeframe, bool alreadyExists)
 	{
-		return worldGen && !alreadyExists;
+		return timeframe is NPCSpawnTimeframe.WorldGen or NPCSpawnTimeframe.NaturalSpawn && !alreadyExists;
 	}
 }

--- a/Common/NPCs/NPCSpawnTimeframe.cs
+++ b/Common/NPCs/NPCSpawnTimeframe.cs
@@ -1,0 +1,17 @@
+﻿namespace PathOfTerraria.Common.NPCs;
+
+public enum NPCSpawnTimeframe
+{
+	/// <summary>
+	/// Used only when a world or subworld is first generated.
+	/// </summary>
+	WorldGen,
+	/// <summary>
+	/// Used when a world or subworld is entered, not necessarily for the first time.
+	/// </summary>
+	WorldLoad,
+	/// <summary>
+	/// Used when a subworld attempts to spawn its missing NPCs.
+	/// </summary>
+	NaturalSpawn,
+}

--- a/Common/Subworlds/RavencrestSubworld.cs
+++ b/Common/Subworlds/RavencrestSubworld.cs
@@ -78,17 +78,7 @@ internal class RavencrestSubworld : MappingWorld
 
 		StructureTools.PlaceByOrigin("Assets/Structures/Worlds/Ravencrest_Structure", new Point16(40, 22), Vector2.Zero);
 
-		foreach (ISpawnInRavencrestNPC npc in ModContent.GetContent<ISpawnInRavencrestNPC>())
-		{
-			if (!npc.CanSpawn(true, NPC.AnyNPCs(npc.Type)))
-			{
-				continue;
-			}
-
-			int x = npc.TileSpawn.X * 16;
-			int y = npc.TileSpawn.Y * 16;
-			NPC.NewNPC(Entity.GetSource_TownSpawn(), x, y, npc.Type);
-		}
+		RavencrestSystem.SpawnNativeNpcs(NPCSpawnTimeframe.WorldGen);
 
 		Main.hardMode = false;
 	}

--- a/Content/NPCs/Town/EldricNPC.cs
+++ b/Content/NPCs/Town/EldricNPC.cs
@@ -26,9 +26,9 @@ public sealed class EldricNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, I
 	Point16 ISpawnInRavencrestNPC.TileSpawn => RavencrestSystem.Structures["Observatory"].Position.ToPoint16();
 	OverheadDialogueInstance IOverheadDialogueNPC.CurrentDialogue { get; set; }
 
-	bool ISpawnInRavencrestNPC.CanSpawn(bool worldGen, bool alreadyExists)
+	bool ISpawnInRavencrestNPC.CanSpawn(NPCSpawnTimeframe timeframe, bool alreadyExists)
 	{
-		return (BossTracker.TotalBossesDowned.Contains(NPCID.EyeofCthulhu) || NPC.downedBoss1) && !worldGen && !alreadyExists;
+		return (BossTracker.TotalBossesDowned.Contains(NPCID.EyeofCthulhu) || NPC.downedBoss1) && timeframe is NPCSpawnTimeframe.WorldGen or NPCSpawnTimeframe.NaturalSpawn && !alreadyExists;
 	}
 
 	public override void SetStaticDefaults()


### PR DESCRIPTION
﻿### Link Issues
Resolves #1218

### Changelog
Ravencrest NPCs will now respawn over a short time period if they happen to be dead or missing.

### Comments
This will print "has arrived" in chat. Should a separate key be made for "has returned"?
