### PR TITLE
Fix batch 2025-08-20

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,10 +29,10 @@ dotnet_style_qualification_for_property = false:warning
 # Language keywords vs BCL types preferences
 
 # Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:warning
-dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:warning
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
 
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = for_non_interface_members
@@ -238,3 +238,6 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 end_of_line = crlf
 dotnet_style_predefined_type_for_member_access = true:warning
 resharper_csharp_place_simple_embedded_statement_on_same_line = true
+
+# IDE0047: Remove unnecessary parentheses
+dotnet_diagnostic.IDE0047.severity = none

--- a/Common/Subworlds/BossDomains/Prehardmode/QueenBeeDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/QueenBeeDomain.cs
@@ -28,8 +28,13 @@ public class QueenBeeDomain : BossDomainSubworld
 	public bool BossSpawned = false;
 	public bool ReadyToExit = false;
 
-	public override List<GenPass> Tasks => [new PassLegacy("Reset", ResetStep), new PassLegacy("Tiles", GenTiles), new PassLegacy("Polish", Polish),
-		new PassLegacy("Settle Liquids", SettleLiquidsStep.Generation)];
+	public override List<GenPass> Tasks => [
+		new PassLegacy("Reset", ResetStep),
+		new PassLegacy("Tiles", GenTiles),
+		new PassLegacy("Polish", Polish),
+		new PassLegacy("Settle Liquids", SettleLiquidsStep.Generation),
+		new PassLegacy("AdjustSpawn", AdjustSpawn),
+	];
 
 	private void Polish(GenerationProgress progress, GameConfiguration configuration)
 	{
@@ -174,6 +179,18 @@ public class QueenBeeDomain : BossDomainSubworld
 		}
 
 		StructureTools.PlaceByOrigin($"Assets/Structures/BeeDomain/Mini_{(left ? "" : "R_")}{WorldGen.genRand.Next(4)}", original, new(left ? 1 : 0, 0.5f));
+	}
+
+	private static void AdjustSpawn(GenerationProgress progress, GameConfiguration configuration)
+	{
+		var basePoint = new Point(Main.spawnTileX, Main.spawnTileY);
+		var targetSize = new Point(3, 3);
+		var searchRadius = new Point(40, 40);
+
+		if (GenerationUtilities.TryFindNearestFreePoint(basePoint, targetSize, searchRadius, out Point spawnPoint))
+		{
+			(Main.spawnTileX, Main.spawnTileY) = (spawnPoint.X, spawnPoint.Y);
+		}
 	}
 
 	public override void OnEnter()

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -294,14 +294,14 @@ public class RavencrestSystem : ModSystem
 					var announceColor = new Color(50, 125, 255);
 					ChatHelper.BroadcastChatMessage(NetworkText.FromKey("Announcement.HasArrived", spawnedNpc.GivenOrTypeName), announceColor);
 				}
+
+				if (++numSpawned >= maxAmount)
+				{
+					break;
+				}
 			}
 
 			pool.RemoveAt(index);
-
-			if (++numSpawned >= maxAmount)
-			{
-				break;
-			}
 		}
 	}
 

--- a/Common/Systems/ModPlayers/LivesSystem/BossDomainLivesUILayer.cs
+++ b/Common/Systems/ModPlayers/LivesSystem/BossDomainLivesUILayer.cs
@@ -26,7 +26,7 @@ internal class BossDomainLivesUILayer : ILoadable
 			return;
 		}
 
-		int lives = Main.LocalPlayer.GetModPlayer<BossDomainLivesPlayer>().LivesLeft;
+		int lives = Main.LocalPlayer.GetModPlayer<BossDomainLivesPlayer>().GetLivesLeft();
 		string text = lives + " " + Language.GetTextValue("Mods.PathOfTerraria.UI.Lives");
 		ReLogic.Graphics.DynamicSpriteFont font = FontAssets.MouseText.Value;
 		var position = new Vector2(Main.screenWidth - ChatManager.GetStringSize(font, text, Vector2.One).X - 8, 0);

