### PR TITLE
feat: Quest Debug Interface.

### DIFF
--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -21,10 +21,21 @@ namespace PathOfTerraria.Common.Quests;
 
 internal sealed class QuestDebugging : ModSystem
 {
+#if DEBUG
+	private static ModKeybind keyToggleQuestDebugging = null!;
+#endif
+
+	public override void Load()
+	{
+#if DEBUG
+		keyToggleQuestDebugging = KeybindLoader.RegisterKeybind(Mod, "ToggleQuestDebugging", Keys.NumPad1);
+#endif
+	}
+
 	public override void PreUpdateEntities()
 	{
 #if DEBUG
-		if (Main.keyState.IsKeyDown(Keys.NumPad1) && !Main.oldKeyState.IsKeyDown(Keys.NumPad1))
+		if (keyToggleQuestDebugging.JustPressed)
 		{
 			SmartUiLoader.GetUiState<QuestDebugState>().Toggle();
 		}

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.UI.Components;
+using PathOfTerraria.Common.UI.Elements;
 using PathOfTerraria.Core.UI;
 using PathOfTerraria.Core.UI.SmartUI;
 using PathOfTerraria.Utilities.Xna;
@@ -51,9 +52,12 @@ internal sealed class QuestDebugCommand : ModCommand
 
 public sealed class QuestDebugState : SmartUiState
 {
+	private string? lastSearchString;
+
 	public UIPanel Panel { get; private set; } = null!;
 	public UIList QuestList { get; private set; } = null!;
 	public UIScrollbar QuestScrollbar { get; private set; } = null!;
+	public UIEditableText SearchBar { get; private set; } = null!;
 
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{
@@ -113,18 +117,38 @@ public sealed class QuestDebugState : SmartUiState
 		Panel.AddElement(new UIText("Quest Debugging"), e =>
 		{
 			e.SetDimensions(x: (0.0f, +StartX), y: (0.00f, +4));
+			e.IgnoresMouseInteraction = true;
 		});
-#if DEBUG
-		Panel.AddElement(new UIButton<string>("Refresh"), e =>
-		{
-			e.SetDimensions(x: (1.0f, -128 - 8), y: (0.00f, +0), width: (0.0f, +96), height: (0f, +32));
-			e.OnLeftClick += (evt, self) => Rebuild();
-		});
-#endif
 		Panel.AddElement(new UIButton<string>("X"), e =>
 		{
 			e.SetDimensions(x: (1.0f, -32), y: (0.00f, +0), width: (0.0f, +32), height: (0f, +32));
 			e.OnLeftClick += (evt, self) => SetEnabled(false);
+		});
+
+		// Search bar
+
+		UIPanel searchBG = Panel.AddElement(new UIPanel(), e =>
+		{
+			e.SetDimensions(x: (0.0f, +160), y: (0.00f, +0), width: (1.0f, -200), height: (0f, +32));
+		});
+		SearchBar = Panel.AddElement(SearchBar ?? new UIEditableText(backingText: "Search..."), e =>
+		{
+			e.SetDimensions(x: (0.0f, +160 + 8f), y: (0.00f, +0), width: (1.0f, -200 - 16f), height: (0f, +32));
+
+			if (SearchBar != null)
+			{
+				return;
+			}
+
+			e.CurrentValue = lastSearchString;
+			e.OnUpdate += uiElement =>
+			{
+				if (uiElement is UIEditableText e && e.CurrentValue != lastSearchString)
+				{
+					Main.QueueMainThreadAction(Rebuild);
+					lastSearchString = e.CurrentValue;
+				}
+			};
 		});
 
 		// List
@@ -139,12 +163,19 @@ public sealed class QuestDebugState : SmartUiState
 		});
 		QuestList.SetScrollbar(QuestScrollbar);
 
+		// List entries
+
 		int questIndex = -1;
 		StringBuilder stringBuilder = new();
 		QuestModPlayer playerQuests = Main.LocalPlayer.GetModPlayer<QuestModPlayer>();
 
 		foreach (Quest quest in playerQuests.QuestsByName.Values.OrderBy(q => q.Name))
 		{
+			if (!string.IsNullOrEmpty(SearchBar.CurrentValue) && !quest.Name.Contains(SearchBar.CurrentValue, StringComparison.InvariantCultureIgnoreCase))
+			{
+				continue;
+			}
+
 			questIndex++;
 
 			UIPanel questPanel = QuestList.AddElement(new UIPanel(), e =>
@@ -240,6 +271,14 @@ public sealed class QuestDebugState : SmartUiState
 
 					return stringBuilder.ToString();
 				}));
+			});
+		}
+
+		if (questIndex < 0)
+		{
+			QuestList.AddElement(new UITextPanel<string>("No quests found"), e =>
+			{
+				e.SetDimensions(x: (0.0f, +0), y: (0.1f, +128 * questIndex), width: (1.0f, +0), height: (0f, +40));
 			});
 		}
 	}

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.UI.Components;
 using PathOfTerraria.Common.UI.Elements;
