### PR TITLE
Critical fixes for custom accessory slots.

### DIFF
--- a/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
@@ -82,19 +82,19 @@ public class ExtraAccessoryModPlayer : ModPlayer
 	{
 		for (int i = 0; i < CustomAccessorySlots.Length; i++)
 		{
-			Item accessory = CustomAccessorySlots[i];
-			if (!accessory.IsAir)
+			(Item accessory, int virtualIndex) = (CustomAccessorySlots[i], CustomFunctionalSlots[i]);
+			if (IsCustomSlotActive(virtualIndex) && !accessory.IsAir)
 			{
 				Player.ApplyEquipFunctional(accessory, false);
 			}
 		}
-		
+
 		for (int i = 0; i < CustomVanitySlots.Length; i++)
 		{
-			Item vanityItem = CustomVanitySlots[i];
-			if (!vanityItem.IsAir)
+			(Item accessory, int virtualIndex) = (CustomVanitySlots[i], CustomFunctionalSlots[i]);
+			if (IsCustomSlotActive(virtualIndex) && !accessory.IsAir)
 			{
-				Player.ApplyEquipVanity(vanityItem);
+				Player.ApplyEquipVanity(accessory);
 			}
 		}
 	}

--- a/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
@@ -151,6 +151,11 @@ public class ExtraAccessoryModPlayer : ModPlayer
 		}
 	}
 
+	public static int GetCustomSlotVirtualIndex(int realIndex)
+	{
+		return CustomFunctionalSlots[realIndex];
+	}
+
 	private static int GetCustomSlotArrayIndex(int virtualIndex)
 	{
 		return Array.IndexOf(CustomFunctionalSlots, virtualIndex);
@@ -159,5 +164,31 @@ public class ExtraAccessoryModPlayer : ModPlayer
 	public static bool IsCustomSlot(int slot)
 	{
 		return Array.IndexOf(CustomFunctionalSlots, slot) >= 0;
+	}
+
+	public bool IsCustomSlotActive(int virtualIndex)
+	{
+		int arrayIndex = GetCustomSlotArrayIndex(virtualIndex);
+		return arrayIndex switch
+		{
+			0 => true, // Add one slot by default.
+			1 => Main.hardMode, // Add one slot after WoF is defeated.
+			_ => false,
+		};
+	}
+
+	public int CountActiveExtraSlots()
+	{
+		int numSlots = 0;
+
+		for (int i = 0; i < CustomAccessorySlots.Length; i++)
+		{
+			if (IsCustomSlotActive(GetCustomSlotVirtualIndex(i)))
+			{
+				numSlots++;
+			}
+		}
+
+		return numSlots;
 	}
 }

--- a/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
@@ -153,14 +153,7 @@ public class ExtraAccessoryModPlayer : ModPlayer
 
 	private static int GetCustomSlotArrayIndex(int virtualIndex)
 	{
-		for (int i = 0; i < CustomFunctionalSlots.Length; i++)
-		{
-			if (CustomFunctionalSlots[i] == virtualIndex)
-			{
-				return i;
-			}
-		}
-		return -1;
+		return Array.IndexOf(CustomFunctionalSlots, virtualIndex);
 	}
 
 	public static bool IsCustomSlot(int slot)

--- a/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExtraAccessoryModPlayer.cs
@@ -99,6 +99,30 @@ public class ExtraAccessoryModPlayer : ModPlayer
 		}
 	}
 