--- a/Common/World/Generation/Tools/GenerationUtilities.cs
+++ b/Common/World/Generation/Tools/GenerationUtilities.cs
@@ -45,4 +45,58 @@ internal class GenerationUtilities
 			}
 		}
 	}
+
+	/// <summary>
+	/// Cycles around the provided base point to try and find the nearest point that <paramref name="targetSize"/> can fit in.
+	/// </summary>
+	public static bool TryFindNearestFreePoint(Point basePoint, Point targetSize, Point maxSearchRadius, out Point result)
+	{
+		(int xOffset, int yOffset) = (0, 0);
+
+		while (true) {
+			(int xDiv, int xRem) = Math.DivRem(xOffset + 1, 2);
+			(int yDiv, int yRem) = Math.DivRem(yOffset + 1, 2);
+			int xStart = basePoint.X + (xDiv * (xRem == 0 ? 1 : -1));
+			int yStart = basePoint.Y + (yDiv * (yRem == 0 ? 1 : -1));
+			int xEnd = xStart + targetSize.X;
+			int yEnd = yStart + targetSize.Y;
+
+			bool CheckArea()
+			{
+				if (xStart < 0 || yStart < 0 || xEnd >= Main.maxTilesX || yEnd >= Main.maxTilesY)
+				{
+					return false;
+				}
+
+				for (int xx = xStart; xx <= xEnd; xx++)
+				{
+					for (int yy = yStart; yy <= yEnd; yy++)
+					{
+						if (WorldGen.SolidOrSlopedTile(xx, yy))
+						{
+							return false;
+						}
+					}
+				}
+
+				return true;
+			}
+
+			if (CheckArea())
+			{
+				result = new Point(xStart, yStart);
+				return true;
+			}
+
+			if (++yOffset >= maxSearchRadius.Y)
+			{
+				yOffset = 0;
+				if (++xOffset >= maxSearchRadius.X)
+				{
+					result = default;
+					return false;
+				}
+			}
+		}
+	}
 }

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -129,7 +129,7 @@ public abstract class Map : ModItem, GenerateName.IItem, GenerateAffixes.IItem, 
 	/// <returns></returns>
 	public static int GetBossUseCount()
 	{
-		int def = 6 / BossDomainLivesPlayer.GetLivesPerPlayer();
+		int def = 6 / BossDomainLivesPlayer.GetLivesPerPlayer(Main.CurrentFrameFlags.ActivePlayersCount);
 
 		if (Main.CurrentFrameFlags.ActivePlayersCount > 6)
 		{

--- a/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
+++ b/Content/Items/Gear/Weapons/WarShields/StarlightBulwark.cs
@@ -174,7 +174,7 @@ internal class StarlightBulwark : LeadBattleBulwark
 			Projectile.velocity *= 0.95f;
 			Projectile.rotation += 0.06f * Projectile.velocity.Length() + 0.006f;
 
-			if (Main.rand.NextBool(45))
+			if (!Main.dedServ && Main.rand.NextBool(45))
 			{
 				Color newColor = GetAlpha(Lighting.GetColor(Projectile.Center.ToTileCoordinates())) ?? Color.White;
 				Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.YellowStarDust, newColor: newColor);


### PR DESCRIPTION
﻿### Link Issues
Resolves #1150
Resolves important issues adjacent to #1035, but could not reproduce the main issue. 

### Description of Work
- Fixed boss domains' max lives counts desynchronizing between players in multiplayer - the first joining players' lives count will now be corrected when more players join the boss domain.
- Fixed Queen Bee's Domain's spawn position sometimes being put inside tiles.
- Fixed an issue with Ravencrest town NPCs respawns happening more rarely than intended.
- Fixed the Starlight Bulwark running client code on servers.
- Misc: Adjusted editorconfig to not complain about extra parentheses. Clarity of intent is everything.
