### PR TITLE
corrupt shard fixes, inconsistency fix

### DIFF
--- a/Common/Subworlds/MappingAreas/DesertAreaContent/DesertAreaNPC.cs
+++ b/Common/Subworlds/MappingAreas/DesertAreaContent/DesertAreaNPC.cs
@@ -35,7 +35,7 @@ internal class DesertAreaNPC : GlobalNPC
 
 	public override void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns)
 	{
-		if (SubworldSystem.Current is not QueenSlimeDomain || spawnRate == int.MinValue)
+		if (SubworldSystem.Current is not DesertArea || spawnRate == int.MinValue)
 		{
 			return;
 		}

--- a/Content/Items/Currency/CorruptShard.cs
+++ b/Content/Items/Currency/CorruptShard.cs
@@ -24,6 +24,11 @@ public class CorruptShard : CurrencyShard
 		staticData.MinDropItemLevel = 5;
 	}
 
+	public override bool CanRightClick()
+	{
+		return base.CanRightClick() && Main.LocalPlayer.selectedItem == 58;
+	}
+
 	public override void SetDefaults()
 	{
 		Item.CloneDefaults(ItemID.Silk);
@@ -37,8 +42,11 @@ public class CorruptShard : CurrencyShard
 		PoTInstanceItemData data = player.HeldItem.GetInstanceData();
 		data.Corrupted = true;
 
+		Item.stack--;
+
 		if (Main.rand.NextBool(2)) // 50% chance to do nothing
 		{
+			PoTItemHelper.SetMouseItemToHeldItem(player);
 			return;
 		}
 
@@ -48,8 +56,16 @@ public class CorruptShard : CurrencyShard
 
 			if (delevel)
 			{
-				IEnumerable<GearItem> gear = ModContent.GetContent<GearItem>().Where(x => x.GetInstanceData().ItemType == data.ItemType);
-				GearItem chosenItem = gear.ElementAt(Main.rand.Next(gear.Count()));
+				IEnumerable<ItemDatabase.ItemRecord> gear = ItemDatabase.AllItems.Where(x => x.Item.ModItem is GearItem &&
+					x.Item.GetInstanceData().ItemType == data.ItemType && x.Rarity == ItemRarity.Rare);
+				int count = gear.Count();
+
+				if (count == 0)
+				{
+					return;
+				}
+
+				var chosenItem = gear.ElementAt(Main.rand.Next(count)).Item.ModItem as GearItem;
 				int oldLevel = data.RealLevel;
 
 				player.HeldItem.SetDefaults(chosenItem.Type);
@@ -57,6 +73,7 @@ public class CorruptShard : CurrencyShard
 				data.Rarity = ItemRarity.Rare;
 				data.RealLevel = oldLevel;
 				PoTItemHelper.Roll(player.HeldItem, data.RealLevel);
+				data.Corrupted = true;
 			}
 			else
 			{
@@ -68,10 +85,7 @@ public class CorruptShard : CurrencyShard
 			AddAffix(data);
 		}
 
-		if (player.selectedItem == 58) // mouseItem copies over HeldItem otherwise
-		{
-			Main.mouseItem = player.HeldItem;
-		}
+		PoTItemHelper.SetMouseItemToHeldItem(player);
 	}
 
 	private static void AddAffix(PoTInstanceItemData data)


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1267
Resolves: #1120

### Description of Work
- Fixed the Desert mapping area not having adjusted spawns due to bad copy paste
- Fixed a lot about Corrupt Shards:
1. Corrupt Shards cannot corrupt held item anymore unless you are holding it in the mouse, stopping accidental uses
2. Properly reduced the stack, which didn't happen for some reason already?
3. Properly updated held item on use, stopping stuff like the item not updating & not retaining the tag
4. Properly selected a random rare to use, and added safety check if none is found