+	public override void UpdateVisibleAccessories()
+	{
+		for (int i = 0; i < CustomAccessorySlots.Length; i++)
+		{
+			(Item accessory, int virtualIndex) = (CustomAccessorySlots[i], CustomFunctionalSlots[i]);
+			if (IsCustomSlotActive(virtualIndex) && !accessory.IsAir)
+			{
+				Player.UpdateVisibleAccessories(accessory, false);
+			}
+		}
+	}
+	public override void UpdateVisibleVanityAccessories()
+	{
+		for (int i = 0; i < CustomVanitySlots.Length; i++)
+		{
+			(Item accessory, int virtualIndex) = (CustomVanitySlots[i], CustomFunctionalSlots[i]);
+			if (IsCustomSlotActive(virtualIndex) && !accessory.IsAir)
+			{
+				Player.ApplyEquipVanity(accessory);
+				Player.UpdateVisibleAccessories(accessory, false);
+			}
+		}
+	}
+
 	public Item GetCustomSlot(int virtualIndex)
 	{
 		int arrayIndex = GetCustomSlotArrayIndex(virtualIndex);

--- a/Common/UI/Armor/Elements/UIArmorPage.cs
+++ b/Common/UI/Armor/Elements/UIArmorPage.cs
@@ -1,4 +1,7 @@
-﻿using ReLogic.Content;
+﻿using System.Linq;
+using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Common.UI.Elements;
+using ReLogic.Content;
 using Terraria.Audio;
 using Terraria.ID;
 using Terraria.UI;
@@ -49,5 +52,32 @@ public abstract class UIArmorPage : UIElement
 				MaxInstances = 1
 			}
 		);
+	}
+
+	protected void MaintainCustomAccessorySlots(ReadOnlySpan<UICustomHoverImageItemSlot> slots)
+	{
+		if (Main.LocalPlayer.TryGetModPlayer(out ExtraAccessoryModPlayer accPlayer))
+		{
+			foreach (UICustomHoverImageItemSlot slot in slots)
+			{
+				bool isPresent = Children.Contains(slot);
+				bool shouldBePresent = accPlayer.IsCustomSlotActive(slot.VirtualSlot);
+
+				if (isPresent != shouldBePresent)
+				{
+					if (shouldBePresent)
+					{
+						// Make sure the slot is properly initialized before appending
+						if (slot.Icon == null) { slot.OnInitialize(); }
+
+						Append(slot);
+					}
+					else
+					{
+						RemoveChild(slot);
+					}
+				}
+			}
+		}
 	}
 }

--- a/Common/UI/Armor/Elements/UIDefaultArmor.cs
+++ b/Common/UI/Armor/Elements/UIDefaultArmor.cs
@@ -1,13 +1,5 @@
 ﻿using PathOfTerraria.Common.UI.Elements;
-using PathOfTerraria.Content.Items.Gear.Amulets;
-using PathOfTerraria.Content.Items.Gear.Armor.Chestplate;
-using PathOfTerraria.Content.Items.Gear.Armor.Helmet;
-using PathOfTerraria.Content.Items.Gear.Armor.Leggings;
-using PathOfTerraria.Content.Items.Gear.Offhands;
-using PathOfTerraria.Content.Items.Gear.Rings;
 using ReLogic.Content;
-using Terraria.Localization;
-using Terraria.ModLoader.UI;
 using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.Armor.Elements;
@@ -16,9 +8,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 {
 	public static readonly Asset<Texture2D> DefaultFrameTexture = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/Inventory/Frame_Default", AssetRequestMode.ImmediateLoad);
 
-	//This is to update the slot once WoF is killed. 
-	private UICustomHoverImageItemSlot accessorySlot4;
-	private bool wasHardMode = false;
+	private UICustomHoverImageItemSlot[] customAccessorySlots = [];
 
 	public override void OnInitialize()
 	{
@@ -170,7 +160,7 @@ public sealed class UIDefaultArmor : UIArmorPage
 		accessorySlot3.OnMouseOut += UpdateMouseOut;
 		Append(accessorySlot3);
 		
-		accessorySlot4 = new UICustomHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture,  21, $"Mods.{PoTMod.ModName}.UI.Slots.12", ItemSlot.Context.EquipAccessory)
+		var accessorySlot4 = new UICustomHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture,  21, $"Mods.{PoTMod.ModName}.UI.Slots.12", ItemSlot.Context.EquipAccessory)
 		{
 			HAlign = 0,
 			VAlign = 1.0f,
@@ -180,36 +170,15 @@ public sealed class UIDefaultArmor : UIArmorPage
 		
 		accessorySlot4.OnMouseOver += UpdateMouseOver;
 		accessorySlot4.OnMouseOut += UpdateMouseOut;
-		
-		wasHardMode = Main.hardMode;
-		if (wasHardMode)
-		{
-			Append(accessorySlot4);	
-		}
+		Append(accessorySlot4);
 
+		customAccessorySlots = [ accessorySlot3, accessorySlot4 ];
 	}
