### PR TITLE
Implemented a unified boss tracker to account for edge-case boss despawns.

### DIFF
--- a/Common/Subworlds/BossDomains/FightTracking.cs
+++ b/Common/Subworlds/BossDomains/FightTracking.cs
@@ -1,0 +1,171 @@
+﻿#pragma warning disable CS9124 // Parameter is captured into the state of the enclosing type and its value is also used to initialize a field, property, or event.
+
+using System.Collections.Generic;
+
+namespace PathOfTerraria.Common.Subworlds.BossDomains;
+
+public enum FightState
+{
+	Halted = -1,
+	NotStarted,
+	JustStarted,
+	InProgress,
+	EnemyVanished,
+	JustCompleted,
+	AlreadyCompleted,
+}
+
+/// <summary>
+/// Keeps track of whether a fight's boss or other enemies have been spawned, defeated, or else.
+/// </summary>
+/// <param name="npcTypes">The type IDs making up the fight's enemy or enemies.</param>
+public struct FightTracker(int[] npcTypes)
+{
+	public int[] NpcTypes { get; } = npcTypes;
+
+	/// <summary> If true, the fight's start will not be signaled automatically when any tracked enemy is detected in the world. </summary>
+	public bool ManualStart { get; init; }
+	/// <summary> If true when enemies vanish without properly dying, the fight's data will be reset automatically, allowing a restart. </summary>
+	public bool ResetOnVanish { get; init; }
+	/// <summary> If true when enemies vanish without properly dying, the tracker's state will be put into <see cref="FightState.Halted"/> for the specified bit of time. </summary>
+	public uint? HaltTimeOnVanish { get; init; }
+
+	public bool Started { get; private set; }
+	public bool AnnouncedStart { get; private set; }
+	public bool Completed { get; private set; }
+	public uint StartKillCount { get; private set; }
+	public uint HaltTime { get; private set; }
+
+	public void Reset()
+	{
+		this = new FightTracker(NpcTypes);
+	}
+
+	public void SignalStart()
+	{
+		Started = true;
+		StartKillCount = GetCurrentKillCount();
+	}
+
+	public void SetHaltTime(uint ticks)
+	{
+		HaltTime = ticks;
+	}
+
+	// Could be made into an iterator method, but that may be more confusing than useful or convenient.
+	public FightState UpdateState()
+	{
+		if (HaltTime > 0)
+		{
+			HaltTime--;
+			return FightState.Halted;
+		}
+
+		if (!Started)
+		{
+			if (!ManualStart && AnyNPCs())
+			{
+				SignalStart();
+			}
+			else
+			{
+				return FightState.NotStarted;
+			}
+		}
+
+		if (!AnnouncedStart)
+		{
+			AnnouncedStart = true;
+			return FightState.JustStarted;
+		}
+
+		if (Completed)
+		{
+			return FightState.AlreadyCompleted;
+		}
+
+		if (!AnyNPCs())
+		{
+			if (GetCurrentKillCount() > StartKillCount)
+			{
+				Completed = true;
+				return FightState.JustCompleted;
+			}
+
+			if (ResetOnVanish)
+			{
+				Reset();
+			}
+
+			if (HaltTimeOnVanish is uint ticks)
+			{
+				SetHaltTime(ticks);
+			}
+
+			return FightState.EnemyVanished;
+		}
+
+		return FightState.InProgress;
+	}
+
+	private readonly uint GetCurrentKillCount()
+	{
+		return LocalKillCountTracking.Get(NpcTypes);
+	}
+
+	private readonly bool AnyNPCs()
+	{
+		foreach (int type in npcTypes)
+		{
+			foreach (NPC activeNpc in Main.ActiveNPCs)
+			{
+				if (activeNpc.type == type) { return true; }
+			}
+		}
+
+		return false;
+	}
+}
+
+/// <summary>
+/// Keeps track of all NPC kills performed in the world. Does not save anything.
+/// </summary>
+internal sealed class LocalKillCountTracking : ModSystem
+{
+	private static uint[] localKillCounts = [];
+
+	public override void Load()
+	{
+		On_NPC.CountKillForBannersAndDropThem += static (orig, npc) =>
+		{
+			orig(npc);
+			CountKill(npc);
+		};
+	}
+
+	private static void CountKill(NPC npc)
+	{
+		if (npc?.type >= 0 && npc.type < NPCLoader.NPCCount)
+		{
+			Array.Resize(ref localKillCounts, NPCLoader.NPCCount);
+			localKillCounts[npc.type]++;
+		}
+	}
+
+	public static uint Get(int npcType)
+	{
+		return npcType >= 0 && npcType < localKillCounts.Length ? localKillCounts[npcType] : 0;
+	}
+
+	public static uint Get(ReadOnlySpan<int> npcTypes)
+	{
+		uint count = 0;
+
+		foreach (int type in npcTypes)
+		{
+			count += Get(type);
+		}
+
+		return count;
+	}
+}

