### PR TITLE
9 new passives

### DIFF
--- a/Common/Systems/EntityModifier.cs
+++ b/Common/Systems/EntityModifier.cs
@@ -90,7 +90,12 @@ public partial class EntityModifier : EntityModifierSegment
 
 		player.GetKnockback(DamageClass.Generic) = player.GetKnockback(DamageClass.Generic).CombineWith(Knockback);
 		player.GetArmorPenetration(DamageClass.Generic) = ArmorPenetration.ApplyTo(player.GetArmorPenetration(DamageClass.Generic));
-
+		
+		// Apply projectile modifiers
+		ProjectileModifierPlayer projPlayer = player.GetModPlayer<ProjectileModifierPlayer>();
+		projPlayer.ProjectileSpeedMultiplier = ProjectileSpeed;
+		projPlayer.ProjectileCountModifier = ProjectileCount;
+		
 		MinorStatsModPlayer msmp = player.GetModPlayer<MinorStatsModPlayer>();
 		msmp.MagicFind = MagicFind.ApplyTo(msmp.MagicFind);
 

--- a/Common/Systems/ModPlayers/ProjectileModifierPlayer.cs
+++ b/Common/Systems/ModPlayers/ProjectileModifierPlayer.cs
@@ -1,0 +1,42 @@
+using Terraria.DataStructures;
+
+namespace PathOfTerraria.Common.Systems.ModPlayers;
+
+internal class ProjectileModifierPlayer : ModPlayer
+{
+	public StatModifier ProjectileSpeedMultiplier { get; set; }
+	public StatModifier ProjectileCountModifier { get; set; }
+
+	public override void ResetEffects()
+	{
+		ProjectileSpeedMultiplier = StatModifier.Default;
+		ProjectileCountModifier = StatModifier.Default;
+	}
+
+	public override void ModifyShootStats(Item item, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+	{
+		if (ProjectileSpeedMultiplier != StatModifier.Default)
+		{
+			velocity *= ProjectileSpeedMultiplier.ApplyTo(1f);
+		}
+	}
+
+	public override bool Shoot(Item item, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
+	{
+		int additionalProjectiles = (int)ProjectileCountModifier.ApplyTo(0f);
+		
+		if (additionalProjectiles > 0)
+		{
+			for (int i = 0; i < additionalProjectiles; i++)
+			{
+				// Slightly randomize angle for any additional projectiles
+				float randomAngle = Main.rand.NextFloat(MathHelper.ToRadians(-10), MathHelper.ToRadians(10));
+
+				Vector2 modifiedVelocity = velocity.RotatedBy(randomAngle);
+				Projectile.NewProjectile(source, position, modifiedVelocity, type, damage, knockback, Player.whoAmI);
+			}
+		}
+
+		return base.Shoot(item, source, position, velocity, type, damage, knockback);
+	}
+}

--- a/Content/Passives/Magic/SmallPassives/IncreasedMagicAndSummonDamagePassive.cs
+++ b/Content/Passives/Magic/SmallPassives/IncreasedMagicAndSummonDamagePassive.cs
@@ -1,0 +1,12 @@
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+
+namespace PathOfTerraria.Content.Passives;
+
+internal class IncreasedMagicAndSummonDamagePassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		player.GetDamage(DamageClass.Magic) += (Value / 100.0f) * Level;
+		player.GetDamage(DamageClass.Summon) += (Value / 100.0f) * Level;
+	}
+}

--- a/Content/Passives/Magic/SmallPassives/IncreasedManaRegenerationRatePassive.cs
+++ b/Content/Passives/Magic/SmallPassives/IncreasedManaRegenerationRatePassive.cs
@@ -1,0 +1,11 @@
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+
+namespace PathOfTerraria.Content.Passives;
+
+internal class IncreasedManaRegenerationRatePassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		player.manaRegen = (int)(player.manaRegen * (1 + (Value / 100f) * Level));
+	}
+}

--- a/Content/Passives/Misc/ElementalResistancePassives.cs
+++ b/Content/Passives/Misc/ElementalResistancePassives.cs
@@ -1,0 +1,47 @@
+using PathOfTerraria.Common.Systems.ElementalDamage;
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+
+namespace PathOfTerraria.Content.Passives;
+
+internal class AddedFireResistancePassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		var elemental = player.GetModPlayer<ElementalPlayer>();
+		elemental.FireResistance += Value / 100f;
+	}
+}
+
+//AddedColdResistancePassive
+internal class AddedColdResistancePassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		var elemental = player.GetModPlayer<ElementalPlayer>();
+		elemental.ColdResistance += Value / 100f;
+	}
+}
+
+//AddedLightningResistancePassive
+internal class AddedLightningResistancePassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		var elemental = player.GetModPlayer<ElementalPlayer>();
+		elemental.LightningResistance += Value / 100f;
+	}
+}
+
+//AddedAllResistancePassive
+internal class AddedAllResistancePassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		var elemental = player.GetModPlayer<ElementalPlayer>();
+		float resistanceBonus = Value / 100f;
+		
+		elemental.FireResistance += resistanceBonus;
+		elemental.ColdResistance += resistanceBonus;
+		elemental.LightningResistance += resistanceBonus;
+	}
+}

