### PR TITLE
Seperation of Explorable Map and Boss Map in Tooltip (#1358)

### DIFF
--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -6,6 +6,8 @@ using PathOfTerraria.Common.Items;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Content.Items.Consumables.Maps;
+using PathOfTerraria.Content.Items.Consumables.Maps.ExplorableMaps;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Gear;
 using PathOfTerraria.Utilities.Xna;
 using ReLogic.Content;
@@ -201,6 +203,25 @@ public sealed partial class ItemTooltips : GlobalItem
 		if (data.ItemType != ItemType.None || data.Rarity > ItemRarity.Normal)
 		{
 			string rarityDesc = GetDescriptor(data.ItemType, data.Rarity, data.Influence);
+
+			// Override the type descriptor for maps to distinguish Explorable vs Boss maps
+			if (item.ModItem is Map)
+			{
+				string mapTypeName = null;
+				if (item.ModItem is ExplorableMap)
+				{
+					mapTypeName = Language.GetTextValue("Mods.PathOfTerraria.Gear.ExplorableMap.Name");
+				}
+				else if (item.ModItem is BossMap)
+				{
+					mapTypeName = Language.GetTextValue("Mods.PathOfTerraria.Gear.BossMap.Name");
+				}
+
+				if (!string.IsNullOrWhiteSpace(mapTypeName))
+				{
+					rarityDesc = GetDescriptor(mapTypeName, data.Rarity, data.Influence);
+				}
+			}
 
 			if (item.ModItem is GearLocalizationCategory.IItem gear)
 			{

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -346,6 +346,12 @@ Shield: {
 }
 
 Map.Name: Map
+ExplorableMap: {
+    Name: Explorable Map
+}
+BossMap: {
+    Name: Boss Map
+}
 None.Name: None
 Magic.Name: Magic
 Ranged.Name: Ranged

--- a/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
@@ -346,6 +346,12 @@ Shield: {
 }
 
 // Map.Name: Map
+ExplorableMap: {
+    Name: Mapa Explorable
+}
+BossMap: {
+    Name: Mapa de Jefe
+}
 // None.Name: None
 // Magic.Name: Magic
 // Ranged.Name: Ranged

--- a/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
@@ -346,6 +346,12 @@ Shield: {
 }
 
 Map.Name: Carte
+ExplorableMap: {
+    Name: Carte Exploratoire
+}
+BossMap: {
+    Name: Carte de Boss
+}
 // None.Name: None
 Magic.Name: Magique
 Ranged.Name: À distance

--- a/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
@@ -346,6 +346,12 @@ Shield: {
 }
 
 Map.Name: Mapa
+ExplorableMap: {
+    Name: Mapa Eksploracyjna
+}
+BossMap: {
+    Name: Mapa Bossa
+}
 None.Name: Żadne
 Magic.Name: Magiczny
 Ranged.Name: Dystansowe

--- a/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
@@ -346,6 +346,12 @@ Shield: {
 }
 
 // Map.Name: Map
+ExplorableMap: {
+    Name: Mapa Explorável
+}
+BossMap: {
+    Name: Mapa de Chefe
+}
 // None.Name: None
 // Magic.Name: Magic
 // Ranged.Name: Ranged

--- a/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
@@ -346,6 +346,12 @@ Shield: {
 }
 
 Map.Name: Карта
+ExplorableMap: {
+    Name: Исследуемая карта
+}
+BossMap: {
+    Name: Карта босса
+}
 None.Name: Ничто
 Magic.Name: Магия
 Ranged.Name: Дистанционный


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1358 

### Description of Work

- Tooltips now say “Explorable Map” or “Boss Map” instead of generic “Map”.
- Detection based on base classes: ExplorableMap vs BossMap.
- Implemented in Core/Items/ItemTooltips.cs; no impact on other items.
- Added localization keys for all supported locales.
- Keeps existing rarity/influence formatting intact.
