### PR TITLE
Fix Echoing Shards on Maps rerolling the item level

### DIFF
--- a/Content/Items/Currency/EchoingShard.cs
+++ b/Content/Items/Currency/EchoingShard.cs
@@ -30,8 +30,7 @@ public class EchoingShard : CurrencyShard
 	{
 		PoTInstanceItemData data = player.HeldItem.GetInstanceData();
 
-		var clonedItem = new Item();
-		clonedItem.SetDefaults(player.HeldItem.type);
+		Item clonedItem = player.HeldItem.Clone();
 		PoTInstanceItemData clonedData = clonedItem.GetInstanceData();
 		clonedData.Rarity = data.Rarity;
 		clonedData.Influence = data.Influence;


### PR DESCRIPTION
This PR fixes #1234 

There's a Clone method, it's overridden on Map to set the `ItemLevel` and tier correctly, but it wasn't used in EchoingShard.cs

### Notes

I've verified that corrupt items, uniques and cloned items can't be cloned.
Cloned maps correctly have the original item level and tier.
All other items (tested with rings and weapons) also correctly clone the original item.

### Patch note
> Echoing shard now correctly clones the original item, copying all stats, including item level and map tier.