### PR TITLE
Affix tooltip corrections.

### DIFF
--- a/Common/Systems/Affixes/AffixTooltips.cs
+++ b/Common/Systems/Affixes/AffixTooltips.cs
@@ -20,6 +20,7 @@ public struct AffixTooltipLine()
 	public LocalizedText? TextWhenRemoved;
 	public float Value;
 	public bool Corrupt;
+	public bool Implicit;
 	public (int Current, int Min, int Max)? Tier;
 	public (float Min, float Max)? ValueRollRange;
 	public Color? OverrideColor;
@@ -176,7 +177,7 @@ public sealed class AffixTooltips
 	{
 		var sb = new StringBuilder();
 
-		foreach (AffixTooltipLine tip in Lines.Values.OrderByDescending(v => v.Value))
+		foreach (AffixTooltipLine tip in Lines.Values.OrderByDescending(v => v.Value).OrderBy(v => v.Implicit ? 0f : 1f))
 		{
 			sb.Clear();
 			sb.Append(ItemTooltips.ColoredDot(ItemTooltips.Colors.AffixAccent));
@@ -202,6 +203,7 @@ public sealed class AffixTooltips
 			Color color = tip.Value switch
 			{
 				_ when tip.OverrideColor.HasValue => tip.OverrideColor.Value,
+				_ when tip.Implicit => ItemTooltips.Colors.Implicit,
 				_ when tip.Corrupt => ItemTooltips.Colors.Corrupt,
 				> 0f => ItemTooltips.Colors.Positive,
 				< 0f => ItemTooltips.Colors.Negative,

--- a/Common/Systems/Affixes/AffixTooltips.cs
+++ b/Common/Systems/Affixes/AffixTooltips.cs
@@ -173,7 +173,17 @@ public sealed class AffixTooltips
 		}
 	}
 
-	private void AddTooltipLines(List<TooltipLine> tooltips, ref int tipNum, bool displayExtraInfo)
+	public List<TooltipLine> CreateTooltipLines(bool displayExtraInfo)
+	{
+		int tipNum = 0;
+		var result = new List<TooltipLine>(capacity: Lines.Values.Count);
+
+		AddTooltipLines(result, ref tipNum, displayExtraInfo);
+
+		return result;
+	}
+
+	public void AddTooltipLines(List<TooltipLine> tooltips, ref int tipNum, bool displayExtraInfo)
 	{
 		var sb = new StringBuilder();
 

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -41,6 +41,7 @@ public abstract class ItemAffix : Affix
 			Tier = (Tier, tierMin, tierMax),
 			ValueRollRange = (tierData.MinValue, tierData.MaxValue),
 			Corrupt = IsCorruptedAffix,
+			Implicit = IsImplicit,
 		};
 	}
 	

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -44,6 +44,7 @@ public sealed partial class ItemTooltips : GlobalItem
 		public static Color StatsAccent => ColorUtils.FromHexRgb(0x_a1bdbd);
 		public static Color AffixAccent => ColorUtils.FromHexRgb(0x_ff2222);
 
+		public static Color Implicit => ColorUtils.FromHexRgb(0x_72abcb);
 		public static Color Corrupt => Color.Lerp(Color.Purple, Color.White, 0.4f);
 		public static Color Cloned => ColorUtils.FromHexRgb(0x_37946e);
 		public static Color ManaCost => ColorUtils.FromHexRgb(0x_5fcde4);


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Implicit affixes will now be shown in a color different than that of rolled affixes.
- Internal: Publicized some methods for POTO to use.

### Comments