--- a/Common/Subworlds/BossDomains/Hardmode/MoonDomain/MoonlordSpawns.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/MoonDomain/MoonlordSpawns.cs
@@ -55,7 +55,7 @@ internal class MoonlordSpawns : GlobalNPC
 			return;
 		}
 
-		if (MoonDomainSystem.BossSpawned)
+		if (MoonDomainSystem.FightTracker.Started)
 		{
 			pool.Clear();
 			return;
@@ -140,7 +140,7 @@ internal class MoonlordSpawns : GlobalNPC
 			return;
 		}
 
-		if (MoonDomainSystem.BossSpawned)
+		if (MoonDomainSystem.FightTracker.Started)
 		{
 			return;
 		}

--- a/Common/Subworlds/BossDomains/Hardmode/TwinsDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/TwinsDomain.cs
@@ -33,8 +33,11 @@ internal class TwinsDomain : BossDomainSubworld
 	internal static int MetalLayerTransEnd => MetalLayerEnd + 20;
 	internal static int GateLayer => 410;
 
-	private static bool BossSpawned = false;
-	private static bool ExitSpawned = false;
+	public FightTracker FightTracker = new([NPCID.Retinazer, NPCID.Spazmatism])
+	{
+		ResetOnVanish = true,
+		HaltTimeOnVanish = 60 * 10,
+	};
 
 	/// <summary>
 	/// This is used as the check for "everyone's belowground" fails in MP by default. Waiting a bit to do it fixes the issue.
@@ -922,8 +925,7 @@ internal class TwinsDomain : BossDomainSubworld
 	{
 		base.OnEnter();
 
-		BossSpawned = false;
-		ExitSpawned = false;
+		FightTracker.Reset();
 	}
 
 	public override void Update()
@@ -938,7 +940,9 @@ internal class TwinsDomain : BossDomainSubworld
 
 		TileEntity.UpdateEnd();
 
-		if (!BossSpawned)
+		FightState state = FightTracker.UpdateState();
+
+		if (state == FightState.NotStarted)
 		{
 			if (Main.netMode == NetmodeID.SinglePlayer)
 			{
@@ -982,22 +986,15 @@ internal class TwinsDomain : BossDomainSubworld
 				{
 					NetMessage.SendData(MessageID.WorldData);
 				}
-
-				BossSpawned = true;
 			}
 		}
-		else
+		else if (state == FightState.JustCompleted)
 		{
-			if (!NPC.AnyNPCs(NPCID.Spazmatism) && !NPC.AnyNPCs(NPCID.Retinazer) && !ExitSpawned)
-			{
-				BossTracker.AddDowned(NPCID.Retinazer, false, true);
-				BossTracker.AddDowned(NPCID.Spazmatism, false, true);
+			BossTracker.AddDowned(NPCID.Retinazer, false, true);
+			BossTracker.AddDowned(NPCID.Spazmatism, false, true);
 
-				ExitSpawned = true;
-
-				IEntitySource src = Entity.GetSource_NaturalSpawn();
-				Projectile.NewProjectile(src, new Vector2(Width / 2, BlockLayer - 16).ToWorldCoordinates(), Vector2.Zero, ModContent.ProjectileType<ExitPortal>(), 0, 0, Main.myPlayer);
-			}
+			IEntitySource src = Entity.GetSource_NaturalSpawn();
+			Projectile.NewProjectile(src, new Vector2(Width / 2, BlockLayer - 16).ToWorldCoordinates(), Vector2.Zero, ModContent.ProjectileType<ExitPortal>(), 0, 0, Main.myPlayer);
 		}
 	}
 }

