### PR TITLE
Fix shard right clicking

### DIFF
--- a/Content/Items/Currency/LimpidShard.cs
+++ b/Content/Items/Currency/LimpidShard.cs
@@ -17,14 +17,7 @@ public class LimpidShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
-		Item heldItem = Main.LocalPlayer.HeldItem;
-		if (heldItem == null || heldItem.IsAir)
-		{
-			return base.CanRightClick();
-		}
-
-		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
-		return base.CanRightClick() && data.Rarity is ItemRarity.Magic or ItemRarity.Rare;
+		return base.CanRightClick() && Main.LocalPlayer.HeldItem.GetInstanceData().Rarity is ItemRarity.Magic or ItemRarity.Rare;
 	}
 
 	public override void RightClick(Player player)

--- a/Content/Items/Currency/MysticShard.cs
+++ b/Content/Items/Currency/MysticShard.cs
@@ -19,14 +19,7 @@ public class MysticShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
-		Item heldItem = Main.LocalPlayer.HeldItem;
-		if (heldItem == null || heldItem.IsAir)
-		{
-			return base.CanRightClick();
-		}
-		
-		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
-		return base.CanRightClick() && data.Rarity is ItemRarity.Normal;
+		return base.CanRightClick() && Main.LocalPlayer.HeldItem.GetInstanceData().Rarity is ItemRarity.Normal;
 	}
 
 	public override void RightClick(Player player)

--- a/Content/Items/Currency/ShiftingShard.cs
+++ b/Content/Items/Currency/ShiftingShard.cs
@@ -19,14 +19,8 @@ public class ShiftingShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
-		Item heldItem = Main.LocalPlayer.HeldItem;
-		if (heldItem == null || heldItem.IsAir)
-		{
-			return base.CanRightClick();
-		}
-		
 		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
-		return base.CanRightClick() && data.Rarity is ItemRarity.Rare;
+		return base.CanRightClick() && Main.LocalPlayer.HeldItem.GetInstanceData().Rarity is ItemRarity.Rare;
 	}
 
 	public override void RightClick(Player player)

--- a/Content/Items/Currency/ShiftingShard.cs
+++ b/Content/Items/Currency/ShiftingShard.cs
@@ -19,7 +19,6 @@ public class ShiftingShard : CurrencyShard
 
 	public override bool CanRightClick()
 	{
-		PoTInstanceItemData data = Main.LocalPlayer.HeldItem.GetInstanceData();
 		return base.CanRightClick() && Main.LocalPlayer.HeldItem.GetInstanceData().Rarity is ItemRarity.Rare;
 	}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Removed how data was being stored before the base.CanRightClick was called, now all shard funcs should work the same way. 

### Comments