-	
+
 	public override void Update(GameTime gameTime)
 	{
 		base.Update(gameTime);
 
-		if (Main.hardMode != wasHardMode)
-		{
-			if (Main.hardMode)
-			{
-				// Make sure the slot is properly initialized before appending
-				if (accessorySlot4.Icon == null)
-				{
-					accessorySlot4.OnInitialize();
-				}
-				Append(accessorySlot4);
-			}
-			else
-			{
-				RemoveChild(accessorySlot4);
-			}
-			wasHardMode = Main.hardMode;
-		}
+		MaintainCustomAccessorySlots(customAccessorySlots);
 	}
-
 }

--- a/Common/UI/Armor/Elements/UIDefaultArmor.cs
+++ b/Common/UI/Armor/Elements/UIDefaultArmor.cs
@@ -14,8 +14,6 @@ public sealed class UIDefaultArmor : UIArmorPage
 	{
 		base.OnInitialize();
 
-		Player.extraAccessorySlots = 3;
-
 		Width = StyleDimension.FromPixels(UIArmorInventory.ArmorPageWidth);
 		Height = StyleDimension.FromPixels(UIArmorInventory.ArmorPageHeight);
 

--- a/Common/UI/Armor/Elements/UIDyeArmor.cs
+++ b/Common/UI/Armor/Elements/UIDyeArmor.cs
@@ -156,7 +156,7 @@ public sealed class UIDyeArmor : UIArmorPage
 		Append(accessorySlot2);
 
 		var accessorySlot3 =
-			new UICustomHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, 24, $"Mods.{PoTMod.ModName}.UI.Slots.11",
+			new UICustomHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, 20, $"Mods.{PoTMod.ModName}.UI.Slots.11",
 				ItemSlot.Context.EquipDye)
 			{
 				HAlign = 1.0f, VAlign = .75f, ActiveScale = 1.15f, ActiveRotation = MathHelper.ToRadians(1f)
@@ -167,8 +167,8 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(accessorySlot3);
 
-			new UICustomHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, 25, $"Mods.{PoTMod.ModName}.UI.Slots.12",
 		var accessorySlot4 =
+			new UICustomHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, 21, $"Mods.{PoTMod.ModName}.UI.Slots.12",
 				ItemSlot.Context.EquipDye)
 			{
 				HAlign = 0.0f, VAlign = 1f, ActiveScale = 1.15f, ActiveRotation = MathHelper.ToRadians(1f)

--- a/Common/UI/Armor/Elements/UIDyeArmor.cs
+++ b/Common/UI/Armor/Elements/UIDyeArmor.cs
@@ -13,8 +13,7 @@ public sealed class UIDyeArmor : UIArmorPage
 	public static readonly Asset<Texture2D> DyeIconTexture =
 		ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/Inventory/Dye", AssetRequestMode.ImmediateLoad);
 
-	private UICustomHoverImageItemSlot accessorySlot4;
-	private bool wasHardMode = false;
+	private UICustomHoverImageItemSlot[] customAccessorySlots = [];
 
 	public override void OnInitialize()
 	{
@@ -168,8 +167,8 @@ public sealed class UIDyeArmor : UIArmorPage
 
 		Append(accessorySlot3);
 
-		accessorySlot4 =
 			new UICustomHoverImageItemSlot(DyeFrameTexture, DyeIconTexture, 25, $"Mods.{PoTMod.ModName}.UI.Slots.12",
+		var accessorySlot4 =
 				ItemSlot.Context.EquipDye)
 			{
 				HAlign = 0.0f, VAlign = 1f, ActiveScale = 1.15f, ActiveRotation = MathHelper.ToRadians(1f)
@@ -178,36 +177,13 @@ public sealed class UIDyeArmor : UIArmorPage
 		accessorySlot4.OnMouseOver += UpdateMouseOver;
 		accessorySlot4.OnMouseOut += UpdateMouseOut;
 
-
-		wasHardMode = Main.hardMode;
-		if (wasHardMode)
-		{
-			Append(accessorySlot4);
-		}
+		customAccessorySlots = [ accessorySlot3, accessorySlot4 ];
 	}
 
 	public override void Update(GameTime gameTime)
 	{
 		base.Update(gameTime);
 
-		if (Main.hardMode != wasHardMode)
-		{
-			if (Main.hardMode)
-			{
-				// Make sure the slot is properly initialized before appending
-				if (accessorySlot4.Icon == null)
-				{
-					accessorySlot4.OnInitialize();
-				}
-
-				Append(accessorySlot4);
-			}
-			else
-			{
-				RemoveChild(accessorySlot4);
-			}
-
-			wasHardMode = Main.hardMode;
-		}
+		MaintainCustomAccessorySlots(customAccessorySlots);
 	}
 }	

--- a/Common/UI/Armor/Elements/UIVanityArmor.cs
+++ b/Common/UI/Armor/Elements/UIVanityArmor.cs
@@ -11,10 +11,8 @@ public sealed class UIVanityArmor : UIArmorPage
 {
 	public static readonly Asset<Texture2D> VanityFrameTexture = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/Inventory/Frame_Vanity", AssetRequestMode.ImmediateLoad);
 
-	//This is to update the slot once WoF is killed. 
-	private UICustomHoverImageItemSlot accessorySlot4;
-	private bool wasHardMode = false;
-	
+	private UICustomHoverImageItemSlot[] customAccessorySlots = [];
+
 	public override void OnInitialize()
 	{
 		base.OnInitialize();
@@ -163,7 +161,7 @@ public sealed class UIVanityArmor : UIArmorPage
 		accessorySlot3.Predicate = (item, _) => item.accessory && item.wingSlot <= 0;	
 		Append(accessorySlot3);
 
-		accessorySlot4 = new UICustomHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, 23, $"Mods.{PoTMod.ModName}.UI.Slots.12", ItemSlot.Context.EquipAccessoryVanity)
+		var accessorySlot4 = new UICustomHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, 23, $"Mods.{PoTMod.ModName}.UI.Slots.12", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 0f,
 			VAlign = 1f,
@@ -174,36 +172,15 @@ public sealed class UIVanityArmor : UIArmorPage
 		accessorySlot4.OnMouseOver += UpdateMouseOver;
 		accessorySlot4.OnMouseOut += UpdateMouseOut;
 		accessorySlot4.Predicate = (item, _) => item.accessory && item.wingSlot <= 0;	
-		
-		wasHardMode = Main.hardMode;
-		if (wasHardMode)
-		{
-			Append(accessorySlot4);	
-		}
+		Append(accessorySlot4);
 
+		customAccessorySlots = [ accessorySlot3, accessorySlot4 ];
 	}
 	
 	public override void Update(GameTime gameTime)
 	{
 		base.Update(gameTime);
 
-		if (Main.hardMode != wasHardMode)
-		{
-			if (Main.hardMode)
-			{
-				// Make sure the slot is properly initialized before appending
-				if (accessorySlot4.Icon == null)
-				{
-					accessorySlot4.OnInitialize();
-				}
-				Append(accessorySlot4);
-			}
-			else
-			{
-				RemoveChild(accessorySlot4);
-			}
-			wasHardMode = Main.hardMode;
-		}
+		MaintainCustomAccessorySlots(customAccessorySlots);
 	}
-
 }