--- a/Common/Subworlds/BossDomains/Prehardmode/BoCDomain/BoCDomainSystem.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/BoCDomain/BoCDomainSystem.cs
@@ -42,7 +42,7 @@ internal class BoCDomainSystem : ModSystem
 		{
 			float strength = NPC.downedBoss2 ? 0.3f : 1;
 
-			if (domain.BossSpawned && !NPC.AnyNPCs(NPCID.BrainofCthulhu))
+			if (domain.FightTracker.Completed)
 			{
 				strength *= 0.5f;
 			}

--- a/Common/Subworlds/BossDomains/Prehardmode/BrainDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/BrainDomain.cs
@@ -28,8 +28,11 @@ public class BrainDomain : BossDomainSubworld
 
 	public Rectangle Arena = Rectangle.Empty;
 	public Vector2 ProjectilePosition = Vector2.Zero;
-	public bool BossSpawned = false;
-	public bool ReadyToExit = false;
+	public FightTracker FightTracker = new([NPCID.BrainofCthulhu])
+	{
+		ResetOnVanish = true,
+		HaltTimeOnVanish = 60 * 10,
+	};
 
 	public override List<GenPass> Tasks => [new PassLegacy("Reset", ResetStep),
 		new PassLegacy("Surface", GenSurface),
@@ -354,8 +357,7 @@ public class BrainDomain : BossDomainSubworld
 	{
 		base.OnEnter();
 
-		BossSpawned = false;
-		ReadyToExit = false;
+		FightTracker.Reset();
 	}
 
 	public override bool GetLight(Tile tile, int x, int y, ref FastRandom rand, ref Vector3 color)
@@ -415,10 +417,11 @@ public class BrainDomain : BossDomainSubworld
 			}
 		}
 
-		if (!BossSpawned && allInArena)
+		FightState state = FightTracker.UpdateState();
+
+		if (state == FightState.NotStarted && allInArena)
 		{
 			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X, Arena.Center.Y - 400, NPCID.BrainofCthulhu);
-			BossSpawned = true;
 
 			Main.spawnTileX = Arena.Center.X / 16;
 			Main.spawnTileY = Arena.Center.Y / 16;
@@ -428,14 +431,12 @@ public class BrainDomain : BossDomainSubworld
 				NetMessage.SendData(MessageID.WorldData);
 			}
 		}
-
-		if (BossSpawned && !NPC.AnyNPCs(NPCID.BrainofCthulhu) && !ReadyToExit)
+		else if (state == FightState.JustCompleted)
 		{
 			Vector2 pos = Arena.Center() + new Vector2(30, 100);
 			int proj = Projectile.NewProjectile(Entity.GetSource_NaturalSpawn(), pos, Vector2.Zero, ModContent.ProjectileType<ExitPortal>(), 0, 0, Main.myPlayer);
 
 			BossTracker.AddDowned(NPCID.BrainofCthulhu, false, true);
-			ReadyToExit = true;
 		}
 	}
 

--- a/Common/Subworlds/BossDomains/Prehardmode/KingSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/KingSlimeDomain.cs
@@ -24,9 +24,12 @@ public class KingSlimeDomain : BossDomainSubworld
 	internal static Point16 ArenaEntrance = Point16.Zero;
 
 	public Rectangle Arena = Rectangle.Empty;
-	public bool BossSpawned = false;
-	public bool ReadyToExit = false;
 	public List<Vector2> SlimePositions = [];
