### PR TITLE
Critical affixes + passive changes

### DIFF
--- a/Common/Data/Affixes/WeaponAffixes.json
+++ b/Common/Data/Affixes/WeaponAffixes.json
@@ -4,27 +4,27 @@
 		"equipTypes": "Weapon",
 		"tiers": [
 			{
-				"minValue": 1,
-				"maxValue": 1,
+				"minValue": 5,
+				"maxValue": 10,
 				"minimumLevel": 1,
 				"weight": 1
 			},
 			{
-				"minValue": 25,
-				"maxValue": 25,
+				"minValue": 11,
+				"maxValue": 16,
 				"minimumLevel": 25,
 				"weight": 1
 			},
 			{
-				"minValue": 50,
-				"maxValue": 50,
+				"minValue": 17,
+				"maxValue": 23,
 				"minimumLevel": 50,
 				"weight": 1
 			},
 			{
-				"minValue": 100,
-				"maxValue": 100,
-				"minimumLevel": 100,
+				"minValue": 24,
+				"maxValue": 30,
+				"minimumLevel": 75,
 				"weight": 1
 			}
 		]
@@ -34,27 +34,27 @@
 		"equipTypes": "Weapon",
 		"tiers": [
 			{
-				"minValue": 1,
-				"maxValue": 1,
+				"minValue": 5,
+				"maxValue": 10,
 				"minimumLevel": 1,
 				"weight": 1
 			},
 			{
-				"minValue": 25,
-				"maxValue": 25,
+				"minValue": 11,
+				"maxValue": 16,
 				"minimumLevel": 25,
 				"weight": 1
 			},
 			{
-				"minValue": 50,
-				"maxValue": 50,
+				"minValue": 17,
+				"maxValue": 23,
 				"minimumLevel": 50,
 				"weight": 1
 			},
 			{
-				"minValue": 100,
-				"maxValue": 100,
-				"minimumLevel": 100,
+				"minValue": 24,
+				"maxValue": 30,
+				"minimumLevel": 75,
 				"weight": 1
 			}
 		]
@@ -64,27 +64,27 @@
 		"equipTypes": "Weapon",
 		"tiers": [
 			{
-				"minValue": 1,
-				"maxValue": 1,
+				"minValue": 5,
+				"maxValue": 10,
 				"minimumLevel": 1,
 				"weight": 1
 			},
 			{
-				"minValue": 25,
-				"maxValue": 25,
+				"minValue": 11,
+				"maxValue": 16,
 				"minimumLevel": 25,
 				"weight": 1
 			},
 			{
-				"minValue": 50,
-				"maxValue": 50,
+				"minValue": 17,
+				"maxValue": 23,
 				"minimumLevel": 50,
 				"weight": 1
 			},
 			{
-				"minValue": 100,
-				"maxValue": 100,
-				"minimumLevel": 100,
+				"minValue": 24,
+				"maxValue": 30,
+				"minimumLevel": 75,
 				"weight": 1
 			}
 		]
@@ -94,27 +94,27 @@
 		"equipTypes": "Weapon",
 		"tiers": [
 			{
-				"minValue": 1,
-				"maxValue": 1,
+				"minValue": 5,
+				"maxValue": 10,
 				"minimumLevel": 1,
 				"weight": 1
 			},
 			{
-				"minValue": 25,
-				"maxValue": 25,
+				"minValue": 11,
+				"maxValue": 16,
 				"minimumLevel": 25,
 				"weight": 1
 			},
 			{
-				"minValue": 50,
-				"maxValue": 50,
+				"minValue": 17,
+				"maxValue": 23,
 				"minimumLevel": 50,
 				"weight": 1
 			},
 			{
-				"minValue": 100,
-				"maxValue": 100,
-				"minimumLevel": 100,
+				"minValue": 24,
+				"maxValue": 30,
+				"minimumLevel": 75,
 				"weight": 1
 			}
 		]

--- a/Common/Systems/Affixes/ItemTypes/CriticalAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/CriticalAffixes.cs
@@ -4,7 +4,7 @@ internal class PercentageIncreasedCriticalStrikeChanceAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.CriticalChance.Base += modifier.CriticalChance.Base * (Value / 100);
+		modifier.CriticalChance.Base *= 1 + Value / 100;
 	}
 }
 

--- a/Content/Passives/CriticalPassives.cs
+++ b/Content/Passives/CriticalPassives.cs
@@ -21,7 +21,7 @@ internal class AddedCriticalStrikeChance : Passive
 /// </summary>
 internal class IncreasedCriticalStrikeChance : Passive
 {
-	private const float AmountPerLevel = 1.05f;
+	private const float AmountPerLevel = 0.10f;
 
 	public override void BuffPlayer(Player player)
 	{

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -101,7 +101,7 @@ AddedCriticalStrikeChance: {
 
 IncreasedCriticalStrikeChance: {
 	Name: Increased Critical Strike Chance
-	Tooltip: Adds 5% increased critical strike chance per level
+	Tooltip: Adds 10% increased critical strike chance per level
 }
 
 IncreasedCriticalStrikeMultiplier: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -101,7 +101,7 @@ AddedCriticalStrikeChance: {
 
 IncreasedCriticalStrikeChance: {
 	// Name: Increased Critical Strike Chance
-	// Tooltip: Adds 5% increased critical strike chance per level
+	// Tooltip: Adds 10% increased critical strike chance per level
 }
 
 IncreasedCriticalStrikeMultiplier: {


### PR DESCRIPTION
### Link Issues
Resolves: #1268 #1266

### Description of Work
- Adjusted critical strike chance multiplier node on tree to be actually 10% base (was previously way too multiplicative, was giving like 5-10% flat per level)
- Changed how critical strike chance multiplier is handled on weapon affix. Previously did nothing.
- Adjusted the rolls of all critical affixes on weapons (previously way too high.)

### Comments
Critical multiplier damage or other damage affix still does not work. It works in the passive tree due to using ModifyHitNPC, could likely do a similar thing here, but might be better to move it to EntityModifier directly?