### PR TITLE
Updated pre-crafting tooltips

### DIFF
--- a/Common/Systems/ItemTooltipBuilder.cs
+++ b/Common/Systems/ItemTooltipBuilder.cs
@@ -5,6 +5,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using PathOfTerraria.Utilities;
+using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Common.Systems;
 
@@ -41,9 +42,28 @@ public sealed class ItemTooltipBuilder : ModSystem
 		Item hoverItemCopy = Main.HoverItem;
 		Player localPlayerCopy = Main.LocalPlayer;
 
+		Item itemToUse = item;
+		
+		//Only run on things with ilvl
+		if (GearGlobalItem.IsGearItem(item))
+		{
+			PoTInstanceItemData data = item.GetInstanceData();
+        
+			// Calculate what the crafting level should be
+			int expectedCraftingLevel = PoTItemHelper.PickItemLevel(false, true);
+        
+			// Check if this is a preview for crafting
+			if (data.RealLevel < expectedCraftingLevel)
+			{
+				// Create a temporary item copy with the correct crafting level
+				itemToUse = item.Clone();
+				SetItemLevel.Invoke(itemToUse, expectedCraftingLevel);
+			}
+		}
+
 		try
 		{
-			Main.HoverItem = item;
+			Main.HoverItem = itemToUse;
 			Main.player[Main.myPlayer] = player;
 			drawTooltipEvaluationCounter = checked(drawTooltipEvaluationCounter + 1);
 


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Hovering over crafted items in any crafting window will now display an accurate item level when crafted

### Comments
Tested pretty much everything I could. Should be fine, but lmk if something seems wrong!
I'm not sure if when "cloning" here, it needs to be garbage cleaned up as well?