--- a/Common/UI/Armor/Elements/UIVanityArmor.cs
+++ b/Common/UI/Armor/Elements/UIVanityArmor.cs
@@ -148,7 +148,7 @@ public sealed class UIVanityArmor : UIArmorPage
 		accessorySlot2.Predicate = (item, _) => item.accessory && item.wingSlot <= 0;
 		Append(accessorySlot2);
 		
-		var accessorySlot3 = new UICustomHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, 22, $"Mods.{PoTMod.ModName}.UI.Slots.11", ItemSlot.Context.EquipAccessoryVanity)
+		var accessorySlot3 = new UICustomHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, 20, $"Mods.{PoTMod.ModName}.UI.Slots.11", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 1f,
 			VAlign = .75f,
@@ -161,7 +161,7 @@ public sealed class UIVanityArmor : UIArmorPage
 		accessorySlot3.Predicate = (item, _) => item.accessory && item.wingSlot <= 0;	
 		Append(accessorySlot3);
 
-		var accessorySlot4 = new UICustomHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, 23, $"Mods.{PoTMod.ModName}.UI.Slots.12", ItemSlot.Context.EquipAccessoryVanity)
+		var accessorySlot4 = new UICustomHoverImageItemSlot(VanityFrameTexture, MiscellaneousIconTexture, 21, $"Mods.{PoTMod.ModName}.UI.Slots.12", ItemSlot.Context.EquipAccessoryVanity)
 		{
 			HAlign = 0f,
 			VAlign = 1f,
@@ -176,7 +176,7 @@ public sealed class UIVanityArmor : UIArmorPage
 
 		customAccessorySlots = [ accessorySlot3, accessorySlot4 ];
 	}
