### PR TITLE
fixed shock debuff on projectiles, allow lightning to apply shock

### DIFF
--- a/Common/Systems/ElementalDamage/ElementalDamage.cs
+++ b/Common/Systems/ElementalDamage/ElementalDamage.cs
@@ -1,6 +1,6 @@
-﻿using PathOfTerraria.Content.Buffs.ElementalBuffs;
+﻿using PathOfTerraria.Content.Buffs;
+using PathOfTerraria.Content.Buffs.ElementalBuffs;
 using System.IO;
-using Terraria.ID;
 
 namespace PathOfTerraria.Common.Systems.ElementalDamage;
 
@@ -100,7 +100,7 @@ public readonly struct ElementalDamage
 		{
 			ElementType.Fire => ModContent.BuffType<IgnitedDebuff>(),
 			ElementType.Cold => ModContent.BuffType<FreezeDebuff>(),
-			ElementType.Lightning => BuffID.Electrified,
+			ElementType.Lightning => ModContent.BuffType<ShockDebuff>(),
 			_ => 0
 		};
 	}

--- a/Content/Buffs/ShockDebuff.cs
+++ b/Content/Buffs/ShockDebuff.cs
@@ -38,7 +38,7 @@ public sealed class ShockDebuff : ModBuff
 
 				if (projectile.TryGetOwner(out Player owner))
 				{
-					mul *= owner.GetModPlayer<AffixPlayer>().StrengthOf<ChanceToApplyShockGearAffix>() * 0.01f;
+					mul *= 1 + owner.GetModPlayer<AffixPlayer>().StrengthOf<ChanceToApplyShockGearAffix>() * 0.01f;
 				}
 
 				modifiers.FinalDamage += mul;


### PR DESCRIPTION
### Description of Work
- Fixed Shock multiplier not working for projectiles
- Allows Lightning damage to apply Shock with the default buff chance