### PR TITLE
Fix batch 2025-08-21

### DIFF
--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -167,7 +167,7 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 			Rarity = oldSelf.Rarity;
 			Affixes = oldSelf.Affixes;
 
-			// We should not need to reapply Rarity here.
+			ApplyRarity(npc, fromNet: true);
 		}
 	}
 
@@ -274,15 +274,15 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 				break;
 			case ItemRarity.Magic:
 				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(125, 125, 255), 0.5f);
-				npc.lifeMax *= 2; //Magic mobs get 100% increased life
-				npc.life = npc.lifeMax + 1; //This will trigger health bar to appear
-				npc.damage = (int)(npc.damage * 1.1f); //Magic mobs get 10% increase damage
+				npc.lifeMax *= 2; // Magic mobs get 100% increased life
+				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
+				npc.damage = (int)(npc.damage * 1.1f); // Magic mobs get 10% increase damage
 				break;
 			case ItemRarity.Rare:
 				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(255, 255, 0), 0.5f);
-				npc.lifeMax *= 3; //Rare mobs get 200% Increased Life
-				npc.life = npc.lifeMax + 1; //This will trigger health bar to appear
-				npc.damage = (int)(npc.damage * 1.2f); //Magic mobs get 20% increase damage
+				npc.lifeMax *= 3; // Rare mobs get 200% Increased Life
+				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
+				npc.damage = (int)(npc.damage * 1.2f); // Magic mobs get 20% increase damage
 				break;
 			case ItemRarity.Unique:
 				break;

--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -268,6 +268,8 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 
 		Affixes.ForEach(a => a.PreRarity(npc));
 
+		bool alwaysDisplayHealthbar = false;
+
 		switch (Rarity)
 		{
 			case ItemRarity.Normal:
@@ -277,17 +279,25 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 				npc.lifeMax *= 2; // Magic mobs get 100% increased life
 				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
 				npc.damage = (int)(npc.damage * 1.1f); // Magic mobs get 10% increase damage
+				alwaysDisplayHealthbar = true;
 				break;
 			case ItemRarity.Rare:
 				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(255, 255, 0), 0.5f);
 				npc.lifeMax *= 3; // Rare mobs get 200% Increased Life
 				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
 				npc.damage = (int)(npc.damage * 1.2f); // Magic mobs get 20% increase damage
+				alwaysDisplayHealthbar = true;
 				break;
 			case ItemRarity.Unique:
+				alwaysDisplayHealthbar = true;
 				break;
 			default:
 				throw new InvalidOperationException("Invalid rarity!");
+		}
+
+		if (alwaysDisplayHealthbar && npc.TryGetGlobalNPC(out HealthbarsNPC healthbars))
+		{
+			healthbars.AlwaysDisplayHealthbar = true;
 		}
 
 		SetName(npc);

--- a/Common/Systems/MobSystem/HealthbarsNPC.cs
+++ b/Common/Systems/MobSystem/HealthbarsNPC.cs
@@ -1,0 +1,49 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace PathOfTerraria.Common.Systems.MobSystem;
+
+internal class HealthbarsNPC : GlobalNPC
+{
+	public override bool InstancePerEntity => true;
+
+	public bool AlwaysDisplayHealthbar;
+
+	public override void Load()
+	{
+		IL_Main.DrawInterface_14_EntityHealthBars += EntityHealthBarsInjection;
+	}
+
+	private static void EntityHealthBarsInjection(ILContext ctx)
+	{
+		var il = new ILCursor(ctx);
+
+		int locNpcIndex = -1;
+
+		// Match 'if (npc[num2].life != npc[num2].lifeMax && ...)'.
+		il.GotoNext(
+			MoveType.After,
+			i => i.MatchLdsfld(typeof(Main), nameof(Main.npc)),
+			i => i.MatchLdloc(out locNpcIndex),
+			i => i.MatchLdelemRef(),
+			i => i.MatchLdfld(typeof(NPC), nameof(NPC.lifeMax)),
+			i => i.MatchBeq(out _)
+		);
+
+		// All we do here is cause the equality comparison to fail if we want the healthbar to render.
+		il.Index--;
+		il.Emit(OpCodes.Ldloc, locNpcIndex);
+		il.EmitDelegate(ModifyHealthbarDisplayComparisonValue);
+	}
+
+	private static int ModifyHealthbarDisplayComparisonValue(int lifeMax, int npcIndex)
+	{
+		return ShouldForceNpcHealthbarDisplay(npcIndex) ? Main.npc[npcIndex].life - 1 : lifeMax;
+	}
+
+	private static bool ShouldForceNpcHealthbarDisplay(int npcIndex)
+	{
+		NPC npc = Main.npc[npcIndex];
+		return npc.TryGetGlobalNPC(out HealthbarsNPC hNpc) && hNpc.AlwaysDisplayHealthbar;
+	}
+}

