### PR TITLE
Block special bombs

### DIFF
--- a/Common/Systems/DisableBuilding/StopBuildingPlayer.cs
+++ b/Common/Systems/DisableBuilding/StopBuildingPlayer.cs
@@ -18,7 +18,7 @@ internal class StopBuildingPlayer : ModPlayer
 {
 	public static HashSet<int> InvalidItemsToUse = [ItemID.Wrench, ItemID.BlueWrench, ItemID.GreenWrench, ItemID.YellowWrench, ItemID.MulticolorWrench, ItemID.WireKite,
 		ItemID.ActuationRod, ItemID.ActuationAccessory, ItemID.Actuator, ItemID.RodofDiscord, ItemID.RodOfHarmony, ItemID.WetBomb, ItemID.HoneyBomb, ItemID.LavaBomb, 
-		ItemID.DirtBomb, ItemID.DirtStickyBomb, ItemID.DryBomb];
+		ItemID.DirtBomb, ItemID.DirtStickyBomb, ItemID.DryBomb, ItemID.MagicConch, ItemID.DemonConch, ItemID.ShellphoneOcean, ItemID.ShellphoneHell];
 
 	/// <summary>
 	/// Stops the player from building if true. This is reset every frame.

--- a/Common/Systems/DisableBuilding/StopBuildingProjectiles.cs
+++ b/Common/Systems/DisableBuilding/StopBuildingProjectiles.cs
@@ -1,0 +1,64 @@
+﻿using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using SubworldLibrary;
+using System.Collections.Generic;
+using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.Systems.DisableBuilding;
+
+/// <summary>
+/// Used to stop certain projectiles from adding or removing liquids.
+/// </summary>
+internal class StopBuildingProjectiles : ILoadable
+{
+	public readonly record struct ProjectileAlias(int ProjectileId, int AltProjectileId, int ItemId, int AltItemId);
+
+	public static Dictionary<int, ProjectileAlias> ProjectileAliasingsByProjectileId = [];
+	public static Dictionary<int, ProjectileAlias> ProjectileAliasingsByItemId = [];
+
+	public void Load(Mod mod)
+	{
+		On_Projectile.NewProjectile_IEntitySource_float_float_float_float_int_int_float_int_float_float_float += ModNewProj;
+
+		// Some projectiles do not have items associated with them. As such, their ItemId is set to None to simply ignore it.
+		ProjectileAliasingsByProjectileId.Clear();
+		AddAliasing(ProjectileID.DryRocket, ProjectileID.RocketI, ItemID.DryRocket, ItemID.RocketI);
+		AddAliasing(ProjectileID.DrySnowmanRocket, ProjectileID.RocketI, ItemID.None, ItemID.RocketI);
+		AddAliasing(ProjectileID.WetRocket, ProjectileID.RocketI, ItemID.WetRocket, ItemID.RocketI);
+		AddAliasing(ProjectileID.WetSnowmanRocket, ProjectileID.RocketI, ItemID.None, ItemID.RocketI);
+		AddAliasing(ProjectileID.LavaRocket, ProjectileID.RocketI, ItemID.LavaRocket, ItemID.RocketI);
+		AddAliasing(ProjectileID.LavaSnowmanRocket, ProjectileID.RocketI, ItemID.None, ItemID.RocketI);
+		AddAliasing(ProjectileID.HoneyRocket, ProjectileID.RocketI, ItemID.HoneyRocket, ItemID.RocketI);
+		AddAliasing(ProjectileID.HoneySnowmanRocket, ProjectileID.RocketI, ItemID.None, ItemID.RocketI);
+	}
+
+	private static void AddAliasing(short projId, short altProjId, short itemId, short altItemId)
+	{
+		var alias = new ProjectileAlias(projId, altProjId, itemId, altItemId);
+		ProjectileAliasingsByProjectileId.Add(projId, alias);
+
+		if (itemId != ItemID.None)
+		{
+			ProjectileAliasingsByItemId.Add(itemId, alias);
+		}
+	}
+
+	private int ModNewProj(On_Projectile.orig_NewProjectile_IEntitySource_float_float_float_float_int_int_float_int_float_float_float orig, IEntitySource spawnSource, 
+		float X, float Y, float SpeedX, float SpeedY, int Type, int Damage, float KnockBack, int Owner, float ai0, float ai1, float ai2)
+	{
+		if (SubworldSystem.Current is MappingWorld and not MoonLordDomain)
+		{
+			if (ProjectileAliasingsByProjectileId.TryGetValue(Type, out ProjectileAlias alias))
+			{
+				Type = alias.AltProjectileId;
+			}
+		}
+
+		return orig(spawnSource, X, Y, SpeedX, SpeedY, Type, Damage, KnockBack, Owner, ai0, ai1, ai2);
+	}
+
+	public void Unload()
+	{
+	}
+}

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Items;
 using PathOfTerraria.Common.Systems.Affixes;
