### PR TITLE
fix for #1417

### DIFF
--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -416,7 +416,7 @@ public sealed class NewHotbar : SmartUiState
 			Identifier = "Skill",
 			SimpleTitle = title,
 			SimpleSubtitle = subtitle,
-			VisibilityTimeInTicks = 0,
+			VisibilityTimeInTicks = 1,
 		});
 	}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves:
#1417 

### Description of Work
Changed `VisibilityTimeInTicks` to 1,  in `NewHotbar.DrawSkillHoverTooltips()`, to match the "CantEquip" tooltips (which did appear).

### Comments
NA