@@ -23,24 +22,20 @@ internal sealed class QuestDebugging : ModSystem
 {
 #if DEBUG
 	private static ModKeybind keyToggleQuestDebugging = null!;
-#endif
 
 	public override void Load()
 	{
-#if DEBUG
-		keyToggleQuestDebugging = KeybindLoader.RegisterKeybind(Mod, "ToggleQuestDebugging", Keys.NumPad1);
-#endif
+		keyToggleQuestDebugging = KeybindLoader.RegisterKeybind(Mod, "ToggleQuestDebugging", Microsoft.Xna.Framework.Input.Keys.NumPad1);
 	}
 
 	public override void PreUpdateEntities()
 	{
-#if DEBUG
 		if (keyToggleQuestDebugging.JustPressed)
 		{
 			SmartUiLoader.GetUiState<QuestDebugState>().Toggle();
 		}
-#endif
 	}
+#endif
 }
 
 internal sealed class QuestDebugCommand : ModCommand

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -1,0 +1,246 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework.Input;
+using PathOfTerraria.Common.Systems.Questing;
+using PathOfTerraria.Common.UI.Components;
+using PathOfTerraria.Core.UI;
+using PathOfTerraria.Core.UI.SmartUI;
+using PathOfTerraria.Utilities.Xna;
+using Terraria.GameContent.UI.Elements;
+using Terraria.ID;
+using Terraria.ModLoader.UI;
+using Terraria.UI;
+
+#nullable enable
+#pragma warning disable IDE0053 // Use expression body for lambda expression
+
+namespace PathOfTerraria.Common.Quests;
+
+internal sealed class QuestDebugging : ModSystem
+{
+	public override void PreUpdateEntities()
+	{
+#if DEBUG
+		if (Main.keyState.IsKeyDown(Keys.NumPad1) && !Main.oldKeyState.IsKeyDown(Keys.NumPad1))
+		{
+			SmartUiLoader.GetUiState<QuestDebugState>().Toggle();
+		}
+#endif
+	}
+}
+
+internal sealed class QuestDebugCommand : ModCommand
+{
+	public override string Command => "potQuestDebug";
+	public override CommandType Type => CommandType.Chat;
+
+	public override void Action(CommandCaller caller, string input, string[] args)
+	{
+#if !DEBUG
+		// Prevent crazy cheating in MP, unless the user is at least on a debug build.
+		if (Main.netMode != NetmodeID.SinglePlayer)
+		{
+			throw new UsageException("This command is only available in singleplayer.");
+		}
+#endif
+
+		SmartUiLoader.GetUiState<QuestDebugState>().Toggle();
+	}
+}
+
+public sealed class QuestDebugState : SmartUiState
+{
+	public UIPanel Panel { get; private set; } = null!;
+	public UIList QuestList { get; private set; } = null!;
+	public UIScrollbar QuestScrollbar { get; private set; } = null!;
+
+	public override int InsertionIndex(List<GameInterfaceLayer> layers)
+	{
+		return layers.FindIndex(layer => layer.Name.Equals("Vanilla: Cursor")) - 1;
+	}
+
+	public void Toggle()
+	{
+		SetEnabled(!Visible);
+	}
+
+	public void SetEnabled(bool value)
+	{
+		if (Visible == value)
+		{
+			return;
+		}
+
+		Visible = value;
+
+		if (Visible)
+		{
+			Rebuild();
+		}
+		else
+		{
+			RemoveAllChildren();
+		}
+	}
+
+	public void Rebuild()
+	{
+		RemoveAllChildren();
+
+		const float StartX = 8f;
+		const float StartY = 40f;
+
+		Panel = this.AddElement(new UIPanel(), e =>
+		{
+			e.MinWidth.Set(+512, 0f);
+			e.MinHeight.Set(+300, 0f);
+
+			if (Panel != null)
+			{
+				(e.Left, e.Top, e.Width, e.Height) = (Panel.Left, Panel.Top, Panel.Width, Panel.Height);
+			}
+			else
+			{
+				e.SetDimensions(x: (0.5f, -256), y: (0.10f, +0), width: (0.0f, +512), height: (0.80f, +0));
+			}
+
+			e.AddComponent(new UIMouseDrag(canMove: true, canResize: true));
+		});
+
+		// Header
+
+		Panel.AddElement(new UIText("Quest Debugging"), e =>
+		{
+			e.SetDimensions(x: (0.0f, +StartX), y: (0.00f, +4));
+		});
+#if DEBUG
+		Panel.AddElement(new UIButton<string>("Refresh"), e =>
+		{
+			e.SetDimensions(x: (1.0f, -128 - 8), y: (0.00f, +0), width: (0.0f, +96), height: (0f, +32));
+			e.OnLeftClick += (evt, self) => Rebuild();
+		});
+#endif
+		Panel.AddElement(new UIButton<string>("X"), e =>
+		{
+			e.SetDimensions(x: (1.0f, -32), y: (0.00f, +0), width: (0.0f, +32), height: (0f, +32));
+			e.OnLeftClick += (evt, self) => SetEnabled(false);
+		});
+
+		// List
+
+		QuestList = Panel.AddElement(new UIList(), e =>
+		{
+			e.SetDimensions(x: (0.00f, +StartX), y: (0.00f, +StartY), width: (1.00f, -48), height: (1.00f, -64));
+		});
+		QuestScrollbar = Panel.AddElement(new UIScrollbar(), e =>
+		{
+			e.SetDimensions(x: (1.00f, -26), y: (0.00f, +StartY + 8), width: (0.00f, +20), height: (1.00f, -80));
+		});
+		QuestList.SetScrollbar(QuestScrollbar);
+
+		int questIndex = -1;
+		StringBuilder stringBuilder = new();
+		QuestModPlayer playerQuests = Main.LocalPlayer.GetModPlayer<QuestModPlayer>();
+
+		foreach (Quest quest in playerQuests.QuestsByName.Values.OrderBy(q => q.Name))
+		{
+			questIndex++;
+
+			UIPanel questPanel = QuestList.AddElement(new UIPanel(), e =>
+			{
+				e.SetDimensions(x: (0.0f, +0), y: (0.1f, +128 * questIndex), width: (1.0f, +0), height: (0f, +132));
+			});
+
+			// Name
+			questPanel.AddElement(new UIText($"[c/{Color.YellowGreen.ToHexRGB()}:{quest.Name}] ({quest.DisplayName})"), e =>
+			{
+				e.SetDimensions(x: (0.0f, +0), y: (0.0f, +0), width: (0.0f, +0), height: (0f, +128));
+			});
+
+			// Buttons
+
+			float buttonX = 0f;
+
+			// Activation and advancement button.
+			questPanel.AddElement(new UIButton<string>(""), e =>
+			{
+				e.BackgroundColor = e.HoverPanelColor = Color.IndianRed;
+				e.AltPanelColor = e.AltHoverPanelColor = Color.YellowGreen;
+				e.UseAltColors = () => quest.Active || quest.Completed;
+				e.HoverText = e.AltHoverText = "Left Click to advance, Right click to backtrack.";
+
+				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
+				e.AddComponent(new UIDynamicText(() => quest.Completed ? "Completed" : (quest.Active ? $"Stage {quest.CurrentStep + 1} of {quest.QuestSteps.Count}" : "Inactive")));
+
+				e.OnLeftClick += (evt, self) =>
+				{
+					if (quest.Completed)
+					{
+						return;
+					}
+
+					if (!quest.Active)
+					{
+						Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest(quest.FullName);
+					}
+					else
+					{
+						quest.Advance(Main.LocalPlayer, delta: 1);
+					}
+				};
+				e.OnRightClick += (evt, self) =>
+				{
+					if (!quest.Active && !quest.Completed)
+					{
+						return;
+					}
+
+					if (quest.Completed || quest.CurrentStep > 0)
+					{
+						quest.Advance(Main.LocalPlayer, delta: -1);
+					}
+					else
+					{
+						quest.Reset();
+					}
+				};
+
+				buttonX += e.Width.Pixels + 8f;
+			});
+			// 'Give Rewards' button.
+			questPanel.AddElement(new UIButton<string>("Give Rewards"), e =>
+			{
+				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
+				e.OnLeftClick += (evt, self) => quest.GiveRewards(Main.LocalPlayer);
+
+				buttonX += e.Width.Pixels + 8f;
+			});
+			// 'Force Reset' button.
+			questPanel.AddElement(new UIButton<string>("Force Reset"), e =>
+			{
+				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
+				e.OnLeftClick += (evt, self) => quest.Reset();
+
+				buttonX += e.Width.Pixels + 8f;
+			});
+
+			// Lower text
+			questPanel.AddElement(new UIText($"[{quest.Name}]"), e =>
+			{
+				e.SetDimensions(x: (0.0f, +0), y: (0.0f, +64), width: (0.0f, +0), height: (0f, +128));
+				e.AddComponent(new UIDynamicText(() =>
+				{
+					stringBuilder.Clear();
+
+					string? giverName = quest.NPCQuestGiver >= 0 ? NPCID.Search.GetName(quest.NPCQuestGiver).Split('/').Last() : null;
+
+					stringBuilder.AppendLine($"Step: [c/{Color.Gold.ToHexRGB()}:{(quest.Active ? quest.ActiveStep : null)?.GetType().Name ?? "N/A"}]");
+					stringBuilder.AppendLine($"Given By: [c/{Color.Gold.ToHexRGB()}:{(quest.NPCQuestGiver >= 0 ? giverName : "N/A")}]");
+
+					return stringBuilder.ToString();
+				}));
+			});
+		}
+	}
+}

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -194,16 +194,62 @@ public sealed class QuestDebugState : SmartUiState
 
 			float buttonX = 0f;
 
