### PR TITLE
Potions now heal 30% max life when used

### DIFF
--- a/Common/Data/Affixes/ArmorAffixes.json
+++ b/Common/Data/Affixes/ArmorAffixes.json
@@ -215,26 +215,20 @@
 		"tiers": [
 			{
 				"minValue": 1,
-				"maxValue": 4,
+				"maxValue": 2,
 				"minimumLevel": 1,
 				"weight": 1
 			},
 			{
-				"minValue": 5,
-				"maxValue": 8,
+				"minValue": 3,
+				"maxValue": 4,
 				"minimumLevel": 21,
 				"weight": 1
 			},
 			{
-				"minValue": 9,
-				"maxValue": 12,
+				"minValue": 5,
+				"maxValue": 6,
 				"minimumLevel": 52,
-				"weight": 1
-			},
-			{
-				"minValue": 13,
-				"maxValue": 16,
-				"minimumLevel": 73,
 				"weight": 1
 			}
 		]

--- a/Common/Systems/PotionPlayer.cs
+++ b/Common/Systems/PotionPlayer.cs
@@ -39,7 +39,9 @@ internal class PotionPlayer : ModPlayer
 	{
 		PotionPlayer mp = self.GetModPlayer<PotionPlayer>();
 
-		self.Heal(mp.HealPower);
+		// Changed from flat healing to percentage-based (Using statLifeMax2 is MaxLife after adjusted buffs/equipment)
+		int healAmount = (int)(self.statLifeMax2 * (mp.HealPower / 100f));
+		self.Heal(healAmount);
 		self.AddBuff(BuffID.PotionSickness, mp.HealDelay);
 		mp.HealingLeft--;
 
@@ -95,6 +97,7 @@ internal class PotionPlayer : ModPlayer
 		}
 
 		MaxHealing = 3;
+		//This is now 30%
 		HealPower = 30;
 		HealDelay = 300;
 

--- a/Content/Passives/LifePassives.cs
+++ b/Content/Passives/LifePassives.cs
@@ -23,6 +23,6 @@ internal class IncreasedPotionRecoveryPassive : Passive
 {
 	public override void BuffPlayer(Player player)
 	{
-		player.GetModPlayer<UniversalBuffingPlayer>().UniversalModifier.PotionHealPower += Level * 0.5f;
+		player.GetModPlayer<UniversalBuffingPlayer>().UniversalModifier.PotionHealPower *= 1 + (Level * 10f) / 100f;
 	}
 }


### PR DESCRIPTION

﻿### Link Issues
Resolves: #1237 

### Description of Work
-Changed calculation of Passive tree node for increased potion charges to actually be 10% and not additive. 
-Potions now restore 30% total maximum life.
-Nerfed potion buff affixes to account for this


### Comments
Mana could easily be done with all of the methods if we want.
