### PR TITLE
Fix shard right clicking

### DIFF
--- a/Content/Items/Currency/LimpidShard.cs
+++ b/Content/Items/Currency/LimpidShard.cs
@@ -17,6 +17,12 @@ public class LimpidShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
+		Item heldItem = Main.LocalPlayer.HeldItem;
+		if (heldItem == null || heldItem.IsAir)
+		{
+			return base.CanRightClick();
+		}
+
 		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
 		return base.CanRightClick() && data.Rarity is ItemRarity.Magic or ItemRarity.Rare;
 	}

--- a/Content/Items/Currency/MysticShard.cs
+++ b/Content/Items/Currency/MysticShard.cs
@@ -19,6 +19,12 @@ public class MysticShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
+		Item heldItem = Main.LocalPlayer.HeldItem;
+		if (heldItem == null || heldItem.IsAir)
+		{
+			return base.CanRightClick();
+		}
+		
 		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
 		return base.CanRightClick() && data.Rarity is ItemRarity.Normal;
 	}

--- a/Content/Items/Currency/ShiftingShard.cs
+++ b/Content/Items/Currency/ShiftingShard.cs
@@ -19,6 +19,12 @@ public class ShiftingShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
+		Item heldItem = Main.LocalPlayer.HeldItem;
+		if (heldItem == null || heldItem.IsAir)
+		{
+			return base.CanRightClick();
+		}
+		
 		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
 		return base.CanRightClick() && data.Rarity is ItemRarity.Rare;
 	}


### PR DESCRIPTION
﻿### Link Issues
Resolves:  #1375

### Description of Work
- Fixed crash/weird UI disabling when right clicking either a Limpid, Mystic, or Shifting shard with nothing held. 

### Comments
- There was previously no check for air/null items, as Held.Item.GetInstanceData was crashing when simply right clicking on an item, now there's a simple null check.