-			// Activation and advancement button.
+			// Backtrack '-' button.
+			questPanel.AddElement(new UIButton<string>(""), e =>
+			{
+				e.AltHoverText = "Click to go back by a step.";
+				e.AltPanelColor = e.AltHoverPanelColor = Color.IndianRed;
+				e.UseAltColors = () => quest.Active && quest.CurrentStep > 0;
+				// Make invisible when inactive:
+				(e.AltBorderColor, e.AltHoverBorderColor) = (e.BorderColor, e.HoverBorderColor);
+				e.HoverPanelColor = e.HoverBorderColor = e.BorderColor = e.BackgroundColor;
+
+				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +32), height: (0f, +32));
+				e.AddComponent(new UIDynamicText(() => quest.Active && quest.CurrentStep > 0 ? "-" : ""));
+
+				e.OnLeftClick += (evt, self) =>
+				{
+					if (!quest.Active && !quest.Completed)
+					{
+						return;
+					}
+
+					if (!quest.Completed && quest.CurrentStep <= 0)
+					{
+						return;
+					}
+
+					quest.Advance(Main.LocalPlayer, delta: -1);
+					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
+				};
+
+				buttonX += e.Width.Pixels;
+			});
+			// State info panel. Button, but doesn't do anything.
 			questPanel.AddElement(new UIButton<string>(""), e =>
 			{
 				e.BackgroundColor = e.HoverPanelColor = Color.IndianRed;
-				e.AltPanelColor = e.AltHoverPanelColor = Color.YellowGreen;
+				e.AltPanelColor = e.AltHoverPanelColor = Color.Orange;
+				e.AltHoverBorderColor = e.HoverBorderColor = e.BorderColor;
 				e.UseAltColors = () => quest.Active || quest.Completed;
-				e.HoverText = e.AltHoverText = "Left Click to advance, Right click to backtrack.";
 
 				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
 				e.AddComponent(new UIDynamicText(() => quest.Completed ? "Completed" : (quest.Active ? $"Stage {quest.CurrentStep + 1} of {quest.QuestSteps.Count}" : "Inactive")));
+
+				buttonX += e.Width.Pixels;
+			});
+			// Advance '+' button.
+			questPanel.AddElement(new UIButton<string>(""), e =>
+			{
+				e.AltHoverText = "Click to advance.";
+				e.AltPanelColor = e.AltHoverPanelColor = Color.YellowGreen;
+				e.UseAltColors = () => !quest.Completed;
+				// Make invisible when inactive:
+				(e.AltBorderColor, e.AltHoverBorderColor) = (e.BorderColor, e.HoverBorderColor);
+				e.HoverPanelColor = e.HoverBorderColor = e.BorderColor = e.BackgroundColor;
+
+				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +32), height: (0f, +32));
+				e.AddComponent(new UIDynamicText(() => !quest.Completed ? "+" : ""));
 
 				e.OnLeftClick += (evt, self) =>
 				{
@@ -223,27 +269,10 @@ public sealed class QuestDebugState : SmartUiState
 
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
-				e.OnRightClick += (evt, self) =>
-				{
-					if (!quest.Active && !quest.Completed)
-					{
-						return;
-					}
-
-					if (quest.Completed || quest.CurrentStep > 0)
-					{
-						quest.Advance(Main.LocalPlayer, delta: -1);
-					}
-					else
-					{
-						quest.Reset();
-					}
-
-					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
-				};
 
 				buttonX += e.Width.Pixels + 8f;
 			});
+
 			// 'Give Rewards' button.
 			questPanel.AddElement(new UIButton<string>("Give Rewards"), e =>
 			{
@@ -252,10 +281,11 @@ public sealed class QuestDebugState : SmartUiState
 
 				buttonX += e.Width.Pixels + 8f;
 			});
+
 			// 'Force Reset' button.
