### PR TITLE
Fixed how quests could be seen by default is they were "Active"

### DIFF
--- a/Common/UI/Quests/QuestsUIState.cs
+++ b/Common/UI/Quests/QuestsUIState.cs
@@ -178,7 +178,7 @@ public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 			player.PinnedQuest = null;
 		}
 
-		foreach (Quest quest in player.QuestsByName.Values.OrderByDescending(x => x.FullName == player.PinnedQuest))
+		foreach (Quest quest in player.QuestsByName.Values.Where(q => q.Active || q.Completed).OrderByDescending(x => x.FullName == player.PinnedQuest))
 		{
 			UISelectableQuest selectable = new(quest);
 			selectable.OnLeftClick += (a, b) => SelectQuest(quest.FullName);


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
An old IsActive check was removed previously in #1311, which in the new version allowed all quests to be automatically added to quest log if they were available, without talking to NPCs. This is fixed now.

### Comments
Tested with first few quests as well as the HM 0/10 queen slime quest and seems to work fine now.