### PR TITLE
Fixed affixes being negative/hidden

### DIFF
--- a/Common/Systems/Affixes/AffixTooltipsHandler.cs
+++ b/Common/Systems/Affixes/AffixTooltipsHandler.cs
@@ -116,8 +116,13 @@ public class AffixTooltipsHandler
 				tooltip.OriginalValueBySource.Add(source, value);
 				tooltip.ValueBySource.Add(source, 0);
 			}
+			
+			//This adds the tooltips together if they are the same affix, and stops the weird affix comparison bug from before resulting in neg numbers.
+			if (tooltip.ValueBySource.ContainsKey(source))
+				tooltip.ValueBySource[source] += value; // Add to existing
+			else
+				tooltip.ValueBySource[source] = value;  // First occurrence
 
-			tooltip.ValueBySource[source] = value;
 
 			if (!tooltip.SourceItems.Any(HasSource(item)))
 			{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1235 #1232

### Description of Work
- Multiple of the same affixes on one item are now added onto each other into one stat tooltip. This stops the weird affix comparison negative value bug from before.

### Comments
In the future if we want to display them seperately we can, but it'd be cool to have an "Alt" advanced show item descriptions, which shows Affix Name / Tier / Stat Roll (like poe) and this could also seperate them into X on the tooltip