### PR TITLE
fix: Restore recently removed extra augment slots.

### DIFF
--- a/Common/UI/AllocatableElement.cs
+++ b/Common/UI/AllocatableElement.cs
@@ -10,7 +10,15 @@ using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI;
 
-internal abstract class AllocatableElement : SmartUiElement
+/// <summary> Methods needed to properly render dynamic edge connections. </summary>
+internal interface IConnectedAllocatableNode
+{
+	Vector2 GetCenter();
+	bool AppearsAsAllocated(Allocatable? nodeOverride = null);
+	bool AppearsAsCanBeAllocated(Allocatable? nodeOverride = null);
+}
+
+internal abstract class AllocatableElement : SmartUiElement, IConnectedAllocatableNode
 {
 	public static Asset<Texture2D> GlowAlpha = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/GlowAlpha");
 	public static Asset<Texture2D> StarAlpha = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/StarAlpha");
@@ -137,6 +145,11 @@ internal abstract class AllocatableElement : SmartUiElement
 		{
 			Allocate(Node, 1);
 		}
+	}
+
+	public virtual Vector2 GetCenter()
+	{
+		return GetDimensions().Center();
 	}
 
 	public virtual bool AppearsAsCanBeAllocated(Allocatable? nodeOverride = null)

--- a/Common/UI/AllocatableInnerPanel.cs
+++ b/Common/UI/AllocatableInnerPanel.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using Microsoft.Xna.Framework.Graphics;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
@@ -18,7 +16,7 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 	protected Vector2 DragOffset;
 	protected Vector2 DragCenter;
 
-	public List<Edge<AllocatableElement>> Connections { get; } = [];
+	public List<Edge<IConnectedAllocatableNode>> Connections { get; } = [];
 
 	public AllocatableInnerPanel()
 	{
@@ -41,16 +39,16 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 		base.DrawChildren(spriteBatch);
 	}
 
-	public static void DrawEdgeConnections(SpriteBatch spriteBatch, ReadOnlySpan<Edge<AllocatableElement>> connections)
+	public static void DrawEdgeConnections(SpriteBatch spriteBatch, ReadOnlySpan<Edge<IConnectedAllocatableNode>> connections)
 	{
 		Vector2 center = default;
 		Texture2D chainTex = _chainTex.Value;
 
-		foreach (Edge<AllocatableElement> edge in connections)
+		foreach (Edge<IConnectedAllocatableNode> edge in connections)
 		{
 			Color color = Color.Gray;
-			AllocatableElement start = edge.Start;
-			AllocatableElement end = edge.End;
+			IConnectedAllocatableNode start = edge.Start;
+			IConnectedAllocatableNode end = edge.End;
 
 			if (start == null || end == null)
 			{
@@ -73,8 +71,8 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 				color = Color.White;
 			}
 
-			Vector2 startPos = start.GetDimensions().Center();
-			Vector2 endPos = end.GetDimensions().Center();
+			Vector2 startPos = start.GetCenter();
+			Vector2 endPos = end.GetCenter();
 
 			if (!edge.Flags.HasFlag(EdgeFlags.EffectsOnly))
 			{

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -12,7 +12,7 @@ namespace PathOfTerraria.Common.UI.PassiveTree;
 /// <summary> Offers a choice of one of multiple passives contained within. Every hidden child node is considered an inner node. </summary>
 internal class MultiPassiveElement : PassiveElement
 {
-	private readonly Edge<AllocatableElement>[] _extraEdges;
+	private readonly Edge<IConnectedAllocatableNode>[] _extraEdges;
 
 	public int AnimationTime { get; set; }
 	public int AnimationTimeMax => 60;
@@ -23,7 +23,7 @@ internal class MultiPassiveElement : PassiveElement
 	{
 		PassiveTreePlayer passiveTreeSystem = Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
 		InnerPassives = passiveTreeSystem.Edges.Where(e => e.Start == Passive && e.End.IsHidden).Select(e => (Passive)e.End).ToArray();
-		_extraEdges = new Edge<AllocatableElement>[InnerPassives.Length];
+		_extraEdges = new Edge<IConnectedAllocatableNode>[InnerPassives.Length];
 	}
 
 	public override void SafeUpdate(GameTime gameTime)
@@ -128,7 +128,7 @@ internal class MultiPassiveElement : PassiveElement
 			Passive inner = InnerPassives[i];
 			var element = new PassiveRadialElement(inner, Vector2.Zero, inner.TreePos - Passive.TreePos);
 			Append(element);
-			_extraEdges[i] = new Edge<AllocatableElement>(this, element, Flags: 0);
+			_extraEdges[i] = new Edge<IConnectedAllocatableNode>(this, element, Flags: 0);
 		}
 
 		RecalculateChildren();

--- a/Common/UI/SkillsTree/AugmentSlotElement.cs
+++ b/Common/UI/SkillsTree/AugmentSlotElement.cs
@@ -1,17 +1,21 @@
-﻿using PathOfTerraria.Common.Mechanics;
+﻿using System;
+using System.Linq;
+using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Skills;
 using PathOfTerraria.Content.Items.Currency;
 using PathOfTerraria.Core.Sounds;
-using System.Linq;
+using PathOfTerraria.Core.UI.SmartUI;
 using Terraria.Audio;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.UI;
 
+#nullable enable
+
 namespace PathOfTerraria.Common.UI.SkillsTree;
 
-internal class AugmentSlotElement : SkillElement
+internal class AugmentSlotElement : SmartUiElement, IConnectedAllocatableNode
 {
 	/// <summary>
 	/// Defines both clickbox size and the hoverbox size for showing/hiding radial augments.
@@ -20,7 +24,8 @@ internal class AugmentSlotElement : SkillElement
 
 	public const int HoverTimeMax = 10;
 
-	public readonly int Index;
+	public int Index { get; }
+	public Allocatable? Node { get; }
 
 	public int HoverTime;
 	private bool _unlocked;
@@ -55,8 +60,9 @@ internal class AugmentSlotElement : SkillElement
 		}
 	}
 
-	public AugmentSlotElement(SkillNode node, int index, bool unlocked = false) : base(node)
+	public AugmentSlotElement(SkillNode? node, int index, bool unlocked = false)
 	{
+		Node = node;
 		Index = index;
 
 		if (Index >= SkillTree.Current.Augments.Count) //Failsafe
@@ -222,6 +228,21 @@ internal class AugmentSlotElement : SkillElement
 				Node.OnDeallocate(Main.LocalPlayer);
 			}
 		}
+	}
+
+	Vector2 IConnectedAllocatableNode.GetCenter()
+	{
+		return GetDimensions().Center();
+	}
+
+	bool IConnectedAllocatableNode.AppearsAsAllocated(Allocatable? nodeOverride)
+	{
+		return SkillTree.Current.Augments[Index].Augment != null;
+	}
+
+	bool IConnectedAllocatableNode.AppearsAsCanBeAllocated(Allocatable? nodeOverride)
+	{
+		return _unlocked && SkillTree.Current.Augments[Index].Augment == null;
 	}
 }
 

