### PR TITLE
fix: exception thrown on null drops for filling chests

### DIFF
--- a/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
@@ -138,7 +138,10 @@ internal class QueenSlimeDomain : BossDomainSubworld
 					if (k < 3)
 					{
 						ItemDatabase.ItemRecord drop = drops[k];
-						chest.item[k] = new Item(drop.ItemId, drop.Item.stack);
+						if (drop.Item != null)
+						{
+							chest.item[k] = new Item(drop.ItemId, drop.Item.stack);
+						}
 					}
 					else
 					{


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1431

### Description of Work
* fix: exception thrown on null drops for filling chests

### Comments
