### PR TITLE
fix: Fixed Eldric's spawn condition checking for EoC instead of KS.

### DIFF
--- a/Content/NPCs/Town/EldricNPC.cs
+++ b/Content/NPCs/Town/EldricNPC.cs
@@ -28,7 +28,7 @@ public sealed class EldricNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, I
 
 	bool ISpawnInRavencrestNPC.CanSpawn(NPCSpawnTimeframe timeframe, bool alreadyExists)
 	{
-		return (BossTracker.TotalBossesDowned.Contains(NPCID.EyeofCthulhu) || NPC.downedBoss1) && timeframe is NPCSpawnTimeframe.WorldGen or NPCSpawnTimeframe.NaturalSpawn && !alreadyExists;
+		return (BossTracker.TotalBossesDowned.Contains(NPCID.KingSlime) || NPC.downedSlimeKing) && timeframe is NPCSpawnTimeframe.WorldGen or NPCSpawnTimeframe.NaturalSpawn && !alreadyExists;
 	}
 
 	public override void SetStaticDefaults()


### PR DESCRIPTION
### Description of Work
Eldric's spawn condition was checking for EoC, while the wiki states that he should spawn after KS. Fascinating, since this seems to be the NPC that gives out the quest to kill EoC in the first place.
<img width="819" height="132" alt="image" src="https://github.com/user-attachments/assets/d299ec66-5021-43c6-929a-3ad7abc2f111" />

**Changelog:** Fixed Eldric's spawn condition requiring Eye of Cthulhu to be defeated, instead of King Slime.