-	
+
 	public override void Update(GameTime gameTime)
 	{
 		base.Update(gameTime);

--- a/Common/UI/Elements/UICustomHoverImageItemSlot.cs
+++ b/Common/UI/Elements/UICustomHoverImageItemSlot.cs
@@ -75,7 +75,7 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         }
     }
 
-    protected override void UpdateInteraction()
+	protected override void UpdateInteraction()
     {
         if (!IsMouseHovering || PlayerInput.IgnoreMouseInterface)
         {
@@ -84,9 +84,9 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
 
         HandleTooltip();
 
-        if (Main.mouseLeft && Main.mouseLeftRelease)
+        if ((Main.mouseLeft && Main.mouseLeftRelease) || (Main.mouseRight && Main.mouseRightRelease))
         {
-            HandleLeftClick();
+            HandleLeftOrRightClick();
         }
 
         Main.LocalPlayer.mouseInterface = true;
@@ -126,7 +126,7 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         }
     }
 
-    private void HandleLeftClick()
+    private void HandleLeftOrRightClick()
     {
         if (!Main.mouseItem.IsAir && Predicate?.Invoke(Main.mouseItem, Item) == false)
         {
@@ -135,11 +135,11 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
         }
 
         Item tempItem = Item;
-        ItemSlot.Handle(ref tempItem, Context);
-        Item = tempItem;
-    }
+		ItemSlot.Handle(ref tempItem, Context);
+		Item = tempItem;
+	}
 
-    protected override Asset<Texture2D> GetIconToDraw()
+	protected override Asset<Texture2D> GetIconToDraw()
     {
         if (Item.IsAir)
         {

--- a/Common/UI/Elements/UICustomHoverImageItemSlot.cs
+++ b/Common/UI/Elements/UICustomHoverImageItemSlot.cs
@@ -15,6 +15,8 @@ public class UICustomHoverImageItemSlot : UIHoverImageItemSlot
     private bool IsDyeSlot => Context == ItemSlot.Context.EquipDye;
     private static Item[] dummyArray = [new Item()];
 
+	public int VirtualSlot => virtualSlot;
+
     public UICustomHoverImageItemSlot(
         Asset<Texture2D> backgroundTexture,
         Asset<Texture2D> iconTexture,


### PR DESCRIPTION
﻿### Link Issues
Resolves #1300 
Resolves #1301
Resolves #1304

### Description of Work
- Fixed a critical issue where right clicking a non-equippable item could equip or even duplicate it.
- Fixed a critical issue where right clicking an accessory could delete it forever.
- Fixed an issue that could lead to crashes in accessory-adjacent code of other mods such as Calamity's Vanities.
- Fixed hardmode accessory slots' unreachable items' effects being applied even in non-hardmode worlds.
- Fixed accessories put in extra accessory slots not being visible.
- Fixed right clicks not working on extra accessory slots.
- Some I may have fixed without knowing of, and some I may not recall.

**In need of testing:**
- (!) I have swapped the indices that vanity and dye slots point to. Does this make some previously equipped items unreachable?

**Known remaining non-critical issues:**
- Right clicking an accessory when all vanilla slots are full may cause an unrelated swap even if PoT's custom accessories are free.
- Dyes may apply to the wrong accessory indices?
- There are surely more I do not know of.

### Comments
Minimal changes, we are still better off rewriting this to use TML's ModAccessorySlot.