-			questPanel.AddElement(new UIButton<string>("Force Reset"), e =>
+			questPanel.AddElement(new UIButton<string>("Reset"), e =>
 			{
-				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
+				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +80), height: (0f, +32));
 				e.OnLeftClick += (evt, self) =>
 				{
 					quest.Reset();

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -158,9 +158,9 @@ public sealed class QuestDebugState : SmartUiState
 		{
 			e.SetDimensions(x: (0.00f, +StartX), y: (0.00f, +StartY), width: (1.00f, -48), height: (1.00f, -64));
 		});
-		QuestScrollbar = Panel.AddElement(new UIScrollbar(), e =>
+		QuestScrollbar = Panel.AddElement(new FixedUIScrollbar(UserInterface), e =>
 		{
-			e.SetDimensions(x: (1.00f, -26), y: (0.00f, +StartY + 8), width: (0.00f, +20), height: (1.00f, -80));
+			e.SetDimensions(x: (1.00f, -26), y: (0.00f, +StartY + 6), width: (0.00f, +20), height: (1.00f, -80));
 		});
 		QuestList.SetScrollbar(QuestScrollbar);
 

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -114,15 +114,17 @@ public sealed class QuestDebugState : SmartUiState
 		});
 
 		// Header
-
 		Panel.AddElement(new UIText("Quest Debugging"), e =>
 		{
 			e.SetDimensions(x: (0.0f, +StartX), y: (0.00f, +4));
 			e.IgnoresMouseInteraction = true;
 		});
-		Panel.AddElement(new UIButton<string>("X"), e =>
+
+		// Close button.
+		Panel.AddElement(new UIImageButton(ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/CloseButton")), e =>
 		{
-			e.SetDimensions(x: (1.0f, -32), y: (0.00f, +0), width: (0.0f, +32), height: (0f, +32));
+			e.SetDimensions(x: (1.0f, -35), y: (0.00f, -3), width: (0.0f, +38), height: (0f, +38));
+			e.SetVisibility(1f, 0.8f);
 			e.OnLeftClick += (evt, self) => SetEnabled(false);
 		});
 

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.UI.Components;
 using PathOfTerraria.Common.UI.Elements;
+using PathOfTerraria.Common.UI.Quests;
 using PathOfTerraria.Core.UI;
 using PathOfTerraria.Core.UI.SmartUI;
 using PathOfTerraria.Utilities.Xna;
@@ -219,6 +220,8 @@ public sealed class QuestDebugState : SmartUiState
 					{
 						quest.Advance(Main.LocalPlayer, delta: 1);
 					}
+
+					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
 				e.OnRightClick += (evt, self) =>
 				{
@@ -235,6 +238,8 @@ public sealed class QuestDebugState : SmartUiState
 					{
 						quest.Reset();
 					}
+
+					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
 
 				buttonX += e.Width.Pixels + 8f;
@@ -251,7 +256,11 @@ public sealed class QuestDebugState : SmartUiState
 			questPanel.AddElement(new UIButton<string>("Force Reset"), e =>
 			{
 				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
-				e.OnLeftClick += (evt, self) => quest.Reset();
+				e.OnLeftClick += (evt, self) =>
+				{
+					quest.Reset();
+					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
+				};
 
 				buttonX += e.Width.Pixels + 8f;
 			});

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -322,5 +322,7 @@ public sealed class QuestDebugState : SmartUiState
 				e.SetDimensions(x: (0.0f, +0), y: (0.1f, +128 * questIndex), width: (1.0f, +0), height: (0f, +40));
 			});
 		}
+
+		Recalculate();
 	}
 }

--- a/Common/Quests/QuestUtils.cs
+++ b/Common/Quests/QuestUtils.cs
@@ -1,0 +1,22 @@
+﻿using Terraria.DataStructures;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.Quests;
+
+internal static class QuestUtils
+{
+	/// <summary> Safely spawns the given item either at the first NPC with the provided type, or at the player if none has been found. </summary>
+	public static Item SpawnNPCQuestRewardItem(Player player, int npcType, int itemType, int stack = 1, bool noSync = false)
+	{
+		Entity entity = NPC.FindFirstNPC(npcType) is >= 0 and int npc ? Main.npc[npc] : player;
+		int itemId = Item.NewItem(new EntitySource_Gift(entity), entity.Center, itemType, Stack: stack, noBroadcast: noSync);
+		Item item = Main.item[itemId];
+
+		if (!noSync && Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			NetMessage.SendData(MessageID.SyncItem, -1, -1, null, itemId);
+		}
+
+		return item;
+	}
+}