--- a/Content/Passives/Misc/IncreasedAttackSpeedPassive.cs
+++ b/Content/Passives/Misc/IncreasedAttackSpeedPassive.cs
@@ -1,0 +1,11 @@
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+
+namespace PathOfTerraria.Content.Passives;
+
+internal class IncreasedAttackSpeedPassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		player.GetAttackSpeed(DamageClass.Generic) *= 1 + (Value / 100f) * Level;
+	}
+}

--- a/Content/Passives/Misc/IncreasedProjectileCountPassive.cs
+++ b/Content/Passives/Misc/IncreasedProjectileCountPassive.cs
@@ -1,0 +1,15 @@
+using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+
+namespace PathOfTerraria.Content.Passives;
+
+internal class IncreasedProjectileCountPassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		var universalPlayer = player.GetModPlayer<UniversalBuffingPlayer>();
+		float bonus = Value * Level;
+		universalPlayer.UniversalModifier.ProjectileCount.Flat += bonus;
+	}
+
+}

--- a/Content/Passives/Misc/IncreasedProjectileSpeedPassive.cs
+++ b/Content/Passives/Misc/IncreasedProjectileSpeedPassive.cs
@@ -1,0 +1,14 @@
+using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+
+namespace PathOfTerraria.Content.Passives;
+
+internal class IncreasedProjectileSpeedPassive : Passive
+{
+	public override void BuffPlayer(Player player)
+	{
+		var universalPlayer = player.GetModPlayer<UniversalBuffingPlayer>();
+		float bonus = (Value / 100f) * Level;
+		universalPlayer.UniversalModifier.ProjectileSpeed += bonus;
+	}
+}

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -201,10 +201,40 @@ IncreasedColdDamagePassive: {
 
 IncreasedWhipDamagePassive: {
 	// Name: IncreasedWhipDamagePassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	// Name: IncreasedWhipSpeedPassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	// Name: Arcane Synergy
+	// Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	// Name: Fire Ward
+	// Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	// Name: Frost Ward
+	// Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	// Name: Storm Ward
+	// Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	// Name: Elemental Ward
+	// Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	// Name: Swift Strikes
+	// Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	// Name: Swift Strikes
 	// Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	// Name: IncreasedManaRegenerationRatePassive
+	// Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	// Name: IncreasedProjectileCountPassive
+	// Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	// Name: IncreasedProjectileSpeedPassive
+	// Tooltip: ""
+}

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -198,13 +198,43 @@ IncreasedColdDamagePassive: {
 	Name: Chilling Precision
 	Tooltip: +{0}% Increased Cold Damage
 }
-	
+
 IncreasedWhipDamagePassive: {
 	Name: IncreasedWhipDamagePassive
-	Tooltip: ""
+	Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	Name: IncreasedWhipSpeedPassive
-	Tooltip: ""
+	Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	Name: Arcane Synergy
+	Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	Name: Fire Ward
+	Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	Name: Frost Ward
+	Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	Name: Storm Ward
+	Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	Name: Elemental Ward
+	Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	Name: Swift Strikes
+	Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	Name: Swift Strikes
 	Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	Name: IncreasedManaRegenerationRatePassive
+	Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	Name: IncreasedProjectileCountPassive
+	Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	Name: IncreasedProjectileSpeedPassive
+	Tooltip: ""
+}

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -201,10 +201,40 @@ IncreasedColdDamagePassive: {
 
 IncreasedWhipDamagePassive: {
 	// Name: IncreasedWhipDamagePassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	// Name: IncreasedWhipSpeedPassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	// Name: Arcane Synergy
+	// Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	// Name: Fire Ward
+	// Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	// Name: Frost Ward
+	// Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	// Name: Storm Ward
+	// Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	// Name: Elemental Ward
+	// Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	// Name: Swift Strikes
+	// Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	// Name: Swift Strikes
 	// Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	// Name: IncreasedManaRegenerationRatePassive
+	// Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	// Name: IncreasedProjectileCountPassive
+	// Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	// Name: IncreasedProjectileSpeedPassive
+	// Tooltip: ""
+}

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -201,10 +201,40 @@ IncreasedColdDamagePassive: {
 
 IncreasedWhipDamagePassive: {
 	// Name: IncreasedWhipDamagePassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	// Name: IncreasedWhipSpeedPassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	// Name: Arcane Synergy
+	// Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	// Name: Fire Ward
+	// Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	// Name: Frost Ward
+	// Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	// Name: Storm Ward
+	// Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	// Name: Elemental Ward
+	// Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	// Name: Swift Strikes
+	// Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	// Name: Swift Strikes
 	// Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	// Name: IncreasedManaRegenerationRatePassive
+	// Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	// Name: IncreasedProjectileCountPassive
+	// Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	// Name: IncreasedProjectileSpeedPassive
+	// Tooltip: ""
+}

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -201,10 +201,40 @@ IncreasedColdDamagePassive: {
 
 IncreasedWhipDamagePassive: {
 	// Name: IncreasedWhipDamagePassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	// Name: IncreasedWhipSpeedPassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	// Name: Arcane Synergy
+	// Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	// Name: Fire Ward
+	// Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	// Name: Frost Ward
+	// Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	// Name: Storm Ward
+	// Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	// Name: Elemental Ward
+	// Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	// Name: Swift Strikes
+	// Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	// Name: Swift Strikes
 	// Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	// Name: IncreasedManaRegenerationRatePassive
+	// Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	// Name: IncreasedProjectileCountPassive
+	// Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	// Name: IncreasedProjectileSpeedPassive
+	// Tooltip: ""
+}

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -201,10 +201,40 @@ IncreasedColdDamagePassive: {
 
 IncreasedWhipDamagePassive: {
 	// Name: IncreasedWhipDamagePassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	// Name: IncreasedWhipSpeedPassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	// Name: Arcane Synergy
+	// Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	// Name: Fire Ward
+	// Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	// Name: Frost Ward
+	// Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	// Name: Storm Ward
+	// Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	// Name: Elemental Ward
+	// Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	// Name: Swift Strikes
+	// Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	// Name: Swift Strikes
 	// Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	// Name: IncreasedManaRegenerationRatePassive
+	// Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	// Name: IncreasedProjectileCountPassive
+	// Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	// Name: IncreasedProjectileSpeedPassive
+	// Tooltip: ""
+}

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -201,10 +201,40 @@ IncreasedColdDamagePassive: {
 
 IncreasedWhipDamagePassive: {
 	// Name: IncreasedWhipDamagePassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Damage
 }
 
 IncreasedWhipSpeedPassive: {
 	// Name: IncreasedWhipSpeedPassive
-	// Tooltip: ""
+	// Tooltip: +{0}% Increased Whip Speed
+}
+
+IncreasedMagicAndSummonDamagePassive: {
+	// Name: Arcane Synergy
+	// Tooltip: +{0}% Increased Magic and Summon Damage
+}
+
+AddedFireResistancePassive: {
+	// Name: Fire Ward
+	// Tooltip: +{0}% Fire Resistance
+}
+
+AddedColdResistancePassive: {
+	// Name: Frost Ward
+	// Tooltip: +{0}% Cold Resistance
+}
+
+AddedLightningResistancePassive: {
+	// Name: Storm Ward
+	// Tooltip: +{0}% Lightning Resistance
+}
+
+AddedAllResistancePassive: {
+	// Name: Elemental Ward
+	// Tooltip: +{0}% All Resistances
+}
+
+IncreasedAttackSpeedPassive: {
+	// Name: Swift Strikes
+	// Tooltip: +{0}% Global Attack Speed
 }

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -238,3 +238,18 @@ IncreasedAttackSpeedPassive: {
 	// Name: Swift Strikes
 	// Tooltip: +{0}% Global Attack Speed
 }
+
+IncreasedManaRegenerationRatePassive: {
+	// Name: IncreasedManaRegenerationRatePassive
+	// Tooltip: +{0}% Mana Regeneration Rate
+}
+
+IncreasedProjectileCountPassive: {
+	// Name: IncreasedProjectileCountPassive
+	// Tooltip: ""
+}
+
+IncreasedProjectileSpeedPassive: {
+	// Name: IncreasedProjectileSpeedPassive
+	// Tooltip: ""
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
Adds the below passives
- Added lightning resistance
- Added fire resistance
- Added cold resistance
- Added all elemental resistances
- Increased magic & summon damage hybrid node
- Increased global attack speed %
- Increased projectile speed
- Increased projectile count
- Increased % mana regeneration rate

NOTE: These all still need the corresponding sprite/png to actually function. This is just code functionality.

### Comments
**GRAPPLING HOOK NEEDS TO BE TESTED FOR PROJ SPEED/COUNT**
**SWORDS THAT SHOOT PROJECTILES NEED TO BE TESTED FOR PROJ SPEED/COUNT**
-Tested the res passives giving above 75 and its clamped no matter what so no issues there. 
-Tested additional projectiles fairly extensively, seems to work fine in 99% of cases. Some edge cases mentioned below.
-Bombs count as projectiles, may be something we want to disable.
-PoT Bows right click functions a bit different, and shoots the additional projectile as soon as you begin charging, not at the end.
-Vortex Blaster / Celebration MK2 (Weapons that have unique weapon chain attacks/patterns) are only affected by the additional projectile in their initial fire. Then it goes to normal. Weapons like Mini/megashark function perfectly with the + projectiles. This could be fixed by using OnSpawn() in a GlobalProjectile, but not sure if this would work/cause other issues.