--- a/Common/UI/TooltipOverrides.cs
+++ b/Common/UI/TooltipOverrides.cs
@@ -42,7 +42,8 @@ public sealed class TooltipOverrides : ModSystem
 		Item hoverItem = Main.HoverItem;
 		Item mouseItem = Main.mouseItem?.IsAir == false ? Main.mouseItem : player.inventory[58];
 		bool drawForHoverItem = (!isLate || !drewHoverItem) && (hoverItem?.IsAir) == false && ShouldOverrideHoverItemTooltip();
-		bool drawForMouseItem = (!isLate || !drewMouseItem) && (mouseItem?.IsAir) == false && Main.LocalPlayer.mouseInterface && !player.ItemAnimationActive && mouseItem.IsNotSameTypePrefixAndStack(hoverItem);
+		bool isHoveringOverUI = Main.LocalPlayer.mouseInterface || drawForHoverItem || drewHoverItem;
+		bool drawForMouseItem = (!isLate || !drewMouseItem) && (mouseItem?.IsAir) == false && isHoveringOverUI && !player.ItemAnimationActive && mouseItem.IsNotSameTypePrefixAndStack(hoverItem);
 		bool drawSideBySide = drawForHoverItem && drawForMouseItem;
 
 		// If we are reacting to a late Hover/MouseItem mutation, i.e. after the tooltips have already been drawn, then we need to make new instances last a whole tick.

--- a/Common/UI/TooltipOverrides.cs
+++ b/Common/UI/TooltipOverrides.cs
@@ -18,6 +18,7 @@ public sealed class TooltipOverrides : ModSystem
 
 	private static void OnDrawMouseText(On_Main.orig_DrawInterface_33_MouseText orig, Main self)
 	{
+		orig(self);
 		AddDefaultTooltips();
 	}
 

--- a/Core/Hooks/NpcTransformHooks.cs
+++ b/Core/Hooks/NpcTransformHooks.cs
@@ -126,25 +126,22 @@ file class NpcTransformHooksImpl : ILoadable
 			i => i.MatchLdfld(typeof(NPC), nameof(NPC.type)),
 			i => i.MatchStloc(out locOldType)
 		);
-
-		// Emit pre-transform hook
+		// Emit PreTransform hook.
 		il.Emit(OpCodes.Ldarg_0);
 		il.Emit(OpCodes.Ldarg_1);
 		il.EmitDelegate(Hook.InvokePreTransform);
-
 		// Emit export
 		il.Emit(OpCodes.Ldarg_0);
 		il.Emit(OpCodes.Ldloca, locOldGlobals);
 		il.EmitDelegate(ExportGlobals);
 
-		// Match 'shimmerTransparency = num2;'.
+		// Match 'spriteDirection = num5;'.
 		il.GotoNext(
 			MoveType.After,
 			i => i.MatchLdarg0(),
 			i => i.MatchLdloc(out _),
-			i => i.MatchStfld(typeof(NPC), nameof(NPC.shimmerTransparency))
+			i => i.MatchStfld(typeof(NPC), nameof(NPC.spriteDirection))
 		);
-
 		// Emit import.
 		il.Emit(OpCodes.Ldarg_0);
 		il.Emit(OpCodes.Ldloc, locOldType);
@@ -156,8 +153,7 @@ file class NpcTransformHooksImpl : ILoadable
 			MoveType.After,
 			i => i.MatchStfld(typeof(NPC), nameof(NPC.altTexture))
 		);
-
-		// Emit OnTransform invoke.
+		// Emit PostTransform invoke.
 		il.Emit(OpCodes.Ldarg_0);
 		il.Emit(OpCodes.Ldloc, locOldType);
 		il.EmitDelegate(Hook.InvokePostTransform);

