### PR TITLE
Added map device quest step in King Slime quest

### DIFF
--- a/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
@@ -5,8 +5,10 @@ using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
 
@@ -27,6 +29,41 @@ internal class KingSlimeQuest : Quest
 	{
 		return 
 		[
+			new InteractWithNPC(ModContent.NPCType<GarrickNPC>(), 
+				Language.GetText("Mods.PathOfTerraria.NPCs.GarrickNPC.Dialogue.QuestResponse"),
+				Language.GetText("Mods.PathOfTerraria.NPCs.GarrickNPC.Dialogue.QuestResponse"),
+				[
+					new GiveItem(5, ItemID.IronBar, ItemID.LeadBar),
+					new GiveItem(5, ItemID.GoldBar, ItemID.PlatinumBar),
+					new GiveItem(1, ItemID.Ruby),
+				], true),
+			//Give the map device to the player once req mats are given
+			new ActionStep((_, _) => 
+			{
+				int npc = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>());
+				int item = Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<Content.Items.Placeable.MapDevice>());
+
+				if (Main.netMode == NetmodeID.MultiplayerClient)
+				{
+					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
+				}
+
+				return true;
+			}),
+			//Give the map as well
+			new ActionStep((_, _) => 
+			{
+				int npc = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>());
+				int item = Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<KingSlimeMap>());
+
+				if (Main.netMode == NetmodeID.MultiplayerClient)
+				{
+					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
+				}
+
+				return true;
+			}),
+
 			new ConditionCheck(_ => SubworldSystem.Current is KingSlimeDomain, 1, this.GetLocalization("EnterDomain")),
 			new ConditionCheck(_ => BossTracker.DownedInDomain<KingSlimeDomain>(NPCID.KingSlime), 1, this.GetLocalization("Kill.KingSlime")),
 			new InteractWithNPC(ModContent.NPCType<GarrickNPC>(), LocalizedText.Empty, this.GetLocalization("ThanksDialogue")) { CountsAsCompletedOnMarker = true }

--- a/Content/Items/Gear/Amulets/Amulet.cs
+++ b/Content/Items/Gear/Amulets/Amulet.cs
@@ -8,6 +8,7 @@ public abstract class Amulet : Gear
 	
 	public override void SetDefaults()
 	{
+		base.SetDefaults();
 		Item.DefaultToAccessory();
 
 		PoTInstanceItemData data = this.GetInstanceData();

--- a/Content/Items/Placeable/MapDevice.cs
+++ b/Content/Items/Placeable/MapDevice.cs
@@ -17,12 +17,16 @@ public class MapDevice : ModItem
 	public override void AddRecipes()
 	{
 		CreateRecipe()
-			.AddIngredient(ItemID.IronBar, 5)
+			.AddRecipeGroup("IronBar", 5)
+			.AddIngredient(ItemID.GoldBar, 5)
+			.AddIngredient(ItemID.Ruby, 1)
 			.AddTile(TileID.WorkBenches)
 			.Register();
 		
 		CreateRecipe()
-			.AddIngredient(ItemID.LeadBar, 5)
+			.AddRecipeGroup("IronBar", 5)
+			.AddIngredient(ItemID.PlatinumBar, 5)
+			.AddIngredient(ItemID.Ruby, 1)
 			.AddTile(TileID.WorkBenches)
 			.Register();
 	}

--- a/Content/NPCs/Town/GarrickNPC.cs
+++ b/Content/NPCs/Town/GarrickNPC.cs
@@ -180,12 +180,6 @@ public sealed class GarrickNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, 
 
 			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.GarrickNPC.Dialogue.Quest");
 			Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<KingSlimeQuest>();
-			int mapItem = Item.NewItem(new EntitySource_Gift(NPC), NPC.Hitbox, ModContent.ItemType<KingSlimeMap>(), noGrabDelay: true);
-
-			if (Main.netMode == NetmodeID.MultiplayerClient)
-			{
-				NetMessage.SendData(MessageID.SyncItem, -1, -1, null, mapItem);
-			}
 		}
 	}
 

