### PR TITLE
Potions cant be used at max, adds sell price to grimoire pickups

### DIFF
--- a/Common/Systems/PotionPlayer.cs
+++ b/Common/Systems/PotionPlayer.cs
@@ -27,7 +27,7 @@ internal class PotionPlayer : ModPlayer
 	{
 		PotionPlayer mp = self.GetModPlayer<PotionPlayer>();
 
-		if (mp.HealingLeft <= 0 || self.HasBuff(BuffID.PotionSickness))
+		if (mp.HealingLeft <= 0 || self.HasBuff(BuffID.PotionSickness) || self.statLife >= self.statLifeMax2)
 		{
 			return;
 		}
@@ -58,7 +58,7 @@ internal class PotionPlayer : ModPlayer
 	{
 		PotionPlayer mp = self.GetModPlayer<PotionPlayer>();
 
-		if (mp.ManaLeft <= 0 || self.HasBuff(BuffID.ManaSickness))
+		if (mp.ManaLeft <= 0 || self.HasBuff(BuffID.ManaSickness) || self.statMana >= self.statManaMax2)
 		{
 			return;
 		}

--- a/Content/Items/Pickups/GrimoirePickup.cs
+++ b/Content/Items/Pickups/GrimoirePickup.cs
@@ -38,6 +38,7 @@ internal abstract class GrimoirePickup : ModItem, IPoTGlobalItem
 
 		PoTInstanceItemData data = this.GetInstanceData();
 		data.ItemType = ItemType.Grimoire;
+		Item.value = Item.sellPrice(silver: 20);
 	}
 
 	public override void OnSpawn(IEntitySource source)


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Potions can now not be used while at full hp or full mp
- Added sell price of 20silver to all grimoire items.

### Comments
