### PR TITLE
Dexterity gives global AS

### DIFF
--- a/Common/Enums/ItemType.cs
+++ b/Common/Enums/ItemType.cs
@@ -33,7 +33,7 @@ public enum ItemType : long
 	Shield = 1 << 24,
 
 	Armor = Helmet | Chestplate | Leggings,
-	Accessories = Ring | Charm,
+	Accessories = Ring | Charm | Amulet,
 	Equipment = Armor | Accessories,
 	Offhand = Shield,
 

--- a/Common/Systems/ModPlayers/AttributesPlayer.cs
+++ b/Common/Systems/ModPlayers/AttributesPlayer.cs
@@ -14,7 +14,7 @@ public class AttributesPlayer : ModPlayer
 	{
 		// Apply buffs
 		Player.statLifeMax2 += LifeBoost;
-		Player.GetAttackSpeed(DamageClass.Melee) += UseSpeedBoost;
+		Player.GetAttackSpeed(DamageClass.Generic) += UseSpeedBoost;
 		Player.statManaMax2 += ManaBoost;
 		
 		// Reset

--- a/Content/Items/Gear/Amulets/Amulet.cs
+++ b/Content/Items/Gear/Amulets/Amulet.cs
@@ -8,6 +8,7 @@ public abstract class Amulet : Gear
 	
 	public override void SetDefaults()
 	{
+		base.SetDefaults();
 		Item.DefaultToAccessory();
 
 		PoTInstanceItemData data = this.GetInstanceData();


### PR DESCRIPTION
Changed damage class on dex to generic from melee

﻿### Link Issues
Resolves: #1256 

### Description of Work
Makes dexterity bonus attack speed affect all damage types, not just melee.

### Comments