--- a/Common/Systems/Questing/Quest.cs
+++ b/Common/Systems/Questing/Quest.cs
@@ -7,7 +7,16 @@ namespace PathOfTerraria.Common.Systems.Questing;
 
 public abstract class Quest : ModType, ILocalizedModType
 {
+	private enum State
+	{
+		NotStarted,
+		InProgress,
+		Completed,
+	}
+
 	private static readonly Dictionary<string, Quest> QuestsByName = [];
+
+	private State state;
 
 	public abstract QuestTypes QuestType { get; }
 	public abstract int NPCQuestGiver { get; }
@@ -29,15 +38,15 @@ public abstract class Quest : ModType, ILocalizedModType
 	/// <summary>
 	/// Checks if the quest is both inactive and not completed.
 	/// </summary>
-	public bool CanBeStarted => !Completed && !Active;
+	public bool CanBeStarted => state == State.NotStarted;
 
 	public string LocalizationCategory => $"Quests.Quest";
 
 	public QuestStep ActiveStep => QuestSteps[CurrentStep];
 
-	public int CurrentStep;
-	public bool Completed;
-	public bool Active = false;
+	public int CurrentStep { get; private set; }
+	public bool Completed => state == State.Completed;
+	public bool Active => state == State.InProgress;
 
 	public sealed override void SetupContent()
 	{
@@ -131,31 +140,66 @@ public abstract class Quest : ModType, ILocalizedModType
 		return;
 	}
 	
-	public void StartQuest(Player player, int currentQuest = 0)
+	public void Start(Player player, int currentStep = 0)
 	{
-		CurrentStep = currentQuest;
+		CurrentStep = currentStep;
 
 		if (CurrentStep >= QuestSteps.Count)
 		{
-			Completed = true;
-			Active = false;
-			QuestRewards.ForEach(qr => qr.GiveReward(player, player.Center));
-			OnCompleted();
+			Complete(player);
 			return;
 		}
 
-		Active = true;
+		state = State.InProgress;
+	}
+
+	public void Complete(Player player)
+	{
+		state = State.Completed;
+
+		GiveRewards(player);
+		OnCompleted();
+	}
+
+	public void GiveRewards(Player player)
+	{
+		QuestRewards.ForEach(qr => qr.GiveReward(player, player.Center));
+	}
+
+	/// <summary> Advances or reverts the quest's steps, calling necessary completion events. </summary>
+	public void Advance(Player player, int delta)
+	{
+		int targetStep = Math.Max(0, Math.Min(CurrentStep + delta, QuestSteps.Count)); // Exclusive end.
+		delta = targetStep - CurrentStep;
+
+		if (delta < 0)
+		{
+			Start(player, targetStep);
+		}
+		else if (delta > 0)
+		{
+			for (int i = 0; i < delta; i++)
+			{
+				try
+				{
+					ActiveStep.OnComplete();
+					Start(player, CurrentStep + 1);
+				}
+				catch
+				{
+					break;
+				}
+			}
+		}
 	}
 
 	public void Update(Player player)
 	{
 		if (ActiveStep.Track(player))
 		{
-			ActiveStep.OnComplete();
-			StartQuest(player, CurrentStep + 1);
+			Advance(player, 1);
 		}
 	}
-	
 
 	public void Save(TagCompound tag)
 	{
@@ -190,22 +234,21 @@ public abstract class Quest : ModType, ILocalizedModType
 	{
 		Reset();
 
-		Completed = tag.GetBool("completed");
+		if (tag.GetBool("completed"))
+		{
+			state = State.Completed;
+			return;
+		}
 
-		if (Completed)
+		if (!tag.GetBool("active"))
 		{
 			return;
 		}
 
-		Active = tag.GetBool("active");
-
-		if (!Active)
-		{
-			return;
-		}
+		state = State.InProgress;
 
 		int step = tag.GetInt("currentQuest");
-		StartQuest(player, step);
+		Start(player, step);
 
 		for (int i = 0; i < step; ++i)
 		{
@@ -217,8 +260,7 @@ public abstract class Quest : ModType, ILocalizedModType
 
 	public void Reset()
 	{
-		Active = false;
-		Completed = false;
+		state = State.NotStarted;
 		CurrentStep = 0;
 		QuestSteps = SetSteps();
 	}

--- a/Common/Systems/Questing/QuestModPlayer.cs
+++ b/Common/Systems/Questing/QuestModPlayer.cs
@@ -38,7 +38,7 @@ public class QuestModPlayer : ModPlayer
 	/// <param name="fromLoad">Skips the quest popups &amp; sound effects if true.</param>
 	public void StartQuest(string name, int step = -1, bool fromLoad = false)
 	{
-		QuestsByName[name].StartQuest(Player, step == -1 ? 0 : step);
+		QuestsByName[name].Start(Player, step == -1 ? 0 : step);
 
 		if (Main.myPlayer == Player.whoAmI && !fromLoad)
 		{
@@ -130,11 +130,7 @@ public class QuestModPlayer : ModPlayer
 
 			quest.Update(Player);
 
-			if (quest.Completed)
-			{
-				quest.Active = false;
-			}
-			else
+			if (!quest.Completed)
 			{
 				// Update markers per area.
 				// This uses all quests, which define their location and complete-ness already,

--- a/Common/Systems/Questing/Quests/MainPath/BlacksmithStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/BlacksmithStartQuest.cs
@@ -1,5 +1,8 @@
-﻿using PathOfTerraria.Common.Enums;
+﻿using System.Collections;
+using System.Collections.Generic;
+using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.ItemDropping;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
@@ -8,7 +11,6 @@ using PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 using PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 using PathOfTerraria.Content.NPCs.Town;
 using PathOfTerraria.Content.Skills.Melee;
-using System.Collections.Generic;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
@@ -44,13 +46,7 @@ internal class BlacksmithStartQuest : Quest
 			{
 				RavencrestSystem.UpgradeBuilding("Forge");
 
-				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<BlacksmithNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
-				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<IronBroadsword>());
-
-				if (Main.netMode == NetmodeID.MultiplayerClient)
-				{
-					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
-				}
+				QuestUtils.SpawnNPCQuestRewardItem(player, ModContent.NPCType<BlacksmithNPC>(), ModContent.ItemType<IronBroadsword>());
 
 				return true;
 			}),

--- a/Common/Systems/Questing/Quests/MainPath/BlacksmithStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/BlacksmithStartQuest.cs
@@ -40,12 +40,12 @@ internal class BlacksmithStartQuest : Quest
 				[
 					new GiveItem(20, ItemID.IronOre, ItemID.LeadOre), new(1, ItemID.IronHammer, ItemID.LeadHammer), new(50, ItemID.StoneBlock), new(20, ItemID.Wood)
 				], true),
-			new ActionStep((_, _) => 
+			new ActionStep((player, _) => 
 			{
 				RavencrestSystem.UpgradeBuilding("Forge");
 
-				int npc = NPC.FindFirstNPC(ModContent.NPCType<BlacksmithNPC>());
-				int item = Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<IronBroadsword>());
+				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<BlacksmithNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
+				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<IronBroadsword>());
 
 				if (Main.netMode == NetmodeID.MultiplayerClient)
 				{

--- a/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.ItemDropping;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
@@ -50,13 +51,7 @@ internal class HunterStartQuest : Quest
 			{
 				RavencrestSystem.UpgradeBuilding("Lodge", 1);
 
-				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<HunterNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
-				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<WoodenBow>());
-
-				if (Main.netMode == NetmodeID.MultiplayerClient)
-				{
-					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
-				}
+				QuestUtils.SpawnNPCQuestRewardItem(player, ModContent.NPCType<HunterNPC>(), ModContent.ItemType<WoodenBow>());
 
 				return true;
 			}),

--- a/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HunterStartQuest.cs
@@ -46,12 +46,12 @@ internal class HunterStartQuest : Quest
 			[
 				new GiveItem(5, ItemID.Silk), new(50, ItemID.Wood), new(50, ItemID.StoneBlock),
 			], true),
-			new ActionStep((_, _) =>
+			new ActionStep((player, _) =>
 			{
 				RavencrestSystem.UpgradeBuilding("Lodge", 1);
 
-				int npc = NPC.FindFirstNPC(ModContent.NPCType<HunterNPC>());
-				int item = Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<WoodenBow>());
+				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<HunterNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
+				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<WoodenBow>());
 
 				if (Main.netMode == NetmodeID.MultiplayerClient)
 				{

--- a/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
+using PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
 using Terraria.DataStructures;
@@ -40,26 +42,14 @@ internal class KingSlimeQuest : Quest
 			//Give the map device to the player once req mats are given
 			new ActionStep((player, _) => 
 			{
-				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
-				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<Content.Items.Placeable.MapDevice>());
-
-				if (Main.netMode == NetmodeID.MultiplayerClient)
-				{
-					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
-				}
+				QuestUtils.SpawnNPCQuestRewardItem(player, ModContent.NPCType<GarrickNPC>(), ModContent.ItemType<Content.Items.Placeable.MapDevice>());
 
 				return true;
 			}),
 			//Give the map as well
 			new ActionStep((player, _) => 
 			{
-				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
-				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<KingSlimeMap>());
-
-				if (Main.netMode == NetmodeID.MultiplayerClient)
-				{
-					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
-				}
+				QuestUtils.SpawnNPCQuestRewardItem(player, ModContent.NPCType<GarrickNPC>(), ModContent.ItemType<KingSlimeMap>());
 
 				return true;
 			}),

--- a/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
@@ -38,10 +38,10 @@ internal class KingSlimeQuest : Quest
 					new GiveItem(1, ItemID.Ruby),
 				], true),
 			//Give the map device to the player once req mats are given
-			new ActionStep((_, _) => 
+			new ActionStep((player, _) => 
 			{
-				int npc = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>());
-				int item = Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<Content.Items.Placeable.MapDevice>());
+				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
+				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<Content.Items.Placeable.MapDevice>());
 
 				if (Main.netMode == NetmodeID.MultiplayerClient)
 				{
@@ -51,10 +51,10 @@ internal class KingSlimeQuest : Quest
 				return true;
 			}),
 			//Give the map as well
