### PR TITLE
fix reset failure, remove cached gore

### DIFF
--- a/Common/Systems/ElementalDamage/ElementalContainer.cs
+++ b/Common/Systems/ElementalDamage/ElementalContainer.cs
@@ -64,9 +64,9 @@ public class ElementalContainer
 
 		if (resetModifiers)
 		{
-			FireDamageModifier.ApplyOverride(0, 0);
-			ColdDamageModifier.ApplyOverride(0, 0);
-			LightningDamageModifier.ApplyOverride(0, 0);
+			FireDamageModifier = FireDamageModifier.ApplyOverride(0, 0);
+			ColdDamageModifier = ColdDamageModifier.ApplyOverride(0, 0);
+			LightningDamageModifier = LightningDamageModifier.ApplyOverride(0, 0);
 		}
 	}
 

--- a/Common/Systems/ElementalDamage/ElementalPlayer.cs
+++ b/Common/Systems/ElementalDamage/ElementalPlayer.cs
@@ -5,7 +5,7 @@ public class ElementalPlayer : ModPlayer
 	public ElementalContainer Container = new();
 
 	// TODO: could be a ModConfig toggle
-	public static bool DebugMessages => true;
+	public static bool DebugMessages => false;
 
 	public override void ResetEffects()
 	{

--- a/Common/Systems/ElementalDamage/ElementalPlayer.cs
+++ b/Common/Systems/ElementalDamage/ElementalPlayer.cs
@@ -5,7 +5,7 @@ public class ElementalPlayer : ModPlayer
 	public ElementalContainer Container = new();
 
 	// TODO: could be a ModConfig toggle
-	public static bool DebugMessages => false;
+	public static bool DebugMessages => true;
 
 	public override void ResetEffects()
 	{

--- a/Content/Buffs/ElementalBuffs/FreezeFunctionality.cs
+++ b/Content/Buffs/ElementalBuffs/FreezeFunctionality.cs
@@ -93,8 +93,6 @@ internal class FreezeNPC : GlobalNPC
 		return gore;
 	}
 
-	// Converts gore spawned by death into frozen gore.
-	// This workaround is necessary because
 	/// <summary>
 	/// Converts gore spawned by death into frozen gore.<br/>
 	/// This workaround is necessary because NPC.checkDead/NPC.HitEffect runs BEFORE on hit effects, 

--- a/Content/Buffs/ElementalBuffs/FrozenNPCBatching.cs
+++ b/Content/Buffs/ElementalBuffs/FrozenNPCBatching.cs
@@ -139,16 +139,20 @@ internal class FrozenNPCBatching : GlobalNPC
 
 	private static void DrawFrozenGore()
 	{
+		HashSet<int> removals = [];
+
 		foreach (int i in CachedGore)
 		{
 			Gore gore = Main.gore[i];
 
 			if (!gore.active || gore.type <= 0)
 			{
+				removals.Add(i);
 				continue;
 			}
 
 			/*
+			// I don't know what this code is for - this was copied from vanilla. I just commented it out because idk - Gabe
 			if (((gore[i].type >= 706 && gore[i].type <= 717) || gore[i].type == 943 || gore[i].type == 1147 || (gore[i].type >= 1160 && gore[i].type <= 1162)) 
 				&& (gore[i].frame < 7 || gore[i].frame > 9)) {
 			*/
@@ -158,7 +162,6 @@ internal class FrozenNPCBatching : GlobalNPC
 			//	continue;
 			//}
 
-			//TML: Added '+ gore[i].drawOffset' to draw calls below
 			if (gore.Frame.ColumnCount > 1 || gore.Frame.RowCount > 1)
 			{
 				Asset<Texture2D> tex = TextureAssets.Gore[gore.type];
@@ -182,6 +185,11 @@ internal class FrozenNPCBatching : GlobalNPC
 				Vector2 pos = new Vector2(gore.position.X + (tex.Width() / 2), gore.position.Y + tex.Height() / 2) + gore.drawOffset - Main.screenPosition;
 				Main.spriteBatch.Draw(tex.Value, pos, new Rectangle(0, 0, tex.Width(), tex.Height()), alpha2, gore.rotation, tex.Size() / 2f, gore.scale, SpriteEffects.None, 0f);
 			}
+		}
+
+		foreach (int value in removals)
+		{
+			CachedGore.Remove(value);
 		}
 	}
 

--- a/Localization/de-DE/Mods.PathOfTerraria.Buffs.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Buffs.hjson
@@ -99,10 +99,10 @@ FocusChargeBuff: {
 
 IgnitedDebuff: {
 	// DisplayName: Ignited Debuff
-	// Description: Mods.PathOfTerraria.Buffs.IgnitedDebuff.Description
+	// Description: Substantial and variable damage over time
 }
 
 FreezeDebuff: {
 	// DisplayName: Freeze Debuff
-	// Description: Mods.PathOfTerraria.Buffs.FreezeDebuff.Description
+	// Description: You can't move!
 }

--- a/Localization/es-ES/Mods.PathOfTerraria.Buffs.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Buffs.hjson
@@ -107,10 +107,10 @@ FocusChargeBuff: {
 
 IgnitedDebuff: {
 	// DisplayName: Ignited Debuff
-	// Description: Mods.PathOfTerraria.Buffs.IgnitedDebuff.Description
+	// Description: Substantial and variable damage over time
 }
 
 FreezeDebuff: {
 	// DisplayName: Freeze Debuff
-	// Description: Mods.PathOfTerraria.Buffs.FreezeDebuff.Description
+	// Description: You can't move!
 }

--- a/Localization/fr-FR/Mods.PathOfTerraria.Buffs.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Buffs.hjson
@@ -107,10 +107,10 @@ FocusChargeBuff: {
 
 IgnitedDebuff: {
 	// DisplayName: Ignited Debuff
-	// Description: Mods.PathOfTerraria.Buffs.IgnitedDebuff.Description
+	// Description: Substantial and variable damage over time
 }
 
 FreezeDebuff: {
 	// DisplayName: Freeze Debuff
-	// Description: Mods.PathOfTerraria.Buffs.FreezeDebuff.Description
+	// Description: You can't move!
 }

--- a/Localization/pl-PL/Mods.PathOfTerraria.Buffs.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Buffs.hjson
@@ -91,10 +91,10 @@ FocusChargeBuff: {
 
 IgnitedDebuff: {
 	// DisplayName: Ignited Debuff
-	// Description: Mods.PathOfTerraria.Buffs.IgnitedDebuff.Description
+	// Description: Substantial and variable damage over time
 }
 
 FreezeDebuff: {
 	// DisplayName: Freeze Debuff
-	// Description: Mods.PathOfTerraria.Buffs.FreezeDebuff.Description
+	// Description: You can't move!
 }

--- a/Localization/pt-BR/Mods.PathOfTerraria.Buffs.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Buffs.hjson
@@ -107,10 +107,10 @@ FocusChargeBuff: {
 
 IgnitedDebuff: {
 	// DisplayName: Ignited Debuff
-	// Description: Mods.PathOfTerraria.Buffs.IgnitedDebuff.Description
+	// Description: Substantial and variable damage over time
 }
 
 FreezeDebuff: {
 	// DisplayName: Freeze Debuff
-	// Description: Mods.PathOfTerraria.Buffs.FreezeDebuff.Description
+	// Description: You can't move!
 }

--- a/Localization/ru-RU/Mods.PathOfTerraria.Buffs.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Buffs.hjson
@@ -103,10 +103,10 @@ FocusChargeBuff: {
 
 IgnitedDebuff: {
 	// DisplayName: Ignited Debuff
-	// Description: Mods.PathOfTerraria.Buffs.IgnitedDebuff.Description
+	// Description: Substantial and variable damage over time
 }
 
 FreezeDebuff: {
 	// DisplayName: Freeze Debuff
-	// Description: Mods.PathOfTerraria.Buffs.FreezeDebuff.Description
+	// Description: You can't move!
 }


### PR DESCRIPTION
### Description of Work
- Fixed elemental damage not being reset properly, causing bleedthrough with elemental affixes
- Allowed cached frozen gore to be removed from the cache
- Internal: Removed some useless comments