### PR TITLE
fix consumability, minor fixes

### DIFF
--- a/Common/Subworlds/MappingAreas/ForestArea.cs
+++ b/Common/Subworlds/MappingAreas/ForestArea.cs
@@ -42,11 +42,6 @@ internal class ForestArea : MappingWorld, IOverrideBiome
 	public override List<GenPass> Tasks => [new PassLegacy("Reset", ResetStep), new PassLegacy("Terrain", GenerateTerrain), new PassLegacy("Structures", GenStructures),
 		new PassLegacy("Detailing", AddDetails)];
 
-	public override void OnEnter()
-	{
-		SubworldSystem.noReturn = true;
-	}
-
 	public override void Update()
 	{
 		TileEntity.UpdateStart();

--- a/Common/UI/Armor/AccessorySlotGlobalItem.cs
+++ b/Common/UI/Armor/AccessorySlotGlobalItem.cs
@@ -41,48 +41,63 @@ public sealed class AccessorySlotGlobalItem : GlobalItem
 		return result;
 	}
 	
-	private bool IsItemAlreadyEquipped(Item itemToCheck, Player player, int targetSlot)
+	private static bool IsItemAlreadyEquipped(Item itemToCheck, Player player, int targetSlot)
 	{
 		if (itemToCheck == null || itemToCheck.IsAir)
+		{
 			return false;
+		}
 
 		ExtraAccessoryModPlayer modPlayer = player.GetModPlayer<ExtraAccessoryModPlayer>();
 
 		// Check all vanilla equipment slots (except the target slot we're trying to equip to)
 		for (int i = 0; i < player.armor.Length; i++)
 		{
-			if (i == targetSlot) continue; // Skip the slot we're trying to equip to
-			
+			if (i == targetSlot)
+			{
+				continue; // Skip the slot we're trying to equip to
+			}
+
 			if (!player.armor[i].IsAir && ItemsAreSameType(player.armor[i], itemToCheck))
+			{
 				return true;
+			}
 		}
 
 		// Check all vanilla dye slots
 		for (int i = 0; i < player.dye.Length; i++)
 		{
 			if (!player.dye[i].IsAir && ItemsAreSameType(player.dye[i], itemToCheck))
+			{
 				return true;
+			}
 		}
 
 		// Check custom accessory slots
 		for (int i = 0; i < modPlayer.CustomAccessorySlots.Length; i++)
 		{
 			if (!modPlayer.CustomAccessorySlots[i].IsAir && ItemsAreSameType(modPlayer.CustomAccessorySlots[i], itemToCheck))
+			{
 				return true;
+			}
 		}
 
 		// Check custom vanity slots
 		for (int i = 0; i < modPlayer.CustomVanitySlots.Length; i++)
 		{
 			if (!modPlayer.CustomVanitySlots[i].IsAir && ItemsAreSameType(modPlayer.CustomVanitySlots[i], itemToCheck))
+			{
 				return true;
+			}
 		}
 
 		// Check custom dye slots
 		for (int i = 0; i < modPlayer.CustomDyeSlots.Length; i++)
 		{
 			if (!modPlayer.CustomDyeSlots[i].IsAir && ItemsAreSameType(modPlayer.CustomDyeSlots[i], itemToCheck))
+			{
 				return true;
+			}
 		}
 
 		return false;
@@ -94,7 +109,7 @@ public sealed class AccessorySlotGlobalItem : GlobalItem
 		return item1.type == item2.type;
 	}
 