-			new ActionStep((_, _) => 
+			new ActionStep((player, _) => 
 			{
-				int npc = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>());
-				int item = Item.NewItem(new EntitySource_Gift(Main.npc[npc]), Main.npc[npc].Center, ModContent.ItemType<KingSlimeMap>());
+				Entity entity = NPC.FindFirstNPC(ModContent.NPCType<GarrickNPC>()) is >= 0 and int npc ? Main.npc[npc] : player;
+				int item = Item.NewItem(new EntitySource_Gift(entity), entity.Center, ModContent.ItemType<KingSlimeMap>());
 
 				if (Main.netMode == NetmodeID.MultiplayerClient)
 				{

--- a/Common/UI/Components/UIDraggable.cs
+++ b/Common/UI/Components/UIDraggable.cs
@@ -1,0 +1,121 @@
+﻿using PathOfTerraria.Core.UI;
+using Terraria.UI;
+
+#nullable enable
+
+namespace PathOfTerraria.Common.UI.Components;
+
+/// <summary> Makes an element movable and resizable using the left mouse button. </summary>
+internal sealed class UIMouseDrag(bool canMove, bool canResize) : UIComponent
+{
+	private Vector2 dragMousePosition;
+	private Vector2 dragElementPosition;
+	private Vector2 dragElementSize;
+	private Vector2 dragMoveAxes;
+	private Vector2 dragResizeAxes;
+
+	public bool CanMove { get; set;  } = canMove;
+	public bool CanResize { get; set; } = canResize;
+	public bool IsDragging { get; private set; }
+
+	protected override void OnAttach(UIElement element)
+	{
+		element.OnUpdate += OnUpdate;
+		element.OnLeftMouseDown += OnLeftMouseDown;
+	}
+	protected override void OnDetach(UIElement element)
+	{
+		element.OnUpdate -= OnUpdate;
+		element.OnLeftMouseDown -= OnLeftMouseDown;
+	}
+
+	private void OnUpdate(UIElement element)
+	{
+		Vector2 mousePosition = Main.MouseScreen;
+
+		if (IsDragging ? (dragResizeAxes != Vector2.Zero) : (CanResize && CheckResizeArea(element, mousePosition, out _, out _, out _, out _)))
+		{
+			Main.cursorOverride = 2;
+		}
+
+		if (!IsDragging)
+		{
+			return;
+		}
+
+		Vector2 mouseDelta = mousePosition - dragMousePosition;
+		Vector2 oldPosition = new(element.Left.Pixels, element.Top.Pixels);
+		Vector2 oldSize = new(element.Width.Pixels, element.Height.Pixels);
+
+		Vector2 moveOffset = mouseDelta * dragMoveAxes;
+		Vector2 resizeOffset = mouseDelta * dragResizeAxes;
+		element.Left.Pixels = dragElementPosition.X + moveOffset.X;
+		element.Top.Pixels = dragElementPosition.Y + moveOffset.Y;
+		element.Width.Pixels = dragElementSize.X + resizeOffset.X;
+		element.Height.Pixels = dragElementSize.Y + resizeOffset.Y;
+
+		if (element.Left.Pixels != oldPosition.X || element.Top.Pixels != oldPosition.Y || element.Width.Pixels != oldSize.X || element.Height.Pixels != oldSize.Y)
+		{
+			element.Recalculate();
+		}
+
+		if (!Main.mouseLeft)
+		{
+			IsDragging = false;
+		}
+	}
+
+	private void OnLeftMouseDown(UIMouseEvent evt, UIElement element)
+	{
+		if (IsDragging || evt.Target != element)
+		{
+			return;
+		}
+
+		Vector2 mousePosition = Main.MouseScreen;
+
+		if (CanResize)
+		{
+			var dimensions = element.GetOuterDimensions().ToRectangle();
+			bool isResizing = CheckResizeArea(element, mousePosition, out bool left, out bool right, out bool top, out bool bottom);
+
+			if (!CanMove && !isResizing)
+			{
+				return;
+			}
+
+			dragResizeAxes = isResizing ? new Vector2(left ? -1f : (right ? 1f : 0f), top ? -1f : (bottom ? 1f : 0f)) : default;
+			dragMoveAxes = isResizing ? new Vector2(left ? 1f : 0f, top ? 1f : 0f) : Vector2.One;
+		}
+		else
+		{
+			dragResizeAxes = Vector2.Zero;
+			dragMoveAxes = Vector2.One;
+		}
+
+		IsDragging = true;
+		dragMousePosition = mousePosition;
+		dragElementPosition = new Vector2(element.Left.Pixels, element.Top.Pixels);
+		dragElementSize = new Vector2(element.Width.Pixels, element.Height.Pixels);
+	}
+
+	private static bool CheckResizeArea(UIElement element, Vector2 mousePosition, out bool resizingLeft, out bool resizingRight, out bool resizingTop, out bool resizingBottom)
+	{
+		const float ResizeRadius = 12f;
+
+		var dimensions = element.GetOuterDimensions().ToRectangle();
+
+		if (!dimensions.Contains(mousePosition.ToPoint()))
+		{
+			(resizingLeft, resizingRight, resizingTop, resizingBottom) = (false, false, false, false);
+			return false; 
+		}
+
+		resizingRight = mousePosition.X >= dimensions.Right - ResizeRadius;
+		resizingLeft = !resizingRight && mousePosition.X <= dimensions.Left + ResizeRadius;
+		resizingBottom = mousePosition.Y >= dimensions.Bottom - ResizeRadius;
+		resizingTop = !resizingBottom && mousePosition.Y <= dimensions.Top + ResizeRadius;
+
+		return resizingLeft | resizingRight | resizingTop | resizingBottom;
+	}
+}

--- a/Common/UI/Components/UIDynamicText.cs
+++ b/Common/UI/Components/UIDynamicText.cs
@@ -23,6 +23,8 @@ internal sealed class UIDynamicText(Func<string> textGetter) : UIComponent
 		}
 
 		element.OnUpdate += OnUpdate;
+
+		UpdateText(element);
 	}
 	protected override void OnDetach(UIElement element)
 	{
@@ -35,6 +37,11 @@ internal sealed class UIDynamicText(Func<string> textGetter) : UIComponent
 	}
 
 	private void OnUpdate(UIElement element)
+	{
+		UpdateText(element);
+	}
+
+	private void UpdateText(UIElement element)
 	{
 		string newText = GetText();
 

--- a/Common/UI/Components/UIDynamicText.cs
+++ b/Common/UI/Components/UIDynamicText.cs
@@ -1,0 +1,66 @@
+﻿using PathOfTerraria.Core.UI;
+using Terraria.GameContent.UI.Elements;
+using Terraria.ModLoader.UI;
+using Terraria.UI;
+
+#nullable enable
+
+namespace PathOfTerraria.Common.UI.Components;
+
+/// <summary>
+/// Makes an element update its text value in real time using the provided delegate in a cached manner.
+/// <br/> Supports UIText, UITextBox, UIButton, UITextPanel(string), UIAutoScaleTextTextPanel(string).
+/// </summary>
+internal sealed class UIDynamicText(Func<string> textGetter) : UIComponent
+{
+	private readonly Func<string> textGetter = textGetter;
+
+	protected override void OnAttach(UIElement element)
+	{
+		if (element is not UIText and not UITextPanel<string> and not UIAutoScaleTextTextPanel<string>)
+		{
+			throw new InvalidOperationException($"{GetType().Name} cannot be used on element of type '{element.GetType().Name}'.");
+		}
+
+		element.OnUpdate += OnUpdate;
+	}
+	protected override void OnDetach(UIElement element)
+	{
+		element.OnUpdate -= OnUpdate;
+	}
+
+	public string GetText()
+	{
+		return textGetter();
+	}
+
+	private void OnUpdate(UIElement element)
+	{
+		string newText = GetText();
+
+		switch (element)
+		{
+			case UIText ui:
+				if (newText != ui.Text)
+				{
+					ui.SetText(newText);
+				}
+
+				break;
+			case UITextPanel<string> ui:
+				if (newText != ui.Text)
+				{
+					ui.SetText(newText);
+				}
+
+				break;
+			case UIAutoScaleTextTextPanel<string> ui:
+				if (newText != ui.Text)
+				{
+					ui.SetText(newText);
+				}
+
+				break;
+		}
+	}
+}

--- a/Common/UI/Elements/UIEditableText.cs
+++ b/Common/UI/Elements/UIEditableText.cs
@@ -25,7 +25,7 @@ public partial class UIEditableText(InputType inputType = InputType.Text, string
 	private readonly int _maxChars = maxChars;
 	private readonly bool _leftAligned = leftAligned;
 
-	public string UseValue => CurrentValue == string.Empty ? _backingString : CurrentValue;
+	public string UseValue => CurrentValue == string.Empty && !_typing ? _backingString : CurrentValue;
 
 	public string CurrentValue = "";
 
@@ -78,6 +78,8 @@ public partial class UIEditableText(InputType inputType = InputType.Text, string
 		{
 			SetNotTyping();
 		}
+
+		base.Update(gameTime);
 	}
 
 	public void HandleText()
@@ -162,7 +164,7 @@ public partial class UIEditableText(InputType inputType = InputType.Text, string
 
 		string displayed = CurrentValue ?? "";
 
-		if (displayed != string.Empty)
+		if (displayed != string.Empty || _typing)
 		{
 			Utils.DrawBorderString(spriteBatch, displayed, pos, color, Scale, _leftAligned ? 0 : 1);
 		}

--- a/Common/UI/Quests/QuestsUIState.cs
+++ b/Common/UI/Quests/QuestsUIState.cs
@@ -70,6 +70,17 @@ public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 		}
 	}
 
+	public override void Refresh()
+	{
+		base.Refresh();
+
+		if (Visible)
+		{
+			Toggle();
+			Toggle();
+		}
+	}
+
 	public void Toggle()
 	{
 		ViewedQuest = null;

--- a/Core/UI/UIComponents.cs
+++ b/Core/UI/UIComponents.cs
@@ -1,0 +1,64 @@
+﻿using Terraria.UI;
+
+#nullable enable
+
+namespace PathOfTerraria.Core.UI;
+
+internal abstract class UIComponent
+{
+	// Avoid keeping attached elements alive.
+	private WeakReference<UIElement> reference = null!;
+
+	/// <summary> The element that this UI component is attached to. When possible, it best to instead use the element parameter provided by events. </summary>
+	public UIElement Element
+	{
+		get
+		{
+			reference.TryGetTarget(out UIElement? element);
+			return element!;
+		}
+	}
+
+	protected abstract void OnAttach(UIElement element);
+
+	protected abstract void OnDetach(UIElement element);
+
+	public void AttachTo(UIElement element)
+	{
+		if (reference != null)
+		{
+			throw new InvalidOperationException("UI component already attached to an element.");
+		}
+
+		reference = new WeakReference<UIElement>(element);
+
+		OnAttach(element);
+	}
+
+	public void DetachFrom(UIElement element)
+	{
+		if (reference == null)
+		{
+			throw new InvalidOperationException("UI component not attached to an element.");
+		}
+
+		if (element != Element)
+		{
+			throw new InvalidOperationException("Attempted to detach a UI component from an element it is not attached to.");
+		}
+
+		OnDetach(element);
+
+		reference = null!;
+	}
+}
+
+internal static class UIComponentExtensions
+{
+	/// <summary> Links a given component with this UI element, returns the component. </summary>
+	public static TComponent AddComponent<TComponent>(this UIElement element, TComponent component) where TComponent : UIComponent
+	{
+		component.AttachTo(element);
+		return component;
+	}
+}

--- a/Core/UI/UIUtilities.cs
+++ b/Core/UI/UIUtilities.cs
@@ -1,0 +1,45 @@
+﻿using Terraria.GameContent.UI.Elements;
+using Terraria.ModLoader.UI.Elements;
+using Terraria.UI;
+
+namespace PathOfTerraria.Core.UI;
+
+internal static class UIUtilities
+{
+	/// <summary> Adds or Appends a child element to the current one and returns it. </summary>
+	public static T AddElement<T>(this UIElement parent, T child, Action<T> initAction) where T : UIElement
+	{
+		initAction?.Invoke(child);
+
+		if (parent is UIGrid uiGrid)
+		{
+			uiGrid.Add(child);
+		}
+		else if (parent is UIList uiList)
+		{
+			uiList.Add(child);
+		}
+		else
+		{
+			parent.Append(child);
+		}
+
+		return child;
+	}
+
+	/// <summary> Sets an element's location and size. </summary>
+	public static void SetDimensions
+	(
+		this UIElement element,
+		(float Factor, float Pixels) x = default,
+		(float Factor, float Pixels) y = default,
+		(float Factor, float Pixels) width = default,
+		(float Factor, float Pixels) height = default
+	)
+	{
+		element.Left = new StyleDimension(x.Pixels, x.Factor);
+		element.Top = new StyleDimension(y.Pixels, y.Factor);
+		element.Width = new StyleDimension(width.Pixels, width.Factor);
+		element.Height = new StyleDimension(height.Pixels, height.Factor);
+	}
+}

--- a/Localization/de-DE/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@
 // QuestUIKey.DisplayName: Quest UI Key
 // DropTableKey.DisplayName: Drop Table Key
 // PassiveTreeUIKey.DisplayName: Passive Tree UI Key
+// ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging

--- a/Localization/en-US/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@ GearSwap.DisplayName: Weapon Swap
 QuestUIKey.DisplayName: Quest UI Key
 DropTableKey.DisplayName: Drop Table Key
 PassiveTreeUIKey.DisplayName: Passive Tree UI Key
+ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging

--- a/Localization/es-ES/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@
 // QuestUIKey.DisplayName: Quest UI Key
 // DropTableKey.DisplayName: Drop Table Key
 // PassiveTreeUIKey.DisplayName: Passive Tree UI Key
+// ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging

--- a/Localization/fr-FR/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@ GearSwap.DisplayName: Change d'Arme
 QuestUIKey.DisplayName: Touche d'interface de Quête
 DropTableKey.DisplayName: Touche de la Table des Butins
 PassiveTreeUIKey.DisplayName: Touche d'interface d'Arbre Passif
+// ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging

--- a/Localization/pl-PL/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@ GearSwap.DisplayName: Zmiana Broni
 QuestUIKey.DisplayName: Klawisz UI Zadań
 // DropTableKey.DisplayName: Drop Table Key
 PassiveTreeUIKey.DisplayName: Klawisz UI Drzewka Pasywnego
+// ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging

--- a/Localization/pt-BR/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@
 // QuestUIKey.DisplayName: Quest UI Key
 // DropTableKey.DisplayName: Drop Table Key
 // PassiveTreeUIKey.DisplayName: Passive Tree UI Key
+// ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging

--- a/Localization/ru-RU/Mods.PathOfTerraria.Keybinds.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Keybinds.hjson
@@ -9,3 +9,4 @@ GearSwap.DisplayName: Обмен оружием
 QuestUIKey.DisplayName: Ключ квестового интерфейса
 DropTableKey.DisplayName: Клавиша сброса таблицы
 PassiveTreeUIKey.DisplayName: Ключ пользовательского интерфейса пассивного дерева
+// ToggleQuestDebugging.DisplayName: Debug: Toggle Quest Debugging


### PR DESCRIPTION
﻿### Link Issues
Resolves #1424

### Description of Work
<img width="987" height="792" alt="image" src="https://github.com/user-attachments/assets/9af8c641-e848-4b54-a776-3a443de16c64" />

- Implemented a debugging UI for quests, which allows viewing, searching for, starting, advancing, reversing, and resetting quests. It can be accessed using the `/potQuestDebug` command, or a configurable key binding if using self-compiled DEBUG builds. For players, this UI will only be accessible in singleplayer.
- Internal: Implemented UI components, which are a lightweight and scalable way to write reusable UI code. This PR includes the `UIMouseDrag` component, which allows making literally any UI element draggable and resizable, regardless of what the element's inheritance chains happen to be. Moving forward, this will be the preferred way to implement any generic UI logic.
- Internal: Implemented a pair of UI extensions meant to made UI code easier to write and read
- Internal: Made certain quest code more defensive, avoiding exceptions when quests are advanced without specific NPCs present in the world.
- Internal: Changed Quests' data layout to completely prevent an unintended "completed but active" state that some code was checking for.

### Comments