--- a/Core/Hooks/NpcTransformHooks.cs
+++ b/Core/Hooks/NpcTransformHooks.cs
@@ -1,0 +1,186 @@
+﻿using System.Diagnostics;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using PathOfTerraria.Utilities;
+using Terraria.ModLoader.Core;
+using Hook = PathOfTerraria.Core.Hooks.INpcTransformCallbacks;
+
+namespace PathOfTerraria.Core.Hooks;
+
+#nullable enable
+
+#pragma warning disable IDE0220 // Add explicit cast
+
+/// <summary>
+/// Various hooks relating to the <see cref="NPC.Transform"/> method.
+/// </summary>
+internal interface INpcTransformCallbacks
+{
+	public static readonly GlobalHookList<GlobalNPC> PreTransformHook = NPCLoader.AddModHook(GlobalHookList<GlobalNPC>.Create(i => ((Hook)i).PreTransform));
+	public static readonly GlobalHookList<GlobalNPC> TransformTransferHook = NPCLoader.AddModHook(GlobalHookList<GlobalNPC>.Create(i => ((Hook)i).TransformTransfer));
+	public static readonly GlobalHookList<GlobalNPC> PostTransformHook = NPCLoader.AddModHook(GlobalHookList<GlobalNPC>.Create(i => ((Hook)i).PostTransform));
+
+	/// <summary>
+	/// Called before an NPC transforms using <see cref="NPC.Transform"/>.
+	/// </summary>
+	public virtual void PreTransform(NPC npc, int oldType) { }
+
+	/// <summary>
+	/// Allows data to be transferred between global instances during <see cref="NPC.Transform"/>'s invocation.
+	/// <br/> Is not called for <see cref="ModNPC"/> instances.
+	/// </summary>
+	public virtual void TransformTransfer(NPC npc, int oldType, Hook? oldInstance) { }
+
+	/// <summary>
+	/// Called after an NPC transforms using <see cref="NPC.Transform"/>.
+	/// </summary>
+	public virtual void PostTransform(NPC npc, int oldType) { }
+
+	public static void InvokePreTransform(NPC npc, int oldType)
+	{
+		if (npc.ModNPC is Hook modNpc)
+		{
+			modNpc.PreTransform(npc, oldType);
+		}
+
+		foreach (Hook g in PreTransformHook.Enumerate(npc))
+		{
+			g.PreTransform(npc, oldType);
+		}
+	}
+
+	public static void InvokePostTransform(NPC npc, int oldType)
+	{
+		if (npc.ModNPC is Hook modNpc)
+		{
+			modNpc.PostTransform(npc, oldType);
+		}
+
+		foreach (Hook g in PostTransformHook.Enumerate(npc))
+		{
+			g.PostTransform(npc, oldType);
+		}
+	}
+
+	public static void InvokeTransformTransfer(NPC npc, int oldType, ReadOnlySpan<GlobalNPC> oldGlobals)
+	{
+#if DEBUG
+		// The below lookups assume that all globals, old and current, are ordered by their StaticIndex.
+		// So let us assert that in Debug mode.
+		for (int i = 1; i < oldGlobals.Length; i++)
+		{
+			Debug.Assert(oldGlobals[i - 1].StaticIndex < oldGlobals[i].StaticIndex);
+		}
+#endif
+
+		int oldIndex = 0;
+
+		foreach (Hook newInstance in TransformTransferHook.Enumerate(npc))
+		{
+			var newGlobal = (GlobalNPC)newInstance;
+			Hook? oldInstance = null;
+
+			// Lookup the old instance matching this global.
+			int oldIndexCopy = oldIndex;
+			for (; oldIndex < oldGlobals.Length; oldIndex++)
+			{
+				GlobalNPC oldGlobal = oldGlobals[oldIndex];
+				if (oldGlobal.StaticIndex == newGlobal.StaticIndex)
+				{
+					oldInstance = (Hook)oldGlobal;
+					break;
+				}
+			}
+
+			if (oldInstance == null)
+			{
+				oldIndex = oldIndexCopy;
+			}
+
+			newInstance.TransformTransfer(npc, oldType, oldInstance);
+		}
+	}
+}
+
+file class NpcTransformHooksImpl : ILoadable
+{
+	void ILoadable.Load(Mod mod)
+	{
+		IL_NPC.Transform += TransformInjection;
+	}
+
+	void ILoadable.Unload() { }
+
+	private static void TransformInjection(ILContext ctx)
+	{
+		var il = new ILCursor(ctx);
+
+		// Define local variables.
+		int locOldGlobals = ILUtils.AddLocalVariable(ctx, typeof(GlobalNPC[]));
+		int locOldType = -1;
+
+		// Match 'int oldType = type;'.
+		il.GotoNext(
+			MoveType.Before,
+			i => i.MatchLdarg0(),
+			i => i.MatchLdfld(typeof(NPC), nameof(NPC.type)),
+			i => i.MatchStloc(out locOldType)
+		);
+
+		// Emit pre-transform hook
+		il.Emit(OpCodes.Ldarg_0);
+		il.Emit(OpCodes.Ldarg_1);
+		il.EmitDelegate(Hook.InvokePreTransform);
+
+		// Emit export
+		il.Emit(OpCodes.Ldarg_0);
+		il.Emit(OpCodes.Ldloca, locOldGlobals);
+		il.EmitDelegate(ExportGlobals);
+
+		// Match 'shimmerTransparency = num2;'.
+		il.GotoNext(
+			MoveType.After,
+			i => i.MatchLdarg0(),
+			i => i.MatchLdloc(out _),
+			i => i.MatchStfld(typeof(NPC), nameof(NPC.shimmerTransparency))
+		);
+
+		// Emit import.
+		il.Emit(OpCodes.Ldarg_0);
+		il.Emit(OpCodes.Ldloc, locOldType);
+		il.Emit(OpCodes.Ldloc, locOldGlobals);
+		il.EmitDelegate(ImportGlobals);
+
+		// Match 'altTexture = 0;'.
+		il.GotoNext(
+			MoveType.After,
+			i => i.MatchStfld(typeof(NPC), nameof(NPC.altTexture))
+		);
+
+		// Emit OnTransform invoke.
+		il.Emit(OpCodes.Ldarg_0);
+		il.Emit(OpCodes.Ldloc, locOldType);
+		il.EmitDelegate(Hook.InvokePostTransform);
+	}
+
+	private static void ExportGlobals(NPC npc, out GlobalNPC[] result)
+	{
+		int numGlobals = 0;
+		EntityGlobalsEnumerator<GlobalNPC> it = npc.Globals;
+		while (it.MoveNext()) { numGlobals++; }
+
+		// If it were plausible to create a try-finally structure in the above stack, then we could fearlessly rent arrays instead.
+		result = new GlobalNPC[numGlobals]; //ArrayPool<GlobalNPC>.Shared.Rent(numGlobals);
+
+		int idx = 0;
+		foreach (GlobalNPC global in npc.Globals)
+		{
+			result[idx++] = global;
+		}
+	}
+
+	private static void ImportGlobals(NPC npc, int oldType, GlobalNPC[] array)
+	{
+		Hook.InvokeTransformTransfer(npc, oldType, array);
+	}
+}

--- a/Utilities/ILUtils.cs
+++ b/Utilities/ILUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 
@@ -21,5 +22,22 @@ internal static class ILUtils
 		}
 
 		return cursor;
+	}
+
+	/// <inheritdoc cref="AddLocalVariable(ILContext, Type)"/>
+	public static int AddLocalVariable(ILCursor cursor, Type type)
+	{
+		return AddLocalVariable(cursor.Context, type);
+	}
+
+	/// <summary> Declares a new local variable in the context's body. Returns its index. </summary>
+	public static int AddLocalVariable(ILContext ctx, Type type)
+	{
+		TypeReference importedType = ctx.Import(type);
+		int localId = ctx.Body.Variables.Count;
+
+		ctx.Body.Variables.Add(new VariableDefinition(importedType));
+
+		return localId;
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves #1209
Resolves #1303
Resolves #1309

### Description of Work
- Fixed transforming NPCs (such as wall-crawling spiders) continuously growing in power by re-rolling rarities and affixes every time they transform. Very scary.
- Fixed some mouse texts, such as that of the ruler mode and minimap hovers, not displaying.
- Fixed tooltips not showing for item chat tags and similar mod elements
- Tooltips of dragged inventory items will now also display when hovering over item chat tags.
