### PR TITLE
Tooltip fixes, batch 1.

### DIFF
--- a/Common/UI/Hotbar/HotbarHijack.cs
+++ b/Common/UI/Hotbar/HotbarHijack.cs
@@ -1,4 +1,5 @@
-using System.Linq;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
 using Terraria.ID;
 using Terraria.UI;
 
@@ -8,27 +9,16 @@ internal sealed class HotbarHijack : ModSystem
 {
 	public override void Load()
 	{
-		On_Main.GUIHotbarDrawInner += StopVanillaHotbarDrawing;
+		IL_Main.GUIHotbarDrawInner += StopVanillaHotbarDrawing;
 		On_ItemSlot.LeftClick_ItemArray_int_int += ReserveHotbarSlots_PreventLeftClickingItemsIntoHotbar;
 		On_Player.GetItem_FillEmptyInventorySlot += ReserveHotbarSlors_PreventFillingHotbarWithItems;
 	}
 
-	private static void StopVanillaHotbarDrawing(On_Main.orig_GUIHotbarDrawInner orig, Main self)
+	private static void StopVanillaHotbarDrawing(ILContext ctx)
 	{
-		// This detour previously handled preventing the hover text that would
-		// draw when hovering over items in the hotbar.
-		// It has been reworked to prevent all associated drawing of the vanilla
-		// hotbar instead.
-		// This allows for other mods' detours to run if they hook this method
-		// while still sufficiently preventing the vanilla hotbar from drawing.
-
-		// Always set it to true to cause an early return in the vanilla method.
-		bool origPlayerInventory = Main.playerInventory;
-		Main.playerInventory = true;
-
-		orig(self);
-
-		Main.playerInventory = origPlayerInventory;
+		// Simply short-circuit all hotbar rendering, while still letting other mods' detour into this function run as usual.
+		var il = new ILCursor(ctx);
+		il.Emit(OpCodes.Ret);
 	}
 
 	private static void ReserveHotbarSlots_PreventLeftClickingItemsIntoHotbar(On_ItemSlot.orig_LeftClick_ItemArray_int_int orig, Item[] inv, int context, int slot)

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -633,7 +633,7 @@ public class HijackHotbarClick : ModSystem
 		{
 			var pos = new Rectangle(offX, offY, SlotSize, SlotSize);
 
-			if (pos.Contains(Main.MouseScreen.ToPoint()) && !Main.playerInventory)
+			if (!Main.playerInventory && pos.Contains(Main.MouseScreen.ToPoint()))
 			{
 				SetHealthOrManaTooltip(i == 0);
 			}

--- a/Common/UI/Tooltip.cs
+++ b/Common/UI/Tooltip.cs
@@ -12,7 +12,7 @@ namespace PathOfTerraria.Common.UI;
 /// <summary>
 /// Draws the popup tooltip when various elements of the UI are hovered over.
 /// </summary>
-public class Tooltip : SmartUiState, ILoadable
+public class Tooltip : SmartUiState
 {
 	private static string text = string.Empty;
 	private static string tooltip = string.Empty;
@@ -26,11 +26,6 @@ public class Tooltip : SmartUiState, ILoadable
 	public override int DepthPriority => 2;
 
 	public override bool Visible => true;
-
-	public void Load(Mod mod)
-	{
-		On_Main.Update += Reset;
-	}
 
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{
@@ -59,6 +54,12 @@ public class Tooltip : SmartUiState, ILoadable
 	public static void SetFancyTooltip(List<DrawableTooltipLine> newTooltip)
 	{
 		fancyTooltips = newTooltip;
+	}
+
+	public override void SafeUpdate(GameTime gameTime)
+	{
+		// UI is updated early and at a fixed rate, perfect for global state reset without causing flickering.
+		Reset();
 	}
 
 	public override void Draw(SpriteBatch spriteBatch)
@@ -131,13 +132,11 @@ public class Tooltip : SmartUiState, ILoadable
 		}
 	}
 
-	private void Reset(On_Main.orig_Update orig, Main self, GameTime gameTime)
+	private static void Reset()
 	{
 		text = string.Empty;
 		tooltip = string.Empty;
 		fancyTooltips.Clear();
 		DrawWidth = 200;
-
-		orig(self, gameTime);
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves #712
Resolves #1236

### Description of Work
[Fixed mouse-item tooltips flickering when Frame Skip is set to Off.](https://github.com/Path-of-Terraria/PathOfTerraria/commit/c8aacd34a1389321db343028a456da36f7ac0546)
[Fixed hotbar potion tooltips not working.](https://github.com/Path-of-Terraria/PathOfTerraria/commit/65feca9109565e86d0f106a3a88195ea9a59e293)

### Comments
There will be more, this is a split.