--- a/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
@@ -144,7 +144,8 @@ GarrickNPC: {
 		1: Adventurers often fail to tell you of how slimy adventuring is. I am not one of those adventurers. It's extremely slimy.
 		2: Watch your head. Generally good advice, but especially in the King's domain.
 		3: Forge your blade as powerful as you can. Cutting through slime is deceptively difficult.
-		Quest: You may be able to tell - I've not had the best time. Tried to take down the King, almost lost everything. You are the one who restored Ravencrest, yes? Would I ask of you; slay the King Slime on my behalf? I'll reward you greatly. Take this map; I drew it on the long walk back. Good luck!
+		Quest: I've heard of an ancient device that can transport adventurers to distant realms. With the right materials - some metal bars and a gem for focus. I could craft one for you. Bring them to me when you can.
+		QuestResponse: Perfect! Here’s the Map Device as promised. I once faced the King and nearly lost everything. You restored Ravencrest, so now I ask you: slay the King Slime for me. You’ll be well rewarded. Take this map and use it with the device.
 		EoCQuestLine: Oh, the Eye you say? Formidable. I recall Eldric speaking of it, though he almost certainly undersold it. Here, I've been tasked with keeping this. Now is the time to use it.
 		TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.

--- a/Localization/en-US/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Quests.hjson
@@ -37,7 +37,7 @@ Quest: {
 		Name: Kill the King
 		Description: ""
 		EnterDomain: Enter the King's Domain
-		ThanksDialogue: I can hardly believe it. Well, you've succeeded where I failed, stranger. I best get back to it; you will not surprass me again. My thanks, however, are in order.
+		ThanksDialogue: I can hardly believe it. Well, you've succeeded where I failed, stranger. I best get back to it; you will not surpass me again. My thanks, however, are in order.
 		Kill.KingSlime: Kill the King Slime
 	}
 

--- a/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
@@ -144,7 +144,8 @@ GarrickNPC: {
 		// 1: Adventurers often fail to tell you of how slimy adventuring is. I am not one of those adventurers. It's extremely slimy.
 		// 2: Watch your head. Generally good advice, but especially in the King's domain.
 		// 3: Forge your blade as powerful as you can. Cutting through slime is deceptively difficult.
-		// Quest: You may be able to tell - I've not had the best time. Tried to take down the King, almost lost everything. You are the one who restored Ravencrest, yes? Would I ask of you; slay the King Slime on my behalf? I'll reward you greatly. Take this map; I drew it on the long walk back. Good luck!
+		// Quest: I've heard of an ancient device that can transport adventurers to distant realms. With the right materials - some metal bars and a gem for focus. I could craft one for you. Bring them to me when you can.
+		// QuestResponse: Perfect! Here’s the Map Device as promised. I once faced the King and nearly lost everything. You restored Ravencrest, so now I ask you: slay the King Slime for me. You’ll be well rewarded. Take this map and use it with the device.
 		// EoCQuestLine: Oh, the Eye you say? Formidable. I recall Eldric speaking of it, though he almost certainly undersold it. Here, I've been tasked with keeping this. Now is the time to use it.
 		// TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		// CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.

--- a/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
@@ -144,7 +144,8 @@ GarrickNPC: {
 		// 1: Adventurers often fail to tell you of how slimy adventuring is. I am not one of those adventurers. It's extremely slimy.
 		// 2: Watch your head. Generally good advice, but especially in the King's domain.
 		// 3: Forge your blade as powerful as you can. Cutting through slime is deceptively difficult.
-		// Quest: You may be able to tell - I've not had the best time. Tried to take down the King, almost lost everything. You are the one who restored Ravencrest, yes? Would I ask of you; slay the King Slime on my behalf? I'll reward you greatly. Take this map; I drew it on the long walk back. Good luck!
+		// Quest: I've heard of an ancient device that can transport adventurers to distant realms. With the right materials - some metal bars and a gem for focus. I could craft one for you. Bring them to me when you can.
+		// QuestResponse: Perfect! Here’s the Map Device as promised. I once faced the King and nearly lost everything. You restored Ravencrest, so now I ask you: slay the King Slime for me. You’ll be well rewarded. Take this map and use it with the device.
 		// EoCQuestLine: Oh, the Eye you say? Formidable. I recall Eldric speaking of it, though he almost certainly undersold it. Here, I've been tasked with keeping this. Now is the time to use it.
 		// TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		// CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.

--- a/build.txt
+++ b/build.txt
@@ -2,4 +2,4 @@ displayName = Path of Terraria (BETA)
 author = ScottieKnowz & GabeHasWon
 modReferences = SubworldLibrary, HousingAPI
 dllReferences = NPCUtils, StructureHelper
-version = 0.2.6
+version = 0.2.7


### PR DESCRIPTION

﻿### Link Issues
Resolves: #1247 

### Description of Work
-1 spelling mistake change in ThanksDialogue
-Added a first step of the king slime quest before being given a map to craft the map device. 
-Map is now given once map device mats are given to garrick
 -Changed crafting recipe of MapDevice to mirror changes in quest (5 Iron/Lead, 5 Gold/Plat & 1 Ruby. )

### Comments
Garrick gives map device, but technically you can still craft it too. Hopefully doesn't confuse anyone, but this will at least guide the possibly confused players on what to get to progress.