--- a/Common/UI/SkillsTree/SkillSelectionPanel.cs
+++ b/Common/UI/SkillsTree/SkillSelectionPanel.cs
@@ -65,10 +65,10 @@ internal class SkillSelectionPanel : SmartUiElement
 		int spareSlotCounter = 0;
 		
 		// Add nodes.
-		var mapping = new Dictionary<Allocatable, AllocatableElement>(capacity: tree.Nodes.Count);
+		var mapping = new Dictionary<Allocatable, IConnectedAllocatableNode>(capacity: tree.Nodes.Count);
 		foreach (SkillNode node in tree.Nodes)
 		{
-			AllocatableElement element = node switch
+			UIElement element = node switch
 			{
 				SpareSlot => new AugmentSlotElement(node, spareSlotCounter++, true),
 				SkillSpecial special => new SkillSpecialElement(special),
@@ -77,7 +77,7 @@ internal class SkillSelectionPanel : SmartUiElement
 			element.Left.Set(node.TreePos.X - node.Size.X / 2, 0.5f);
 			element.Top.Set(node.TreePos.Y - node.Size.Y / 2, 0.5f);
 
-			mapping[node] = element;
+			mapping[node] = (IConnectedAllocatableNode)element;
 
 			_skillTreeInnerPanel.AppendAsDraggable(element);
 		}
@@ -86,11 +86,18 @@ internal class SkillSelectionPanel : SmartUiElement
 		_skillTreeInnerPanel.Connections.EnsureCapacity(tree.Edges.Count);
 		foreach (Edge<Allocatable> edge in tree.Edges)
 		{
-			if (mapping.TryGetValue(edge.Start, out AllocatableElement uiStart)
-			&& mapping.TryGetValue(edge.End, out AllocatableElement uiEnd))
+			if (mapping.TryGetValue(edge.Start, out IConnectedAllocatableNode uiStart)
+			&& mapping.TryGetValue(edge.End, out IConnectedAllocatableNode uiEnd))
 			{
 				_skillTreeInnerPanel.Connections.Add(new(uiStart, uiEnd, edge.Flags));
 			}
+		}
+
+		// Add additional augment slots to the side.
+		int count = Math.Min(SkillTree.DefaultAugmentCount, tree.Augments.Count);
+		for (int i = 0; i < count; i++)
+		{
+			_skillTreeInnerPanel.Append(new AugmentSlotElement(node: null, index: spareSlotCounter++, unlocked: tree.Augments[i].Unlocked));
 		}
 
 		UIButton<string> closeButton = new(Language.GetTextValue("Mods.PathOfTerraria.UI.SkillUI.Back"))


### PR DESCRIPTION
﻿### Link Issues
Follow-up to #1421 

### Description of Work
- Restored the two hovering augment slots that were previously present in skill-specific trees.
- Improved rendering of connections to augment slots within skill trees to match other nodes' animations.