### PR TITLE
Fixed non boss subworlds being explodable

### DIFF
--- a/Common/Systems/DisableBuilding/StopExplodingTile.cs
+++ b/Common/Systems/DisableBuilding/StopExplodingTile.cs
@@ -10,7 +10,7 @@ internal class StopExplodingTile : GlobalTile
 	{
 		Tile tile = Main.tile[i, j];
 		Point16 frame = new(tile.TileFrameX, tile.TileFrameY);
-		return SubworldSystem.Current is not BossDomainSubworld || BuildingWhitelist.InMiningWhitelist(type, frame) || BuildingWhitelist.InExplodingWhitelist(type, frame);
+		return SubworldSystem.Current is not MappingWorld || BuildingWhitelist.InMiningWhitelist(type, frame) || BuildingWhitelist.InExplodingWhitelist(type, frame);
 	}
 
 	public override bool Slope(int i, int j, int type)

--- a/Common/Systems/DisableBuilding/StopExplodingWall.cs
+++ b/Common/Systems/DisableBuilding/StopExplodingWall.cs
@@ -7,6 +7,6 @@ internal class StopExplodingWall : GlobalWall
 {
 	public override bool CanExplode(int i, int j, int type)
 	{
-		return SubworldSystem.Current is not BossDomainSubworld;
+		return SubworldSystem.Current is not MappingWorld;
 	}
 }


### PR DESCRIPTION
### Link Issues
Resolves: #1255

### Description of Work
Changed two BossDomainSubworlds to just MappingWorld to account for Ravencrest & maps

### Comments
