### PR TITLE
No "5th" affix bug and affixes not adding together fixed

### DIFF
--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -16,6 +16,7 @@ public abstract class Affix : ILocalizedModType
 	public float Value = 0;
 	public int Duration = 180; //3 Seconds by default
 	public bool IsCorruptedAffix = false;
+	public bool IsImplicit = false;
 	public bool Round = false;
 	public int Tier = 1;
 

--- a/Common/Systems/Affixes/AffixTooltipsHandler.cs
+++ b/Common/Systems/Affixes/AffixTooltipsHandler.cs
@@ -116,12 +116,13 @@ public class AffixTooltipsHandler
 				tooltip.OriginalValueBySource.Add(source, value);
 				tooltip.ValueBySource.Add(source, 0);
 			}
-			
-			//This adds the tooltips together if they are the same affix, and stops the weird affix comparison bug from before resulting in neg numbers.
-			if (tooltip.ValueBySource.ContainsKey(source))
-				tooltip.ValueBySource[source] += value; // Add to existing
 			else
-				tooltip.ValueBySource[source] = value;  // First occurrence
+			{
+				// Add to existing values - both original and current should be updated
+				tooltip.ValueBySource[source] += value;
+				tooltip.OriginalValueBySource[source] += value;
+			}
+
 
 
 			if (!tooltip.SourceItems.Any(HasSource(item)))

--- a/Core/Items/ItemHooks.PoT.cs
+++ b/Core/Items/ItemHooks.PoT.cs
@@ -191,6 +191,12 @@ public sealed class GenerateImplicits : ILoadable
 
 			gl.ModifyImplicits(item, implicits);
 		}
+		
+		// Mark all generated implicits as implicit
+		foreach (ItemAffix affix in implicits)
+		{
+			affix.IsImplicit = true;
+		}
 
 		return implicits;
 	}

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -10,6 +10,7 @@ using PathOfTerraria.Common.Systems.ModPlayers;
 using SubworldLibrary;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
+using System.Linq;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -214,7 +215,8 @@ public static class PoTItemHelper
 	public static bool HasMaxAffixesForRarity(Item item)
 	{
 		PoTInstanceItemData data = item.GetInstanceData();
-		return data.Affixes.Count >= GetMaxAffixCounts(data.Rarity);
+		int nonImplicitAffixCount = data.Affixes.Count(affix => !affix.IsImplicit);
+		return nonImplicitAffixCount >= GetMaxAffixCounts(data.Rarity);
 	}
 
 	public static void SetMouseItemToHeldItem(Player player)


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1265  #1232

### Description of Work
- Fixed how an implicit counted as a 4th affix for ascendant shards, just added an IsImplicit to track if it is one.
- Changed the previous affix tooltip code to add to existing values properly...
- Small change to HasMaxAffixesForRarity for the implicit reason, needed to track it

### Comments
- After some pretty thorough testing and stat sheet inspections this SHOULD be all affix tooltips fixed. 