+using PathOfTerraria.Common.Systems.DisableBuilding;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Content.Items.Consumables.Maps;
 using PathOfTerraria.Content.Items.Gear;
@@ -106,13 +107,15 @@ public sealed partial class ItemTooltips : GlobalItem
 			case "Description":
 			case "ShiftNotice":
 			case "SwapNotice":
+			case "BuildBlocked":
+			case "ShootBlocked":
 				yOffset = 2;
 				line.BaseScale = new Vector2(0.8f);
 				return true;
 		}
 
 		if (line.Name.Contains("Affix") || line.Name.Contains("Socket") || line.Name.StartsWith("Stat")
-		|| line.Name is "Damage" or "Defense" or "AttacksPerSecond" or "CriticalStrikeChance" or "ManaCost")
+			|| line.Name is "Damage" or "Defense" or "AttacksPerSecond" or "CriticalStrikeChance" or "ManaCost")
 		{
 			line.BaseScale = new Vector2(0.95f);
 			yOffset = -4;
@@ -350,6 +353,17 @@ public sealed partial class ItemTooltips : GlobalItem
 			{
 				OverrideColor = new Color(170, 170, 170)
 			});
+		}
+
+		if (StopBuildingPlayer.InvalidItemsToUse.Contains(item.type))
+		{
+			AddNewTooltipLine(item, tooltips, new TooltipLine(Mod, "BuildBlocked", Localize("BuildBlocked")) { OverrideColor = new Color(220, 110, 110) });
+		}
+
+		if (StopBuildingProjectiles.ProjectileAliasingsByItemId.TryGetValue(item.type, out StopBuildingProjectiles.ProjectileAlias alias))
+		{
+			string text = Language.GetTextValue("Mods.PathOfTerraria.Gear.Tooltips.ShootBlocked", Lang.GetItemName(alias.AltItemId), alias.AltItemId);
+			AddNewTooltipLine(item, tooltips, new TooltipLine(Mod, "ShootBlocked", text) { OverrideColor = new Color(220, 110, 110) });
 		}
 
 		// Affix tooltips

--- a/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	ManaCost: Mana Kosten
 	// AttackSpeed: Attack Speed
 	// CastSpeed: Cast Speed
+	// BuildBlocked: Blocked by the energies in the domain
+	// ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	ManaCost: Mana Cost
 	AttackSpeed: Attack Speed
 	CastSpeed: Cast Speed
+	BuildBlocked: Blocked by the energies in the domain
+	ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	// ManaCost: Mana Cost
 	// AttackSpeed: Attack Speed
 	// CastSpeed: Cast Speed
+	// BuildBlocked: Blocked by the energies in the domain
+	// ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	// ManaCost: Mana Cost
 	// AttackSpeed: Attack Speed
 	// CastSpeed: Cast Speed
+	// BuildBlocked: Blocked by the energies in the domain
+	// ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	ManaCost: Koszt many
 	// AttackSpeed: Attack Speed
 	// CastSpeed: Cast Speed
+	// BuildBlocked: Blocked by the energies in the domain
+	// ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	// ManaCost: Mana Cost
 	// AttackSpeed: Attack Speed
 	// CastSpeed: Cast Speed
+	// BuildBlocked: Blocked by the energies in the domain
+	// ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
@@ -18,6 +18,8 @@ Tooltips: {
 	ManaCost: "Расход маны "
 	// AttackSpeed: Attack Speed
 	// CastSpeed: Cast Speed
+	// BuildBlocked: Blocked by the energies in the domain
+	// ShootBlocked: Will be replaced by {0} [i:{1}] when shot
 }
 
 Influence: {


### PR DESCRIPTION
### Link Issues
Resolves: #1361

### Description of Work
- Stops the various liquid, tile and dry bombs from being used in domains
- Stops the various liquid and dry projectiles from being used in non-Moon Lord domains, replaced with Rocket I
- Disabled all teleporting items aside from those that teleport you to the spawn tile of the world
- Added blocking notice tooltip for clarity