+	public FightTracker FightTracker = new([NPCID.KingSlime])
+	{
+		ResetOnVanish = true,
+		HaltTimeOnVanish = 60 * 10,
+	};
 
 	public override List<GenPass> Tasks => [new PassLegacy("Reset", ResetStep),
 		new FlatWorldPass(200, true, GetGenNoise()),
@@ -44,8 +47,7 @@ public class KingSlimeDomain : BossDomainSubworld
 	{
 		base.OnEnter();
 
-		BossSpawned = false;
-		ReadyToExit = false;
+		FightTracker.Reset();
 		SlimePositions.Clear();
 	}
 
@@ -257,7 +259,9 @@ public class KingSlimeDomain : BossDomainSubworld
 			}
 		}
 
-		if (!BossSpawned && allInArena)
+		FightState state = FightTracker.UpdateState();
+
+		if (state == FightState.NotStarted && allInArena)
 		{
 			for (int i = -6; i < 11; ++i)
 			{
@@ -274,17 +278,13 @@ public class KingSlimeDomain : BossDomainSubworld
 				NetMessage.SendTileSquare(-1, ArenaEntrance.X - 6, ArenaEntrance.Y, 16, 1);
 				NetMessage.SendData(MessageID.WorldData);
 			}
-
-			BossSpawned = true;
 		}
-
-		if (BossSpawned && !NPC.AnyNPCs(NPCID.KingSlime) && !ReadyToExit)
+		else if (state == FightState.JustCompleted)
 		{
 			Vector2 pos = Arena.Center() + new Vector2(0, 150);
 			Projectile.NewProjectile(Entity.GetSource_NaturalSpawn(), pos, Vector2.Zero, ModContent.ProjectileType<ExitPortal>(), 0, 0, Main.myPlayer);
 
 			BossTracker.AddDowned(NPCID.KingSlime, false, true);
-			ReadyToExit = true;
 		}
 	}
 }

--- a/Common/Subworlds/BossDomains/Prehardmode/WoFDomain/WoFDomainSystem.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/WoFDomain/WoFDomainSystem.cs
@@ -11,7 +11,7 @@ public class WoFDomainSystem : ModSystem
 {
 	public override void ModifyScreenPosition()
 	{
-		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
+		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.FightTracker.Started)
 		{
 			if (domain.LeftBlocked)
 			{
@@ -32,7 +32,7 @@ public class WoFDomainSystem : ModSystem
 
 	public override void NetSend(BinaryWriter writer)
 	{
-		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
+		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.FightTracker.Started)
 		{
 			writer.Write(domain.LeftBlocked);
 		}
@@ -40,7 +40,7 @@ public class WoFDomainSystem : ModSystem
 
 	public override void NetReceive(BinaryReader reader)
 	{
-		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.BossSpawned)
+		if (SubworldSystem.Current is WallOfFleshDomain domain && !domain.FightTracker.Started)
 		{
 			domain.LeftBlocked = reader.ReadBoolean();
 		}

--- a/Content/NPCs/Town/LloydNPC.cs
+++ b/Content/NPCs/Town/LloydNPC.cs
@@ -598,7 +598,7 @@ public sealed class LloydNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, IP
 
 		if (SubworldSystem.Current is BrainDomain domain)
 		{
-			return Language.GetTextValue(baseNPC + (domain.BossSpawned && !NPC.AnyNPCs(NPCID.BrainofCthulhu) ? "DomainBossDead." : "InDomain.") + Main.rand.Next(3));
+			return Language.GetTextValue(baseNPC + (domain.FightTracker.Completed ? "DomainBossDead." : "InDomain.") + Main.rand.Next(3));
 		}
 
 		if (doPathing)


### PR DESCRIPTION
﻿### Link Issues
Resolves #1228

### Description of Work
Causing bosses to despawn in one way or another will no longer count as a victory. They will instead respawn in a few seconds.

### Comments
We should probably eventually prevent bosses from despawning altogether, but this PR is a catch-all that has to exist regardless.