### PR TITLE
fix: Proper tooltip autopause fix, resolved some tooltips not showing.

### DIFF
--- a/Common/UI/TooltipOverrides.cs
+++ b/Common/UI/TooltipOverrides.cs
@@ -46,8 +46,8 @@ public sealed class TooltipOverrides : ModSystem
 		bool drawForMouseItem = (!isLate || !drewMouseItem) && (mouseItem?.IsAir) == false && isHoveringOverUI && !player.ItemAnimationActive && mouseItem.IsNotSameTypePrefixAndStack(hoverItem);
 		bool drawSideBySide = drawForHoverItem && drawForMouseItem;
 
-		// The tooltip must last at least one tick, otherwise it won't appear when autopause is on
-		uint visibilityTimeInTicks = 1u;
+		// If we are reacting to a late Hover/MouseItem mutation, i.e. after the tooltips have already been drawn, then we need to make new instances last a whole tick.
+		uint visibilityTimeInTicks = isLate ? 1u : 0u;
 		drewHoverItem = drawForHoverItem || (isLate && drewHoverItem);
 		drewMouseItem = drawForMouseItem || (isLate && drewHoverItem);
 

--- a/Core/Time/TimeSystem.cs
+++ b/Core/Time/TimeSystem.cs
@@ -1,0 +1,27 @@
+﻿namespace PathOfTerraria.Core.Time;
+
+internal sealed class TimeSystem : ModSystem
+{
+	/// <summary> Logical update count, including those during which the game has been paused. </summary>
+	public static ulong UpdateCount { get; private set; }
+
+	public override void Load()
+	{
+		Main.OnTickForInternalCodeOnly += OnTickForInternalCodeOnly;
+		On_Main.DoUpdate_WhilePaused += OnDoUpdateWhilePaused;
+	}
+	public override void Unload()
+	{
+		Main.OnTickForInternalCodeOnly -= OnTickForInternalCodeOnly;
+	}
+
+	private static void OnTickForInternalCodeOnly()
+	{
+		UpdateCount = unchecked(UpdateCount + 1);
+	}
+	private static void OnDoUpdateWhilePaused(On_Main.orig_DoUpdate_WhilePaused orig)
+	{
+		UpdateCount = unchecked(UpdateCount + 1);
+		orig();
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves #1417 
Supersedes #1418

### Description of Work
- Fixed skill descriptions and some other tooltips not being visible.
- Internal: PR #1351 has introduced this bug when fixing tooltips' behavior during pause, as it has changed a counter purposefully acting in tick time to that of acting in frame time.
