### PR TITLE
Prevent duplicate items dropping from the same mob

### DIFF
--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -147,9 +147,7 @@ internal class ArpgNPC : GlobalNPC
 		// Roll guaranteed rare/magic items first
 		if (Rarity is ItemRarity.Magic or ItemRarity.Rare)
 		{
-			drops.AddRange(DropTable.RollManyMobDrops(1, itemLevel, DropRarity * magicFind,
-				gearChance: 0.8f, currencyChance: 0.15f, mapChance: 0.05f,
-				forceRarity: Rarity));
+			drops.Add(DropTable.RollMobDrops(itemLevel, DropRarity * magicFind, gearChance: 0.8f, currencyChance: 0.15f, mapChance: 0.05f, null, forceRarity: Rarity));
 		}
 
 		// Roll the remaining items normally


### PR DESCRIPTION

### Description of Work
Adjust the OnKill method to prevent duplicates to roll from the same mob

### Comments
This seems to reduce the droprate, which doesn't logically make sense, because the amount of rolls should be the same as before, it's using the same logic to determine the amount of drops.