-	public bool IsNormalAccessory(Item item)
+	public static bool IsNormalAccessory(Item item)
 	{
 		return item is not null && 
 		       item.accessory && 
@@ -108,29 +123,21 @@ public sealed class AccessorySlotGlobalItem : GlobalItem
 	{
 		if (!item.accessory)
 		{
-			return base.CanRightClick(item);
+			return false;
 		}
 
-		var accessorySlotGlobal = ModContent.GetInstance<AccessorySlotGlobalItem>();
-		return accessorySlotGlobal.IsNormalAccessory(item);
+		return IsNormalAccessory(item);
 	}
 
 	public override void RightClick(Item item, Player player)
 	{
-
-		var extraAccessoryPlayer = player.GetModPlayer<ExtraAccessoryModPlayer>();
-		var accessorySlotGlobal = ModContent.GetInstance<AccessorySlotGlobalItem>();
-        
-		if (!accessorySlotGlobal.IsNormalAccessory(item))
-		{
-			equipped = false;
-			return;
-		}
+		ExtraAccessoryModPlayer extraAccessoryPlayer = player.GetModPlayer<ExtraAccessoryModPlayer>();
 		
 		// Check if item is already equipped before trying to equip
 		if (IsItemAlreadyEquipped(item, player, -1)) // -1 means we're not targeting a specific slot
 		{
 			equipped = false;
+			item.stack++;
 			return;
 		}
         
@@ -147,6 +154,7 @@ public sealed class AccessorySlotGlobalItem : GlobalItem
 			player.armor[9] = item.Clone();
 			equipped = true;
 		}
+
 		// Try custom slots (only functional slots, indices 0 and 1)
 		else if (extraAccessoryPlayer.CustomAccessorySlots[0].IsAir)
 		{
@@ -158,12 +166,6 @@ public sealed class AccessorySlotGlobalItem : GlobalItem
 			extraAccessoryPlayer.CustomAccessorySlots[1] = item.Clone();
 			equipped = true;
 		}
-	}
-	
-	public override bool ConsumeItem(Item item, Player player)
-	{
-		// Only consume the item if it was successfully equipped (not swapped)
-		return equipped;
 	}
 	
 	private enum EquipmentSlot

--- a/Common/UI/Elements/UICustomHoverImageItemSlot.cs
+++ b/Common/UI/Elements/UICustomHoverImageItemSlot.cs
@@ -35,7 +35,7 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         }
         else
         {
-            Predicate = (item, _) => ModContent.GetInstance<AccessorySlotGlobalItem>().IsNormalAccessory(item);
+            Predicate = (item, _) => AccessorySlotGlobalItem.IsNormalAccessory(item);
         }
     }
 
@@ -44,12 +44,18 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         get
         {
             if (IsDyeSlot)
-                return ModPlayer.GetCustomDyeSlot(virtualSlot);
-            else if (IsVanitySlot)
-                return ModPlayer.GetCustomVanitySlot(virtualSlot);
-            else
-                return ModPlayer.GetCustomSlot(virtualSlot);
-        }
+			{
+				return ModPlayer.GetCustomDyeSlot(virtualSlot);
+			}
+			else if (IsVanitySlot)
+			{
+				return ModPlayer.GetCustomVanitySlot(virtualSlot);
+			}
+			else
+			{
+				return ModPlayer.GetCustomSlot(virtualSlot);
+			}
+		}
         set
         {
             if (IsDyeSlot)
@@ -108,8 +114,10 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         {
             return;
         }
+
         Main.hoverItemName = Item.IsAir ? Language.GetTextValue(Key) : Item.HoverName;
         Main.HoverItem = Item.IsAir ? new Item() : Item.Clone();
+
         if (!Item.IsAir)
         {
             Main.HoverItem.tooltipContext = Context;
@@ -135,6 +143,7 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         {
             return IconTexture;
         }
+
         Main.instance.LoadItem(Item.type);
         return TextureAssets.Item[Item.type];
     }

--- a/Content/Items/Currency/CorruptShard.cs
+++ b/Content/Items/Currency/CorruptShard.cs
@@ -42,8 +42,6 @@ public class CorruptShard : CurrencyShard
 		PoTInstanceItemData data = player.HeldItem.GetInstanceData();
 		data.Corrupted = true;
 
-		Item.stack--;
-
 		if (Main.rand.NextBool(2)) // 50% chance to do nothing
 		{
 			PoTItemHelper.SetMouseItemToHeldItem(player);


### PR DESCRIPTION
### Description of Work
- Fixes all items being unconsumable...unless they're equipped accessories
- Allowed Settings -> Return on Forest maps
- Major cleanup & code style fixes on AccessorySlotGlobalItem & UICustomHoverImageItemSlot
- Fixed dupe/deletion issue with accessories on the 3rd and 4th general slots
- Removed CorruptShard force-consume alongside fix of root issue (above)