### PR TITLE
Resolve major accessory slot regression and skill/passives panel troubles.

### DIFF
--- a/Common/AccessorySlots/AccessorySlotRemapping.cs
+++ b/Common/AccessorySlots/AccessorySlotRemapping.cs
@@ -90,7 +90,7 @@ file sealed class ItemAccessorySlotRemapping : GlobalItem
 
 	public override bool CanEquipAccessory(Item item, Player player, int slot, bool modded)
 	{
-		bool result = slot switch
+		bool result = modded || slot switch
 		{
 			(int)RemappedEquipSlots.Accessory1 => AccessorySlotRemapping.IsNormalAccessory(item),
 			(int)RemappedEquipSlots.Accessory2 => AccessorySlotRemapping.IsNormalAccessory(item),

--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -24,9 +24,10 @@ internal class TreeState : TabsUiState
 	private SkillSelectionPanel _skillSelection;
 
 	public override List<SmartUiElement> TabPanels => [_passiveTreeInner, _skillSelection];
-	protected static PassiveTreePlayer PassiveTreeSystem => Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
-	public override int DepthPriority => 1;
 
+	protected static PassiveTreePlayer PassiveTreeSystem => Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
+
+	public override int DepthPriority => 1;
 
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{
@@ -61,10 +62,12 @@ internal class TreeState : TabsUiState
 				(_passiveTreeInner.TabName, Language.GetText($"Mods.PathOfTerraria.GUI.{_passiveTreeInner.TabName}Tab")),
 				(_skillSelection.TabName, Language.GetText($"Mods.PathOfTerraria.GUI.{_skillSelection.TabName}Tab"))
 		};
-		base.CreateMainPanel(localizedTexts, false, panelSize: new Point(Main.screenWidth - ShrinkX * 2, Main.screenHeight - ShrinkY * 2));
+
+		base.CreateMainPanel(localizedTexts, false, panelSize: (Width: new(-ShrinkX * 2, 1f), Height: new(-ShrinkY * 2, 1f)));
 		base.AppendChildren();
 		AddCloseButton();
 		ResetTree();
+		Recalculate();
 
 		IsVisible = true;
 	}

--- a/Common/UI/Utilities/TabsUiState.cs
+++ b/Common/UI/Utilities/TabsUiState.cs
@@ -29,9 +29,9 @@ public abstract class TabsUiState : CloseableSmartUi
 		return layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
 	}
 
-	protected virtual void CreateMainPanel((string key, LocalizedText text)[] tabs, bool showCloseButton = true, Point? panelSize = null, Action extraOnTabChanged = null)
+	protected virtual void CreateMainPanel((string key, LocalizedText text)[] tabs, bool showCloseButton = true, (StyleDimension Width, StyleDimension Height)? panelSize = null, Action extraOnTabChanged = null)
 	{
-		panelSize ??= new Point(PanelWidth, PanelHeight);
+		panelSize ??= (StyleDimension.FromPixels(PanelWidth), StyleDimension.FromPixels(PanelHeight));
 
 		Panel = new UITabsPanel(false, false, tabs, DraggablePanelHeight);
 		TabPanel.OnActiveTabChanged += HandleActiveTabChanged;
@@ -43,8 +43,8 @@ public abstract class TabsUiState : CloseableSmartUi
 
 		Panel.Left.Set(LeftPadding, 0.5f);
 		Panel.Top.Set(TopPadding, 0.5f);
-		Panel.Width.Set(panelSize.Value.X, 0);
-		Panel.Height.Set(panelSize.Value.Y, 0);
+		Panel.Width = panelSize.Value.Width;
+		Panel.Height = panelSize.Value.Height;
 		Append(Panel);
 
 		if (showCloseButton)


### PR DESCRIPTION
﻿### Link Issues
Resolves #1428
Supposedly resolves #1425 (Could not reproduce per se, please check in-game.)

### Description of Work
- Fixed a major regression in the accessory slot behavior.
- Fixed skill/passives panel not properly reacting to window resizes.
- Fixed the skill/passives panel sometimes not being of correct size when opened via the hotkey.
