### PR TITLE
a ton of random fixes

### DIFF
--- a/Common/Projectiles/ClickableProjectilePlayer.cs
+++ b/Common/Projectiles/ClickableProjectilePlayer.cs
@@ -1,6 +1,15 @@
-﻿using System.Collections.Generic;
+﻿namespace PathOfTerraria.Common.Projectiles;
 
-namespace PathOfTerraria.Common.Projectiles;
+/// <summary>
+/// Allows a given projectile to have right click functionality.
+/// </summary>
+internal interface IRightClickableProjectile
+{
+	/// <summary>
+	/// Called when the projectile is right clicked on the local client.
+	/// </summary>
+	public bool RightClick(Projectile self, Player player);
+}
 
 /// <summary>
 /// Allows the developer to define behaviour when the player hovers over a specific projectile.<br/>
@@ -8,33 +17,16 @@ namespace PathOfTerraria.Common.Projectiles;
 /// </summary>
 internal class ClickableProjectilePlayer : ModPlayer
 {
-	private readonly static Dictionary<int, Func<Projectile, Player, bool>> OnHoverProjectile = [];
-
-	/// <summary>
-	/// Registers a projectile ID and a corresponding hover action to the internal dictionary. This should be run in <see cref="ModType.SetStaticDefaults"/>.
-	/// </summary>
-	/// <param name="projectile">Projectile ID to use.</param>
-	/// <param name="onClick">Behaviour to run for the projectile. Takes in the current projectile and the client.</param>
-	public static void RegisterProjectile(int projectile, Func<Projectile, Player, bool> onClick)
-	{
-		if (Main.dedServ)
-		{
-			return;
-		}
-
-		OnHoverProjectile.Add(projectile, onClick);
-	}
-
 	public override void UpdateEquips()
 	{
 		if (Main.myPlayer == Player.whoAmI)
 		{
 			foreach (Projectile projectile in Main.ActiveProjectiles)
 			{
-				if (OnHoverProjectile.TryGetValue(projectile.type, out Func<Projectile, Player, bool> value) && projectile.Hitbox.Contains(Main.MouseWorld.ToPoint())
+				if (projectile.ModProjectile is IRightClickableProjectile right && projectile.Hitbox.Contains(Main.MouseWorld.ToPoint())
 					&& Player.IsInTileInteractionRange(Player.tileTargetX, Player.tileTargetY, Terraria.DataStructures.TileReachCheckSettings.Simple))
 				{
-					if (value.Invoke(projectile, Player))
+					if (right.RightClick(projectile, Player))
 					{
 						return;
 					}

--- a/Common/Projectiles/ClickableProjectilePlayer.cs
+++ b/Common/Projectiles/ClickableProjectilePlayer.cs
@@ -8,14 +8,14 @@ namespace PathOfTerraria.Common.Projectiles;
 /// </summary>
 internal class ClickableProjectilePlayer : ModPlayer
 {
-	private readonly static Dictionary<int, Action<Projectile, Player>> OnHoverProjectile = [];
+	private readonly static Dictionary<int, Func<Projectile, Player, bool>> OnHoverProjectile = [];
 
 	/// <summary>
 	/// Registers a projectile ID and a corresponding hover action to the internal dictionary. This should be run in <see cref="ModType.SetStaticDefaults"/>.
 	/// </summary>
 	/// <param name="projectile">Projectile ID to use.</param>
 	/// <param name="onClick">Behaviour to run for the projectile. Takes in the current projectile and the client.</param>
-	public static void RegisterProjectile(int projectile, Action<Projectile, Player> onClick)
+	public static void RegisterProjectile(int projectile, Func<Projectile, Player, bool> onClick)
 	{
 		if (Main.dedServ)
 		{
@@ -31,10 +31,13 @@ internal class ClickableProjectilePlayer : ModPlayer
 		{
 			foreach (Projectile projectile in Main.ActiveProjectiles)
 			{
-				if (OnHoverProjectile.TryGetValue(projectile.type, out Action<Projectile, Player> value) && projectile.Hitbox.Contains(Main.MouseWorld.ToPoint())
+				if (OnHoverProjectile.TryGetValue(projectile.type, out Func<Projectile, Player, bool> value) && projectile.Hitbox.Contains(Main.MouseWorld.ToPoint())
 					&& Player.IsInTileInteractionRange(Player.tileTargetX, Player.tileTargetY, Terraria.DataStructures.TileReachCheckSettings.Simple))
 				{
-					value.Invoke(projectile, Player);
+					if (value.Invoke(projectile, Player))
+					{
+						return;
+					}
 				}
 			}
 		}

--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -18,6 +18,7 @@ using Terraria.UI;
 
 namespace PathOfTerraria.Common.Quests;
 
+[Autoload(true, Side = ModSide.Client)]
 internal sealed class QuestDebugging : ModSystem
 {
 #if DEBUG

--- a/Common/Subworlds/BossDomains/Hardmode/EmpressDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/EmpressDomain.cs
@@ -12,7 +12,7 @@ namespace PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 
 internal class EmpressDomain : BossDomainSubworld, IOverrideBiome
 {
-	public override int Width => 670;
+	public override int Width => 654;
 	public override int Height => 600;
 	public override (int time, bool isDay) ForceTime => (8000, false);
 

--- a/Common/Systems/ModPlayers/LivesSystem/BossDomainLivesPlayer.cs
+++ b/Common/Systems/ModPlayers/LivesSystem/BossDomainLivesPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using SubworldLibrary;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -38,7 +39,7 @@ internal class BossDomainLivesPlayer : ModPlayer
 		}
 	}
 
-	public override void ResetEffects()
+	public override void OnEnterWorld()
 	{
 		bool inDomain = SubworldSystem.Current is MappingWorld;
 
@@ -98,13 +99,21 @@ internal class BossDomainLivesPlayer : ModPlayer
 		return true;
 	}
 
+	/// <summary>
+	/// Called when the player exits a domain. Local player only.
+	/// </summary>
 	private void ExitDomain()
 	{
 		if (Player.dead || Player.ghost)
 		{
-			Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
 			Player.ghost = false;
 			Player.deadForGood = false;
+			Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
+
+			if (Main.netMode == NetmodeID.MultiplayerClient)
+			{
+				ModContent.GetInstance<RequestCheckSectionHandler>().Send((byte)Player.whoAmI, Player.Center);
+			}
 		}
 
 		LivesLost = 0;

--- a/Common/Systems/Questing/Quest.cs
+++ b/Common/Systems/Questing/Quest.cs
@@ -248,6 +248,13 @@ public abstract class Quest : ModType, ILocalizedModType
 		state = State.InProgress;
 
 		int step = tag.GetInt("currentQuest");
+
+		if (step >= QuestSteps.Count)
+		{
+			Mod.Logger.Debug("Quest " + Name + " needed to have loaded step adjusted.");
+			step = QuestSteps.Count - 1;
+		}
+
 		Start(player, step);
 
 		for (int i = 0; i < step; ++i)

--- a/Common/Systems/Synchronization/Handlers/RequestCheckSectionHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/RequestCheckSectionHandler.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
+
+/// <inheritdoc cref="Networking.Message.RequestCheckSection"/>
+internal class RequestCheckSectionHandler : Handler
+{
+	public override Networking.Message MessageType => Networking.Message.RequestCheckSection;
+
+	/// <inheritdoc cref="Networking.Message.RequestCheckSection"/>
+	public override void Send(params object[] parameters)
+	{
+		CastParameters(parameters, out byte player, out Vector2 position);
+
+		ModPacket packet = Networking.GetPacket(MessageType);
+		packet.Write(player);
+		packet.Write(position.X);
+		packet.Write(position.Y);
+		packet.Send();
+	}
+
+	internal override void ServerRecieve(BinaryReader reader)
+	{
+		byte plr = reader.ReadByte();
+		Vector2 pos = reader.ReadVector2();
+
+		RemoteClient.CheckSection(plr, pos);
+		NetMessage.SendData(MessageID.TeleportEntity, -1, -1, null, 0, plr, pos.X, pos.Y, 2, 1);
+	}
+}

--- a/Common/Systems/Synchronization/Networking.cs
+++ b/Common/Systems/Synchronization/Networking.cs
@@ -154,6 +154,12 @@ internal static class Networking
 		/// <c>byte who</c>
 		/// </summary>
 		RequestMappingDomainInfo,
+
+		/// <summary>
+		/// Calls <see cref="RemoteClient.CheckSection(int, Vector2, int)"/> on the server for the given player.<br/>Signature:<br/>
+		/// <c>byte who, Vector2 position</c>
+		/// </summary>
+		RequestCheckSection,
 	}
 
 	internal static void HandlePacket(BinaryReader reader)

--- a/Common/World/Passes/RemoveBeeLarvaeStep.cs
+++ b/Common/World/Passes/RemoveBeeLarvaeStep.cs
@@ -9,14 +9,7 @@ internal class RemoveBeeLarvaeStep : AutoGenStep
 {
 	public override void Generate(GenerationProgress progress, GameConfiguration config)
 	{
-		Range xRange = (Main.maxTilesX / 3)..(Main.maxTilesX - 100);
-
-		if (Main.dungeonX < 0)
-		{
-			xRange = 100..(int)(Main.maxTilesX / 1.5f);
-		}
-
-		for (int i = xRange.Start.Value; i <= xRange.End.Value; i++)
+		for (int i = 100; i <= Main.maxTilesX - 100; i++)
 		{
 			for (int j = (int)Main.worldSurface; j < Main.maxTilesY - 200; ++j)
 			{

--- a/Content/Buffs/ElementalBuffs/FreezeFunctionality.cs
+++ b/Content/Buffs/ElementalBuffs/FreezeFunctionality.cs
@@ -131,7 +131,7 @@ internal class FreezeNPC : GlobalNPC
 	{
 		SoundStyle? hitSound = self.HitSound;
 
-		if (self.GetGlobalNPC<FreezeNPC>().Frozen)
+		if (self.TryGetGlobalNPC(out FreezeNPC freeze) && freeze.Frozen)
 		{
 			self.HitSound = SoundID.Item27;
 		}

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -5,7 +5,6 @@ using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Common.Systems.ModPlayers.LivesSystem;
 using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using PathOfTerraria.Core.Items;
-using SubworldLibrary;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.ID;
@@ -13,7 +12,7 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Items.Consumables.Maps;
 
-public abstract class Map : ModItem, GenerateName.IItem, GenerateAffixes.IItem, GenerateImplicits.IItem, IPoTGlobalItem, GetItemLevel.IItem, SetItemLevel.IItem
+public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.IItem, GenerateImplicits.IItem, IPoTGlobalItem, GetItemLevel.IItem, SetItemLevel.IItem
 {
 	protected sealed override bool CloneNewInstances => true;
 
@@ -71,14 +70,6 @@ public abstract class Map : ModItem, GenerateName.IItem, GenerateAffixes.IItem, 
 	}
 
 	protected abstract void OpenMapInternal();
-
-	/// <summary>
-	/// Gets name and what tier the map is of as a singular string.
-	/// </summary>
-	public virtual string GetNameAndTier()
-	{
-		return Core.Items.GenerateName.Invoke(Item);
-	}
 
 	public virtual int GetMapTier(int itemLevel)
 	{
@@ -178,5 +169,10 @@ public abstract class Map : ModItem, GenerateName.IItem, GenerateAffixes.IItem, 
 		realLevel = level;
 		ItemLevel = realLevel;
 		Tier = GetMapTier(ItemLevel);
+	}
+
+	(sbyte, sbyte) GenerateNameAffixes.IItem.GenerateAffixIds()
+	{
+		return (-1, -1);
 	}
 }

--- a/Content/Items/Currency/CurrencyShard.cs
+++ b/Content/Items/Currency/CurrencyShard.cs
@@ -7,7 +7,7 @@ namespace PathOfTerraria.Content.Items.Currency;
 /// <summary>
 /// Base class for currency shards. Defaults to having a 4-frame animation, consumable, and has a default <see cref="CanRightClick"/>.
 /// </summary>
-public abstract class CurrencyShard : ModItem
+public abstract class CurrencyShard : ModItem, GenerateNameAffixes.IItem
 {
 	protected virtual int FrameCount => 4;
 
@@ -43,5 +43,10 @@ public abstract class CurrencyShard : ModItem
 
 		PoTInstanceItemData item = Main.LocalPlayer.HeldItem.GetInstanceData();
 		return !item.Corrupted && !item.Cloned;
+	}
+
+	(sbyte, sbyte) GenerateNameAffixes.IItem.GenerateAffixIds()
+	{
+		return (-1, -1);
 	}
 }

--- a/Content/Items/Currency/EchoingShard.cs
+++ b/Content/Items/Currency/EchoingShard.cs
@@ -38,6 +38,7 @@ public class EchoingShard : CurrencyShard
 		clonedData.ImplicitCount = data.ImplicitCount;
 		clonedData.RealLevel = data.RealLevel;
 		clonedData.Affixes = [..data.Affixes];
+		clonedData.NameAffix = data.NameAffix;
 		clonedData.Cloned = true;
 
 		var source = new Terraria.DataStructures.EntitySource_Misc("EchoingShard");

--- a/Content/Items/Currency/EchoingShard.cs
+++ b/Content/Items/Currency/EchoingShard.cs
@@ -34,7 +34,6 @@ public class EchoingShard : CurrencyShard
 		PoTInstanceItemData clonedData = clonedItem.GetInstanceData();
 		clonedData.Rarity = data.Rarity;
 		clonedData.Influence = data.Influence;
-		clonedData.SpecialName = data.SpecialName;
 		clonedData.ImplicitCount = data.ImplicitCount;
 		clonedData.RealLevel = data.RealLevel;
 		clonedData.Affixes = [..data.Affixes];

--- a/Content/Items/Gear/Armor/Leggings/BurningRedBoots.cs
+++ b/Content/Items/Gear/Armor/Leggings/BurningRedBoots.cs
@@ -28,11 +28,6 @@ internal class BurningRedBoots : Leggings
 		];
 	}
 
-	//string GenerateNameAffixes.IItem.GenerateName(string defaultName)
-	//{
-	//	return Language.GetTextValue("Mods.PathOfTerraria.Items.BurningRedBoots.DisplayName");
-	//}
-
 	public override void ModifyTooltips(List<TooltipLine> tooltips)
 	{
 		TooltipLine nameTip = tooltips.First(x => x.Name == "ItemName");

--- a/Content/Items/Gear/Armor/Leggings/BurningRedBoots.cs
+++ b/Content/Items/Gear/Armor/Leggings/BurningRedBoots.cs
@@ -3,12 +3,11 @@ using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Core.Items;
 using System.Collections.Generic;
 using System.Linq;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Armor.Leggings;
 
 [AutoloadEquip(EquipType.Legs)]
-internal class BurningRedBoots : Leggings, GenerateName.IItem
+internal class BurningRedBoots : Leggings
 {
 	public override void SetStaticDefaults()
 	{
@@ -29,10 +28,10 @@ internal class BurningRedBoots : Leggings, GenerateName.IItem
 		];
 	}
 
-	string GenerateName.IItem.GenerateName(string defaultName)
-	{
-		return Language.GetTextValue("Mods.PathOfTerraria.Items.BurningRedBoots.DisplayName");
-	}
+	//string GenerateNameAffixes.IItem.GenerateName(string defaultName)
+	//{
+	//	return Language.GetTextValue("Mods.PathOfTerraria.Items.BurningRedBoots.DisplayName");
+	//}
 
 	public override void ModifyTooltips(List<TooltipLine> tooltips)
 	{

--- a/Content/Items/Gear/Offhands/Offhand.cs
+++ b/Content/Items/Gear/Offhands/Offhand.cs
@@ -2,10 +2,15 @@
 
 namespace PathOfTerraria.Content.Items.Gear.Offhands;
 
-public abstract class Offhand : Gear
+public abstract class Offhand : Gear, GenerateNameAffixes.IItem
 {
 	protected override string GearLocalizationCategory => "Offhand";
-	
+
+	public virtual (sbyte, sbyte) GenerateAffixIds()
+	{
+		return (-1, -1);
+	}
+
 	public override void SetDefaults()
 	{
 		base.SetDefaults();

--- a/Content/Items/Gear/Weapons/Sword/BloodOath.cs
+++ b/Content/Items/Gear/Weapons/Sword/BloodOath.cs
@@ -11,7 +11,7 @@ using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
-internal class BloodOath : Sword, GenerateName.IItem
+internal class BloodOath : Sword
 {
 	protected override bool CloneNewInstances => true;
 
@@ -50,11 +50,6 @@ internal class BloodOath : Sword, GenerateName.IItem
 		Item.UseSound = SoundID.Item1;
 		Item.shoot = ProjectileID.None;
 		Item.value = Item.buyPrice(0, 0, 20, 0);
-	}
-
-	string GenerateName.IItem.GenerateName(string defaultName)
-	{
-		return Language.GetTextValue("Mods.PathOfTerraria.Items.BloodOath.DisplayName");
 	}
 
 	public override List<ItemAffix> GenerateAffixes()

--- a/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
+++ b/Content/Items/Gear/Weapons/Sword/DwarvenGreatsword.cs
@@ -5,11 +5,10 @@ using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Core.Items;
 using Terraria.GameContent;
 using Terraria.ID;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
-internal class DwarvenGreatsword : Sword, GenerateName.IItem
+internal class DwarvenGreatsword : Sword
 {
 	public override void SetStaticDefaults()
 	{
@@ -36,11 +35,6 @@ internal class DwarvenGreatsword : Sword, GenerateName.IItem
 		Item.shoot = ProjectileID.None;
 		Item.useTime = Item.useAnimation = 34;
 		Item.value = Item.buyPrice(0, 15, 0, 0);
-	}
-
-	string GenerateName.IItem.GenerateName(string defaultName)
-	{
-		return Language.GetTextValue("Mods.PathOfTerraria.Items.DwarvenGreatsword.DisplayName");
 	}
 
 	public override List<ItemAffix> GenerateAffixes()

--- a/Content/Items/Gear/Weapons/Sword/FireStarter.cs
+++ b/Content/Items/Gear/Weapons/Sword/FireStarter.cs
@@ -8,11 +8,10 @@ using System.Linq;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.ID;
-using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 
-internal class FireStarter : Sword, GenerateName.IItem
+internal class FireStarter : Sword
 {
 	public override void SetStaticDefaults()
 	{
@@ -35,11 +34,6 @@ internal class FireStarter : Sword, GenerateName.IItem
 		Item.value = Item.buyPrice(0, 0, 5, 0);
 	}
 	
-	string GenerateName.IItem.GenerateName(string defaultName)
-	{
-		return Language.GetTextValue("Mods.PathOfTerraria.Items.FireStarter.DisplayName");
-	}
-
 	public override void ModifyTooltips(List<TooltipLine> tooltips)
 	{
 		TooltipLine nameTip = tooltips.First(x => x.Name == "ItemName");

--- a/Content/Projectiles/Utility/ExitPortal.cs
+++ b/Content/Projectiles/Utility/ExitPortal.cs
@@ -7,27 +7,8 @@ using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class ExitPortal : ModProjectile
+internal class ExitPortal : ModProjectile, IRightClickableProjectile
 {
-	public override void SetStaticDefaults()
-	{
-		ClickableProjectilePlayer.RegisterProjectile(Type, (_, _) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease)
-			{
-				SubworldSystem.Exit();
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-			return false;
-		});
-	}
-
 	public override void SetDefaults()
 	{
 		Projectile.friendly = false;
@@ -69,6 +50,22 @@ internal class ExitPortal : ModProjectile
 			Main.spriteBatch.Draw(tex, position, null, color, rotation, tex.Size() / 2f, 1f - i * 0.2f, SpriteEffects.None, 0);
 		}
 
+		return false;
+	}
+
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
+	{
+		if (Main.mouseRight && Main.mouseRightRelease)
+		{
+			SubworldSystem.Exit();
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
 		return false;
 	}
 

--- a/Content/Projectiles/Utility/ExitPortal.cs
+++ b/Content/Projectiles/Utility/ExitPortal.cs
@@ -16,6 +16,7 @@ internal class ExitPortal : ModProjectile
 			if (Main.mouseRight && Main.mouseRightRelease)
 			{
 				SubworldSystem.Exit();
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -23,6 +24,7 @@ internal class ExitPortal : ModProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/EyePortal.cs
+++ b/Content/Projectiles/Utility/EyePortal.cs
@@ -10,39 +10,11 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class EyePortal : ModProjectile, ISaveProjectile
+internal class EyePortal : ModProjectile, ISaveProjectile, IRightClickableProjectile
 {
 	private ref float Timer => ref Projectile.ai[0];
 	private ref float Uses => ref Projectile.ai[1];
 	private ref float MaxUses => ref Projectile.ai[2];
-
-	public override void SetStaticDefaults()
-	{
-		ClickableProjectilePlayer.RegisterProjectile(Type, static (proj, _) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease)
-			{
-				SubworldSystem.Enter<EyeDomain>();
-
-				proj.ai[1]++;
-				proj.netUpdate = true;
-
-				if (proj.ai[1] > proj.ai[2])
-				{
-					proj.Kill();
-				}
-
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-			return false;
-		});
-	}
 
 	public override void SetDefaults()
 	{
@@ -124,5 +96,30 @@ internal class EyePortal : ModProjectile, ISaveProjectile
 	{
 		projectile.ai[0] = 49;
 		projectile.ai[1] = tag.GetFloat("uses");
+	}
+
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
+	{
+		if (Main.mouseRight && Main.mouseRightRelease)
+		{
+			SubworldSystem.Enter<EyeDomain>();
+
+			self.ai[1]++;
+			self.netUpdate = true;
+
+			if (self.ai[1] > self.ai[2])
+			{
+				self.Kill();
+			}
+
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
+		return false;
 	}
 }

--- a/Content/Projectiles/Utility/EyePortal.cs
+++ b/Content/Projectiles/Utility/EyePortal.cs
@@ -31,6 +31,8 @@ internal class EyePortal : ModProjectile, ISaveProjectile
 				{
 					proj.Kill();
 				}
+
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -38,6 +40,7 @@ internal class EyePortal : ModProjectile, ISaveProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/MLPortal.cs
+++ b/Content/Projectiles/Utility/MLPortal.cs
@@ -8,37 +8,9 @@ using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class MLPortal : ModProjectile, ISaveProjectile
+internal class MLPortal : ModProjectile, ISaveProjectile, IRightClickableProjectile
 {
 	private ref float MaxUses => ref Projectile.ai[2];
-
-	public override void SetStaticDefaults()
-	{
-		ClickableProjectilePlayer.RegisterProjectile(Type, static (proj, _) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease)
-			{
-				SubworldSystem.Enter<MoonLordDomain>();
-
-				proj.ai[1]++;
-				proj.netUpdate = true;
-
-				if (proj.ai[1] > proj.ai[2])
-				{
-					proj.Kill();
-				}
-
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-			return false;
-		});
-	}
 
 	public override void SetDefaults()
 	{
@@ -88,6 +60,31 @@ internal class MLPortal : ModProjectile, ISaveProjectile
 			Main.spriteBatch.Draw(tex, position, null, color, rotation, tex.Size() / 2f, 2f - i * 0.4f, SpriteEffects.None, 0);
 		}
 
+		return false;
+	}
+
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
+	{
+		if (Main.mouseRight && Main.mouseRightRelease)
+		{
+			SubworldSystem.Enter<MoonLordDomain>();
+
+			self.ai[1]++;
+			self.netUpdate = true;
+
+			if (self.ai[1] > self.ai[2])
+			{
+				self.Kill();
+			}
+
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
 		return false;
 	}
 }

--- a/Content/Projectiles/Utility/MLPortal.cs
+++ b/Content/Projectiles/Utility/MLPortal.cs
@@ -27,6 +27,8 @@ internal class MLPortal : ModProjectile, ISaveProjectile
 				{
 					proj.Kill();
 				}
+
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -34,6 +36,7 @@ internal class MLPortal : ModProjectile, ISaveProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/QueenBeePortal.cs
+++ b/Content/Projectiles/Utility/QueenBeePortal.cs
@@ -33,6 +33,8 @@ internal class QueenBeePortal : ModProjectile
 				{
 					proj.Kill();
 				}
+
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -40,6 +42,8 @@ internal class QueenBeePortal : ModProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/QueenBeePortal.cs
+++ b/Content/Projectiles/Utility/QueenBeePortal.cs
@@ -6,45 +6,17 @@ using SubworldLibrary;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
-using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class QueenBeePortal : ModProjectile
+internal class QueenBeePortal : ModProjectile, IRightClickableProjectile
 {
 	private ref float Timer => ref Projectile.ai[0];
-	private ref float Uses => ref Projectile.ai[1];
 	private ref float MaxUses => ref Projectile.ai[2];
 
 	public override void SetStaticDefaults()
 	{
 		Main.projFrames[Type] = 3;
-
-		ClickableProjectilePlayer.RegisterProjectile(Type, static (proj, _) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease)
-			{
-				SubworldSystem.Enter<QueenBeeDomain>();
-
-				proj.ai[1]++;
-				proj.netUpdate = true;
-
-				if (proj.ai[1] > proj.ai[2])
-				{
-					proj.Kill();
-				}
-
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-
-			return false;
-		});
 	}
 
 	public override void SetDefaults()
@@ -110,21 +82,36 @@ internal class QueenBeePortal : ModProjectile
 			float rotation = Projectile.rotation * (i % 2 == 0 ? -1 : 1);
 			Vector2 position = Projectile.Center - Main.screenPosition;
 			Color color = lightColor * ((3 - i) * 0.2f) * Projectile.Opacity;
-			Rectangle frame = new Rectangle(0, 60 * Projectile.frame, 60, 58);
+			Rectangle frame = new(0, 60 * Projectile.frame, 60, 58);
 			Main.spriteBatch.Draw(tex, position, frame, color, rotation, frame.Size() / 2f, 1f - i * 0.2f, SpriteEffects.None, 0);
 		}
 
 		return false;
 	}
 
-	public void SaveData(TagCompound tag)
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
 	{
-		tag.Add("uses", Uses);
-	}
+		if (Main.mouseRight && Main.mouseRightRelease)
+		{
+			SubworldSystem.Enter<QueenBeeDomain>();
 
-	public void LoadData(TagCompound tag, Projectile projectile)
-	{
-		projectile.ai[0] = 49;
-		projectile.ai[1] = tag.GetFloat("uses");
+			self.ai[1]++;
+			self.netUpdate = true;
+
+			if (self.ai[1] > self.ai[2])
+			{
+				self.Kill();
+			}
+
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
+
+		return false;
 	}
 }

--- a/Content/Projectiles/Utility/SkeletronPortal.cs
+++ b/Content/Projectiles/Utility/SkeletronPortal.cs
@@ -17,6 +17,7 @@ internal class SkeletronPortal : ModProjectile
 			if (Main.mouseRight && Main.mouseRightRelease)
 			{
 				SubworldSystem.Enter<SkeletronDomain>();
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -24,6 +25,7 @@ internal class SkeletronPortal : ModProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/SkeletronPortal.cs
+++ b/Content/Projectiles/Utility/SkeletronPortal.cs
@@ -8,27 +8,8 @@ using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class SkeletronPortal : ModProjectile
+internal class SkeletronPortal : ModProjectile, IRightClickableProjectile
 {
-	public override void SetStaticDefaults()
-	{
-		ClickableProjectilePlayer.RegisterProjectile(Type, (_, _) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease)
-			{
-				SubworldSystem.Enter<SkeletronDomain>();
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-			return false;
-		});
-	}
-
 	public override void SetDefaults()
 	{
 		Projectile.friendly = false;
@@ -72,6 +53,22 @@ internal class SkeletronPortal : ModProjectile
 			Main.spriteBatch.Draw(tex, position, null, color, rotation, tex.Size() / 2f, 1f - i * 0.2f, SpriteEffects.None, 0);
 		}
 
+		return false;
+	}
+
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
+	{
+		if (Main.mouseRight && Main.mouseRightRelease)
+		{
+			SubworldSystem.Enter<SkeletronDomain>();
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
 		return false;
 	}
 }

--- a/Content/Projectiles/Utility/Teleportal.cs
+++ b/Content/Projectiles/Utility/Teleportal.cs
@@ -17,6 +17,7 @@ internal class Teleportal : ModProjectile
 			if (Main.mouseRight && Main.mouseRightRelease)
 			{
 				player.Teleport((proj.ModProjectile as Teleportal).TeleportLocation);
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -24,6 +25,8 @@ internal class Teleportal : ModProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/Teleportal.cs
+++ b/Content/Projectiles/Utility/Teleportal.cs
@@ -6,29 +6,9 @@ using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class Teleportal : ModProjectile
+internal class Teleportal : ModProjectile, IRightClickableProjectile
 {
 	public Vector2 TeleportLocation => new(Projectile.ai[0], Projectile.ai[1]);
-
-	public override void SetStaticDefaults()
-	{
-		ClickableProjectilePlayer.RegisterProjectile(Type, (proj, player) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease)
-			{
-				player.Teleport((proj.ModProjectile as Teleportal).TeleportLocation);
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-
-			return false;
-		});
-	}
 
 	public override void SetDefaults()
 	{
@@ -71,6 +51,23 @@ internal class Teleportal : ModProjectile
 			Color color = lightColor * ((3 - i) * 0.2f) * Projectile.Opacity;
 			Main.spriteBatch.Draw(tex, position, null, color, rotation, tex.Size() / 2f, 1f - i * 0.2f, SpriteEffects.None, 0);
 		}
+
+		return false;
+	}
+
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
+	{
+		if (Main.mouseRight && Main.mouseRightRelease)
+		{
+			player.Teleport((self.ModProjectile as Teleportal).TeleportLocation);
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
 
 		return false;
 	}

--- a/Content/Projectiles/Utility/VoidPearlThrown.cs
+++ b/Content/Projectiles/Utility/VoidPearlThrown.cs
@@ -53,9 +53,12 @@ internal class VoidPearlThrown : ModProjectile
 	{
 		if (AnyAshNearby())
 		{
-			IEntitySource src = Projectile.GetSource_Death();
-			int type = ModContent.ProjectileType<WoFRitualProj>();
-			Projectile.NewProjectile(src, Projectile.Center, new Vector2(0, 0), type, 0, 0, Main.myPlayer);
+			if (Main.myPlayer == Projectile.owner)
+			{
+				IEntitySource src = Projectile.GetSource_Death();
+				int type = ModContent.ProjectileType<WoFRitualProj>();
+				Projectile.NewProjectile(src, Projectile.Center, new Vector2(0, 0), type, 0, 0, Main.myPlayer);
+			}
 
 			foreach (Particle particle in localDusts)
 			{

--- a/Content/Projectiles/Utility/WoFPortal.cs
+++ b/Content/Projectiles/Utility/WoFPortal.cs
@@ -10,38 +10,10 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Projectiles.Utility;
 
-internal class WoFPortal : ModProjectile, ISaveProjectile
+internal class WoFPortal : ModProjectile, ISaveProjectile, IRightClickableProjectile
 {
 	private ref float Uses => ref Projectile.ai[1];
 	private ref float MaxUses => ref Projectile.ai[2];
-
-	public override void SetStaticDefaults()
-	{
-		ClickableProjectilePlayer.RegisterProjectile(Type, static (proj, _) =>
-		{
-			if (Main.mouseRight && Main.mouseRightRelease && SubworldSystem.Current is null)
-			{
-				SubworldSystem.Enter<WallOfFleshDomain>();
-
-				proj.ai[1]++;
-				proj.netUpdate = true;
-
-				if (proj.ai[1] > proj.ai[2])
-				{
-					proj.Kill();
-				}
-
-				return true;
-			}
-
-			Tooltip.Create(new TooltipDescription
-			{
-				Identifier = "Portal",
-				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
-			});
-			return false;
-		});
-	}
 
 	public override void SetDefaults()
 	{
@@ -117,5 +89,30 @@ internal class WoFPortal : ModProjectile, ISaveProjectile
 	public void LoadData(TagCompound tag, Projectile projectile)
 	{
 		projectile.ai[1] = tag.GetFloat("uses");
+	}
+
+	bool IRightClickableProjectile.RightClick(Projectile self, Player player)
+	{
+		if (Main.mouseRight && Main.mouseRightRelease && SubworldSystem.Current is null)
+		{
+			SubworldSystem.Enter<WallOfFleshDomain>();
+
+			self.ai[1]++;
+			self.netUpdate = true;
+
+			if (self.ai[1] > self.ai[2])
+			{
+				self.Kill();
+			}
+
+			return true;
+		}
+
+		Tooltip.Create(new TooltipDescription
+		{
+			Identifier = "Portal",
+			SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
+		});
+		return false;
 	}
 }

--- a/Content/Projectiles/Utility/WoFPortal.cs
+++ b/Content/Projectiles/Utility/WoFPortal.cs
@@ -12,7 +12,6 @@ namespace PathOfTerraria.Content.Projectiles.Utility;
 
 internal class WoFPortal : ModProjectile, ISaveProjectile
 {
-	private ref float Timer => ref Projectile.ai[0];
 	private ref float Uses => ref Projectile.ai[1];
 	private ref float MaxUses => ref Projectile.ai[2];
 
@@ -20,7 +19,7 @@ internal class WoFPortal : ModProjectile, ISaveProjectile
 	{
 		ClickableProjectilePlayer.RegisterProjectile(Type, static (proj, _) =>
 		{
-			if (Main.mouseRight && Main.mouseRightRelease)
+			if (Main.mouseRight && Main.mouseRightRelease && SubworldSystem.Current is null)
 			{
 				SubworldSystem.Enter<WallOfFleshDomain>();
 
@@ -31,6 +30,8 @@ internal class WoFPortal : ModProjectile, ISaveProjectile
 				{
 					proj.Kill();
 				}
+
+				return true;
 			}
 
 			Tooltip.Create(new TooltipDescription
@@ -38,6 +39,7 @@ internal class WoFPortal : ModProjectile, ISaveProjectile
 				Identifier = "Portal",
 				SimpleTitle = Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.Enter"),
 			});
+			return false;
 		});
 	}
 

--- a/Content/Projectiles/Utility/WoFRitualProj.cs
+++ b/Content/Projectiles/Utility/WoFRitualProj.cs
@@ -74,10 +74,13 @@ internal class WoFRitualProj : ModProjectile
 
 			SoundEngine.PlaySound(SoundID.Item14 with { PitchRange = (-0.8f, 0.2f), Volume = 0.7f }, pos);
 
-			int type = ModContent.ProjectileType<ExplosionHitbox>();
-			IEntitySource source = Projectile.GetSource_FromThis();
+			if (Main.myPlayer == Projectile.owner)
+			{
+				int type = ModContent.ProjectileType<ExplosionHitbox>();
+				IEntitySource source = Projectile.GetSource_FromThis();
 
-			Projectile.NewProjectile(source, Projectile.Center, Vector2.Zero, type, 20, 6f, Projectile.owner, 20 * size, 20 * size);
+				Projectile.NewProjectile(source, Projectile.Center, Vector2.Zero, type, 20, 6f, Projectile.owner, 20 * size, 20 * size);
+			}
 
 			explosionCap -= 0.5f;
 			ExplosionTimer = 0;
@@ -101,16 +104,18 @@ internal class WoFRitualProj : ModProjectile
 			PunchCameraModifier modifier = new(Projectile.Center, rotation, 9, 10f, 100, 6000, "SkeletronRitual");
 			Main.instance.CameraModifiers.Add(modifier);
 
-			IEntitySource src = Projectile.GetSource_Death();
-			int type = ModContent.ProjectileType<WoFPortal>();
-			Projectile.NewProjectile(src, Projectile.Center, new Vector2(0, -1), type, 0, 0, Main.myPlayer);
-
 			SoundEngine.PlaySound(SoundID.Item14 with { Pitch = -0.2f, Volume = 1f }, Projectile.Center);
 			Digging.CircleOpening(Projectile.Center / 16f, 8);
 
-			type = ModContent.ProjectileType<ExplosionHitbox>();
+			if (Main.myPlayer == Projectile.owner)
+			{
+				IEntitySource src = Projectile.GetSource_Death();
+				int type = ModContent.ProjectileType<WoFPortal>();
+				Projectile.NewProjectile(src, Projectile.Center, new Vector2(0, -1), type, 0, 0, Main.myPlayer);
 
-			Projectile.NewProjectile(src, Projectile.Center, Vector2.Zero, type, 30, 6f, Projectile.owner, 18 * 8, 18 * 8);
+				type = ModContent.ProjectileType<ExplosionHitbox>();
+				Projectile.NewProjectile(src, Projectile.Center, Vector2.Zero, type, 30, 6f, Projectile.owner, 18 * 8, 18 * 8);
+			}
 		}
 	}
 	public override bool PreDraw(ref Color lightColor)

--- a/Content/Socketables/Socketable.cs
+++ b/Content/Socketables/Socketable.cs
@@ -4,7 +4,7 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Socketables;
 
-public abstract class Socketable : ModItem, GenerateName.IItem
+public abstract class Socketable : ModItem, GenerateNameAffixes.IItem
 {
 	public override string Texture => $"{PoTMod.ModName}/Assets/Items/Socketable/Placeholder";
 	
@@ -28,8 +28,6 @@ public abstract class Socketable : ModItem, GenerateName.IItem
 	/// <param name="player">the player wielding the weapon this is socketed into.</param>
 	/// <param name="item">the item this is socketed into.</param>
 	public virtual void UpdateEquip(Player player, Item item) { }
-
-	public virtual string GenerateName(string defaultName) { return "Unknown Socket"; }
 
 	public void Save(TagCompound tag)
 	{
@@ -61,4 +59,6 @@ public abstract class Socketable : ModItem, GenerateName.IItem
 		(item.ModItem as Socketable)?.Load(tag);
 		return item.ModItem as Socketable;
 	}
+
+	public abstract (sbyte, sbyte) GenerateAffixIds();
 }

--- a/Core/Items/GearGlobalItem.cs
+++ b/Core/Items/GearGlobalItem.cs
@@ -235,18 +235,13 @@ internal sealed partial class GearGlobalItem : GlobalItem, InsertAdditionalToolt
 		}
 	}
 
-	void GeneratePrefix.IGlobal.ModifyPrefix(Item item, ref string prefix)
+	void GeneratePrefix.IGlobal.ModifyPrefix(Item item, ref sbyte prefix)
 	{
-		prefix = Language.SelectRandom((key, _) => BasicAffixSearchFilter(item, key, true)).Value;
+		prefix = (sbyte)Main.rand.Next(5);
 	}
 
-	void GenerateSuffix.IGlobal.ModifySuffix(Item item, ref string suffix)
+	void GenerateSuffix.IGlobal.ModifySuffix(Item item, ref sbyte suffix)
 	{
-		suffix = Language.SelectRandom((key, _) => BasicAffixSearchFilter(item, key, false)).Value;
-	}
-
-	private static bool BasicAffixSearchFilter(Item item, string key, bool isPrefix)
-	{
-		return key.StartsWith("Mods.PathOfTerraria.Gear." + GearLocalizationCategory.Invoke(item) + (isPrefix ? ".Prefixes" : ".Suffixes"));
+		suffix = (sbyte)Main.rand.Next(5);
 	}
 }

--- a/Core/Items/GearGlobalItem.cs
+++ b/Core/Items/GearGlobalItem.cs
@@ -5,8 +5,6 @@ using PathOfTerraria.Content.Socketables;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.ID;
-using Terraria.Localization;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace PathOfTerraria.Core.Items;
 

--- a/Core/Items/GearGlobalItem.cs
+++ b/Core/Items/GearGlobalItem.cs
@@ -4,13 +4,78 @@ using PathOfTerraria.Content.Items.Gear;
 using PathOfTerraria.Content.Socketables;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Terraria.ID;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Core.Items;
 
 internal sealed partial class GearGlobalItem : GlobalItem, InsertAdditionalTooltipLines.IGlobal, ExtraRolls.IGlobal, SwapItemModifiers.IGlobal, GeneratePrefix.IGlobal, GenerateSuffix.IGlobal
 {
+	/// <summary>
+	/// All prefixes associated with a Gear category, defined by <see cref="GearLocalizationCategory"/>'s functionality.
+	/// </summary>
+	private static readonly Dictionary<string, List<sbyte>> GearPrefixIdsByCategory = [];
+
+	/// <summary>
+	/// All suffixes associated with a Gear category, defined by <see cref="GearLocalizationCategory"/>'s functionality.
+	/// </summary>
+	private static readonly Dictionary<string, List<sbyte>> GearSuffixIdsByCategory = [];
+
 	private static HashSet<int> _optInGearItems = [];
+
+	public override void SetStaticDefaults()
+	{
+		GearPrefixIdsByCategory.Clear();
+		GearSuffixIdsByCategory.Clear();
+
+		Dictionary<string, LocalizedText> texts = GetTexts(LanguageManager.Instance);
+
+		// Load and store all possible prefixes for every "gear category" in the mod.
+		// This is necessary since Language/LanguageManager don't expose a way to both
+		// get a LocalizedText in a "category" randomly, AND also get the key associated with it.
+		foreach (KeyValuePair<string, LocalizedText> pair in texts)
+		{
+			const string Prefix = "Mods.PathOfTerraria.Gear.";
+
+			if (!pair.Key.StartsWith(Prefix))
+			{
+				continue;
+			}
+
+			string[] split = pair.Key.Replace(Prefix, "").Split('.');
+
+			if (split.Length != 3)
+			{
+				continue;
+			}
+
+			string category = split[0];
+			
+			if (!sbyte.TryParse(split[2], out sbyte id))
+			{
+				continue;
+			}
+
+			if (split[1].Equals("Prefixes", StringComparison.OrdinalIgnoreCase))
+			{
+				if (!GearPrefixIdsByCategory.TryAdd(category, [id]))
+				{
+					GearPrefixIdsByCategory[category].Add(id);
+				}
+			}
+			else if (split[1].Equals("Suffixes", StringComparison.OrdinalIgnoreCase))
+			{
+				if (!GearSuffixIdsByCategory.TryAdd(category, [id]))
+				{
+					GearSuffixIdsByCategory[category].Add(id);
+				}
+			}
+		}
+
+		[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_localizedTexts")]
+		static extern ref Dictionary<string, LocalizedText> GetTexts(LanguageManager mananger);
+	}
 
 	public static void EquipItem(Item item, Player player)
 	{
@@ -236,13 +301,27 @@ internal sealed partial class GearGlobalItem : GlobalItem, InsertAdditionalToolt
 
 	void GeneratePrefix.IGlobal.ModifyPrefix(Item item, ref sbyte prefix)
 	{
+		if (GearLocalizationCategory.Invoke(item) is not { } category || category == string.Empty)
+		{
+			prefix = -1;
+			return;
+		}
+
 		PoTInstanceItemData data = item.GetInstanceData();
-		prefix = (sbyte)(data.ItemType == ItemType.None && data.Rarity is ItemRarity.Magic or ItemRarity.Rare ? -1 : Main.rand.Next(5));
+		bool noPrefix = data.ItemType == ItemType.None && data.Rarity is ItemRarity.Magic or ItemRarity.Rare || !GearPrefixIdsByCategory.ContainsKey(category);
+		prefix = (sbyte)(noPrefix ? -1 : Main.rand.Next(GearPrefixIdsByCategory[category]));
 	}
 
 	void GenerateSuffix.IGlobal.ModifySuffix(Item item, ref sbyte suffix)
 	{
+		if (GearLocalizationCategory.Invoke(item) is not { } category || category == string.Empty)
+		{
+			suffix = -1;
+			return;
+		}
+
 		PoTInstanceItemData data = item.GetInstanceData();
-		suffix = (sbyte)(data.ItemType == ItemType.None && data.Rarity is ItemRarity.Magic or ItemRarity.Rare ? -1 : Main.rand.Next(5));
+		bool noPrefix = data.ItemType == ItemType.None && data.Rarity is ItemRarity.Magic or ItemRarity.Rare || !GearSuffixIdsByCategory.ContainsKey(category);
+		suffix = (sbyte)(noPrefix ? -1 : Main.rand.Next(GearSuffixIdsByCategory[category]));
 	}
 }

--- a/Core/Items/GearGlobalItem.cs
+++ b/Core/Items/GearGlobalItem.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria.ID;
 using Terraria.Localization;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace PathOfTerraria.Core.Items;
 
@@ -237,11 +238,13 @@ internal sealed partial class GearGlobalItem : GlobalItem, InsertAdditionalToolt
 
 	void GeneratePrefix.IGlobal.ModifyPrefix(Item item, ref sbyte prefix)
 	{
-		prefix = (sbyte)Main.rand.Next(5);
+		PoTInstanceItemData data = item.GetInstanceData();
+		prefix = (sbyte)(data.ItemType == ItemType.None && data.Rarity is ItemRarity.Magic or ItemRarity.Rare ? -1 : Main.rand.Next(5));
 	}
 
 	void GenerateSuffix.IGlobal.ModifySuffix(Item item, ref sbyte suffix)
 	{
-		suffix = (sbyte)Main.rand.Next(5);
+		PoTInstanceItemData data = item.GetInstanceData();
+		suffix = (sbyte)(data.ItemType == ItemType.None && data.Rarity is ItemRarity.Magic or ItemRarity.Rare ? -1 : Main.rand.Next(5));
 	}
 }

--- a/Core/Items/ItemHooks.PoT.cs
+++ b/Core/Items/ItemHooks.PoT.cs
@@ -1,7 +1,9 @@
 ﻿using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.Systems.Affixes;
+using PathOfTerraria.Content.Tiles.BossDomain;
 using System.Collections.Generic;
+using Terraria.Localization;
 using Terraria.ModLoader.Core;
 using Terraria.UI;
 
@@ -209,27 +211,39 @@ public sealed class GenerateImplicits : ILoadable
 	}
 }
 
-public sealed class GenerateName : ILoadable
+public sealed class GenerateName
+{
+	public static string Invoke(Item item)
+	{
+		PoTInstanceItemData data = item.GetInstanceData();
+		PoTInstanceItemData.NameAffixes affixes = data.NameAffix;
+		string prefix = affixes.Prefix == -1 ? string.Empty : Language.GetTextValue("Mods.PathOfTerraria.Gear." + data.ItemType + ".Prefixes." + affixes.Prefix) + " ";
+		string suffix = affixes.Suffix == -1 ? string.Empty : " " + Language.GetTextValue("Mods.PathOfTerraria.Gear." + data.ItemType + ".Suffixes." + affixes.Suffix);
+		return prefix + item.Name + suffix;
+	}
+}
+
+public sealed class GenerateNameAffixes : ILoadable
 {
 	public interface IItem
 	{
-		string GenerateName(string defaultName);
+		(sbyte, sbyte) GenerateAffixIds();
 	}
 
 	public interface IGlobal
 	{
-		void ModifyName(Item item, ref string name);
+		void ModifyNameAffixes(Item item, ref sbyte prefix, ref sbyte suffix);
 	}
 
-	private static GlobalHookList<GlobalItem> _hook = ItemLoader.AddModHook(GlobalHookList<GlobalItem>.Create(x => ((IGlobal)x).ModifyName));
+	private static GlobalHookList<GlobalItem> _hook = ItemLoader.AddModHook(GlobalHookList<GlobalItem>.Create(x => ((IGlobal)x).ModifyNameAffixes));
 
-	public static string Invoke(Item item)
+	public static PoTInstanceItemData.NameAffixes Invoke(Item item)
 	{
-		string name = GetDefaultName(item);
+		(sbyte pre, sbyte suf) = GetDefaultNameAffixes(item);
 
 		if (item.ModItem is IItem i)
 		{
-			name = i.GenerateName(name);
+			(pre, suf) = i.GenerateAffixIds();
 		}
 
 		foreach (GlobalItem g in _hook.Enumerate(item))
@@ -239,21 +253,19 @@ public sealed class GenerateName : ILoadable
 				continue;
 			}
 
-			gl.ModifyName(item, ref name);
+			gl.ModifyNameAffixes(item, ref pre, ref suf);
 		}
 
-		return name;
+		return new(pre, suf);
 	}
 
-	public static string GetDefaultName(Item item)
+	public static (sbyte, sbyte) GetDefaultNameAffixes(Item item)
 	{
 		return item.GetInstanceData().Rarity switch
 		{
-			ItemRarity.Normal => item.Name,
-			ItemRarity.Magic => $"{GeneratePrefix.Invoke(item)} {item.Name}",
-			ItemRarity.Rare => $"{GeneratePrefix.Invoke(item)} {item.Name} {GenerateSuffix.Invoke(item)}",
-			ItemRarity.Unique => item.Name, // uniques might just want to override the GenerateName function
-			_ => "Unknown Item"
+			ItemRarity.Magic => (GeneratePrefix.Invoke(item), -1),
+			ItemRarity.Rare => (GeneratePrefix.Invoke(item), GenerateSuffix.Invoke(item)),
+			_ => (-1, -1),
 		};
 	}
 
@@ -269,19 +281,19 @@ public sealed class GeneratePrefix : ILoadable
 {
 	public interface IItem
 	{
-		string GeneratePrefix(string defaultPrefix);
+		sbyte GeneratePrefix(sbyte defaultId);
 	}
 
 	public interface IGlobal
 	{
-		void ModifyPrefix(Item item, ref string prefix);
+		void ModifyPrefix(Item item, ref sbyte prefix);
 	}
 
 	private static GlobalHookList<GlobalItem> _hook = ItemLoader.AddModHook(GlobalHookList<GlobalItem>.Create(x => ((IGlobal)x).ModifyPrefix));
 
-	public static string Invoke(Item item)
+	public static sbyte Invoke(Item item)
 	{
-		string prefix = GetDefaultPrefix();
+		sbyte prefix = GetDefaultPrefix();
 
 		if (item.ModItem is IItem i)
 		{
@@ -301,9 +313,9 @@ public sealed class GeneratePrefix : ILoadable
 		return prefix;
 	}
 
-	public static string GetDefaultPrefix()
+	public static sbyte GetDefaultPrefix()
 	{
-		return "";
+		return -1;
 	}
 
 	void ILoadable.Load(Mod mod) { }
@@ -318,19 +330,19 @@ public sealed class GenerateSuffix : ILoadable
 {
 	public interface IItem
 	{
-		string GenerateSuffix(string defaultSuffix);
+		sbyte GenerateSuffix(sbyte defaultId);
 	}
 
 	public interface IGlobal
 	{
-		void ModifySuffix(Item item, ref string suffix);
+		void ModifySuffix(Item item, ref sbyte suffix);
 	}
 
 	private static GlobalHookList<GlobalItem> _hook = ItemLoader.AddModHook(GlobalHookList<GlobalItem>.Create(x => ((IGlobal)x).ModifySuffix));
 
-	public static string Invoke(Item item)
+	public static sbyte Invoke(Item item)
 	{
-		string suffix = GetDefaultSuffix();
+		sbyte suffix = GetDefaultSuffix();
 
 		if (item.ModItem is IItem i)
 		{
@@ -350,9 +362,9 @@ public sealed class GenerateSuffix : ILoadable
 		return suffix;
 	}
 
-	public static string GetDefaultSuffix()
+	public static sbyte GetDefaultSuffix()
 	{
-		return "";
+		return -1;
 	}
 
 	void ILoadable.Load(Mod mod) { }

--- a/Core/Items/ItemHooks.PoT.cs
+++ b/Core/Items/ItemHooks.PoT.cs
@@ -211,7 +211,7 @@ public sealed class GenerateImplicits : ILoadable
 	}
 }
 
-public sealed class GenerateName
+public static class GenerateName
 {
 	public static string Invoke(Item item)
 	{

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -169,21 +169,21 @@ public sealed partial class ItemTooltips : GlobalItem
 		PoTInstanceItemData data = item.GetInstanceData();
 		PoTStaticItemData staticData = item.GetStaticData();
 
-		if (data.SpecialName == string.Empty) // Make sure SpecialName generated if it hasn't already for some reason
+		if (data.Rarity > ItemRarity.Normal && data.NameAffix.Empty) // Make sure SpecialName generated if it hasn't already for some reason
 		{
-			data.SpecialName = GenerateName.Invoke(item);
+			data.NameAffix = GenerateNameAffixes.Invoke(item);
 		}
 
 		if (nameLine is null)
 		{
-			nameLine = new TooltipLine(Mod, "Name", data.SpecialName)
+			nameLine = new TooltipLine(Mod, "Name", GenerateName.Invoke(item))
 			{
 				OverrideColor = GetRarityColor(data.Rarity)
 			};
 		}
 		else
 		{
-			nameLine.Text = data.SpecialName;
+			nameLine.Text = GenerateName.Invoke(item);
 			nameLine.OverrideColor ??= GetRarityColor(data.Rarity);
 		}
 

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -169,10 +169,10 @@ public sealed partial class ItemTooltips : GlobalItem
 		PoTInstanceItemData data = item.GetInstanceData();
 		PoTStaticItemData staticData = item.GetStaticData();
 
-		if (data.Rarity > ItemRarity.Normal && data.NameAffix.Empty) // Make sure SpecialName generated if it hasn't already for some reason
-		{
-			data.NameAffix = GenerateNameAffixes.Invoke(item);
-		}
+		//if (data.Rarity > ItemRarity.Normal && data.NameAffix.Empty) // Make sure SpecialName generated if it hasn't already for some reason
+		//{
+		//	data.NameAffix = GenerateNameAffixes.Invoke(item);
+		//}
 
 		if (nameLine is null)
 		{

--- a/Core/Items/PoTGlobalItem.Data.cs
+++ b/Core/Items/PoTGlobalItem.Data.cs
@@ -30,7 +30,6 @@ public sealed class PoTInstanceItemData : GlobalItem
 		clone.ItemType = ItemType;
 		clone.Rarity = Rarity;
 		clone.Influence = Influence;
-		clone.SpecialName = SpecialName;
 		clone.ImplicitCount = ImplicitCount;
 		clone.RealLevel = RealLevel;
 		clone.Affixes = Affixes;
@@ -57,12 +56,7 @@ public sealed class PoTInstanceItemData : GlobalItem
 	public Influence Influence { get; set; }
 
 	/// <summary>
-	///		The formatted, post-rolled name containing formatting for rarities.
-	/// </summary>
-	public string SpecialName { get; set; } = string.Empty;
-
-	/// <summary>
-	///		The localization ID for the prefix. Defaults to -1.
+	///		The localization IDs for the prefix/suffix. Defaults to -1, -1.
 	/// </summary>
 	public NameAffixes NameAffix { get; set; } = new();
 

--- a/Core/Items/PoTGlobalItem.Data.cs
+++ b/Core/Items/PoTGlobalItem.Data.cs
@@ -13,6 +13,14 @@ namespace PathOfTerraria.Core.Items;
 ///	</summary>
 public sealed class PoTInstanceItemData : GlobalItem
 {
+	public class NameAffixes(sbyte pre = -1, sbyte suf = -1)
+	{
+		public bool Empty => Prefix == -1 && Suffix == -1;
+
+		public sbyte Prefix { get; set; } = pre;
+		public sbyte Suffix { get; set; } = suf;
+	}
+
 	public override bool InstancePerEntity => true;
 	protected override bool CloneNewInstances => true;
 
@@ -28,6 +36,7 @@ public sealed class PoTInstanceItemData : GlobalItem
 		clone.Affixes = Affixes;
 		clone.Corrupted = Corrupted;
 		clone.Cloned = Cloned;
+		clone.NameAffix = NameAffix;
 		return clone;
 	}
 
@@ -51,6 +60,11 @@ public sealed class PoTInstanceItemData : GlobalItem
 	///		The formatted, post-rolled name containing formatting for rarities.
 	/// </summary>
 	public string SpecialName { get; set; } = string.Empty;
+
+	/// <summary>
+	///		The localization ID for the prefix. Defaults to -1.
+	/// </summary>
+	public NameAffixes NameAffix { get; set; } = new();
 
 	/// <summary>
 	///		The affixes of the item.

--- a/Core/Items/PoTGlobalItem.Data.cs
+++ b/Core/Items/PoTGlobalItem.Data.cs
@@ -59,6 +59,9 @@ public sealed class PoTInstanceItemData : GlobalItem
 	///		The localization IDs for the prefix/suffix. Defaults to -1, -1.
 	/// </summary>
 	public NameAffixes NameAffix { get; set; } = new();
+	
+	[Obsolete($"Use {nameof(NameAffix)}", error: true)]
+	public string SpecialName { get => string.Empty; set { } }
 
 	/// <summary>
 	///		The affixes of the item.

--- a/Core/Items/PoTGlobalItem.IO.cs
+++ b/Core/Items/PoTGlobalItem.IO.cs
@@ -20,7 +20,6 @@ partial class PoTGlobalItem : GlobalItem
 
 		tag["implicits"] = data.ImplicitCount;
 
-		tag["name"] = data.SpecialName;
 		tag["ItemLevel"] = data.RealLevel;
 		tag["corrupt"] = data.Corrupted;
 		tag["cloned"] = data.Cloned;
@@ -48,7 +47,6 @@ partial class PoTGlobalItem : GlobalItem
 
 		data.ImplicitCount = tag.GetInt("implicits");
 
-		data.SpecialName = tag.GetString("name");
 		data.RealLevel = tag.GetInt("ItemLevel");
 		data.Corrupted = tag.GetBool("corrupt");
 		data.Cloned = tag.GetBool("cloned");
@@ -76,15 +74,10 @@ partial class PoTGlobalItem : GlobalItem
 		writer.Write((byte)data.ItemType);
 		writer.Write((byte)data.Rarity);
 		writer.Write((byte)data.Influence);
-
 		writer.Write((byte)data.ImplicitCount);
+
 		writer.Write(data.Corrupted);
 		writer.Write(data.Cloned);
-
-		// Is this necessary?
-		// Probably should save the name as
-		// `GenericPrefix-ID (Item.Name can probably be omitted) GenericSuffix-ID`.
-		writer.Write(data.SpecialName);
 		writer.Write(data.NameAffix.Prefix);
 		writer.Write(data.NameAffix.Suffix);
 		writer.Write((byte)data.RealLevel);
@@ -103,11 +96,10 @@ partial class PoTGlobalItem : GlobalItem
 		data.ItemType = (ItemType)reader.ReadByte();
 		data.Rarity = (ItemRarity)reader.ReadByte();
 		data.Influence = (Influence)reader.ReadByte();
-
 		data.ImplicitCount = reader.ReadByte();
+
 		data.Corrupted = reader.ReadBoolean();
 		data.Cloned = reader.ReadBoolean();
-		data.SpecialName = reader.ReadString();
 		data.RealLevel = reader.ReadByte();
 		data.NameAffix = new(reader.ReadSByte(), reader.ReadSByte());
 

--- a/Core/Items/PoTGlobalItem.IO.cs
+++ b/Core/Items/PoTGlobalItem.IO.cs
@@ -24,6 +24,8 @@ partial class PoTGlobalItem : GlobalItem
 		tag["ItemLevel"] = data.RealLevel;
 		tag["corrupt"] = data.Corrupted;
 		tag["cloned"] = data.Cloned;
+		tag["namePrefix"] = (short)data.NameAffix.Prefix;
+		tag["nameSuffix"] = (short)data.NameAffix.Suffix;
 
 		List<TagCompound> affixTags = [];
 		foreach (ItemAffix affix in data.Affixes)
@@ -50,6 +52,8 @@ partial class PoTGlobalItem : GlobalItem
 		data.RealLevel = tag.GetInt("ItemLevel");
 		data.Corrupted = tag.GetBool("corrupt");
 		data.Cloned = tag.GetBool("cloned");
+
+		data.NameAffix = new((sbyte)tag.GetShort("namePrefix"), (sbyte)tag.GetShort("nameSuffix"));
 
 		data.Affixes.Clear();
 		IList<TagCompound> affixTags = tag.GetList<TagCompound>("affixes");
@@ -81,6 +85,8 @@ partial class PoTGlobalItem : GlobalItem
 		// Probably should save the name as
 		// `GenericPrefix-ID (Item.Name can probably be omitted) GenericSuffix-ID`.
 		writer.Write(data.SpecialName);
+		writer.Write(data.NameAffix.Prefix);
+		writer.Write(data.NameAffix.Suffix);
 		writer.Write((byte)data.RealLevel);
 
 		writer.Write((byte)data.Affixes.Count);
@@ -103,6 +109,7 @@ partial class PoTGlobalItem : GlobalItem
 		data.Cloned = reader.ReadBoolean();
 		data.SpecialName = reader.ReadString();
 		data.RealLevel = reader.ReadByte();
+		data.NameAffix = new(reader.ReadSByte(), reader.ReadSByte());
 
 		data.Affixes.Clear();
 		int affixes = reader.ReadByte();

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -70,7 +70,7 @@ public static class PoTItemHelper
 
 		RollAffixes(item);
 		PostRoll.Invoke(item);
-		data.SpecialName = GenerateName.Invoke(item);
+		data.NameAffix = GenerateNameAffixes.Invoke(item);
 	}
 
 	private static void RollAffixes(Item item)

--- a/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
@@ -369,9 +369,9 @@ Ring: {
 	}
 
 	Suffixes: {
-		// 0: Forgotten
+		// 0: of Embers
 		// 1: of Memories
-		// 2: Nevermore
+		// 2: of Nevermore
 		// 3: of Hatred
 		// 4: of Fury
 	}

--- a/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-// Broadsword.Name: Broadsword
+Broadsword: {
+	// Name: Broadsword
+	// AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		// 0: "{$Sword.Prefixes.0}"
+		// 1: "{$Sword.Prefixes.1}"
+		// 2: "{$Sword.Prefixes.2}"
+		// 3: "{$Sword.Prefixes.3}"
+		// 4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		// 0: "{$Sword.Suffixes.0}"
+		// 1: "{$Sword.Suffixes.1}"
+		// 2: "{$Sword.Suffixes.2}"
+		// 3: "{$Sword.Suffixes.3}"
+		// 4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	// Name: Sword

--- a/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ Shield: {
 // Melee.Name: Melee
 // Summon.Name: Summon
 // Accessory.Name: Accessory
+
+Ring: {
+	// Name: Ring
+
+	Prefixes: {
+		// 0: Cursed
+		// 1: Hollow
+		// 2: Shattered
+		// 3: Sturdy
+		// 4: Reinforced
+	}
+
+	Suffixes: {
+		// 0: Forgotten
+		// 1: of Memories
+		// 2: Nevermore
+		// 3: of Hatred
+		// 4: of Fury
+	}
+}

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-Broadsword.Name: Broadsword
+Broadsword: {
+	Name: Broadsword
+	AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		0: "{$Sword.Prefixes.0}"
+		1: "{$Sword.Prefixes.1}"
+		2: "{$Sword.Prefixes.2}"
+		3: "{$Sword.Prefixes.3}"
+		4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		0: "{$Sword.Suffixes.0}"
+		1: "{$Sword.Suffixes.1}"
+		2: "{$Sword.Suffixes.2}"
+		3: "{$Sword.Suffixes.3}"
+		4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	Name: Sword

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ Ranged.Name: Ranged
 Melee.Name: Melee
 Summon.Name: Summon
 Accessory.Name: Accessory
+
+Ring: {
+	Name: Ring
+
+	Prefixes: {
+		0: Cursed
+		1: Hollow
+		2: Shattered
+		3: Sturdy
+		4: Reinforced
+	}
+
+	Suffixes: {
+		0: of Embers
+		1: of Memories
+		2: of Nevermore
+		3: of Hatred
+		4: of Fury
+	}
+}

--- a/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ BossMap.Name: Mapa de Jefe
 // Melee.Name: Melee
 // Summon.Name: Summon
 // Accessory.Name: Accessory
+
+Ring: {
+	// Name: Ring
+
+	Prefixes: {
+		// 0: Cursed
+		// 1: Hollow
+		// 2: Shattered
+		// 3: Sturdy
+		// 4: Reinforced
+	}
+
+	Suffixes: {
+		// 0: Forgotten
+		// 1: of Memories
+		// 2: Nevermore
+		// 3: of Hatred
+		// 4: of Fury
+	}
+}

--- a/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
@@ -369,9 +369,9 @@ Ring: {
 	}
 
 	Suffixes: {
-		// 0: Forgotten
+		// 0: of Embers
 		// 1: of Memories
-		// 2: Nevermore
+		// 2: of Nevermore
 		// 3: of Hatred
 		// 4: of Fury
 	}

--- a/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-// Broadsword.Name: Broadsword
+Broadsword: {
+	// Name: Broadsword
+	// AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		// 0: "{$Sword.Prefixes.0}"
+		// 1: "{$Sword.Prefixes.1}"
+		// 2: "{$Sword.Prefixes.2}"
+		// 3: "{$Sword.Prefixes.3}"
+		// 4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		// 0: "{$Sword.Suffixes.0}"
+		// 1: "{$Sword.Suffixes.1}"
+		// 2: "{$Sword.Suffixes.2}"
+		// 3: "{$Sword.Suffixes.3}"
+		// 4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	// Name: Sword

--- a/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ Ranged.Name: À distance
 Melee.Name: Mélée
 Summon.Name: Invocation
 Accessory.Name: Accessoire
+
+Ring: {
+	// Name: Ring
+
+	Prefixes: {
+		// 0: Cursed
+		// 1: Hollow
+		// 2: Shattered
+		// 3: Sturdy
+		// 4: Reinforced
+	}
+
+	Suffixes: {
+		// 0: Forgotten
+		// 1: of Memories
+		// 2: Nevermore
+		// 3: of Hatred
+		// 4: of Fury
+	}
+}

--- a/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-// Broadsword.Name: Broadsword
+Broadsword: {
+	// Name: Broadsword
+	// AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		// 0: "{$Sword.Prefixes.0}"
+		// 1: "{$Sword.Prefixes.1}"
+		// 2: "{$Sword.Prefixes.2}"
+		// 3: "{$Sword.Prefixes.3}"
+		// 4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		// 0: "{$Sword.Suffixes.0}"
+		// 1: "{$Sword.Suffixes.1}"
+		// 2: "{$Sword.Suffixes.2}"
+		// 3: "{$Sword.Suffixes.3}"
+		// 4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	Name: Épée

--- a/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
@@ -369,9 +369,9 @@ Ring: {
 	}
 
 	Suffixes: {
-		// 0: Forgotten
+		// 0: of Embers
 		// 1: of Memories
-		// 2: Nevermore
+		// 2: of Nevermore
 		// 3: of Hatred
 		// 4: of Fury
 	}

--- a/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-// Broadsword.Name: Broadsword
+Broadsword: {
+	// Name: Broadsword
+	// AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		// 0: "{$Sword.Prefixes.0}"
+		// 1: "{$Sword.Prefixes.1}"
+		// 2: "{$Sword.Prefixes.2}"
+		// 3: "{$Sword.Prefixes.3}"
+		// 4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		// 0: "{$Sword.Suffixes.0}"
+		// 1: "{$Sword.Suffixes.1}"
+		// 2: "{$Sword.Suffixes.2}"
+		// 3: "{$Sword.Suffixes.3}"
+		// 4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	Name: Miecz

--- a/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ Ranged.Name: Dystansowe
 Melee.Name: Wręcz
 Summon.Name: Przywoływanie
 Accessory.Name: Akcesoria
+
+Ring: {
+	// Name: Ring
+
+	Prefixes: {
+		// 0: Cursed
+		// 1: Hollow
+		// 2: Shattered
+		// 3: Sturdy
+		// 4: Reinforced
+	}
+
+	Suffixes: {
+		// 0: Forgotten
+		// 1: of Memories
+		// 2: Nevermore
+		// 3: of Hatred
+		// 4: of Fury
+	}
+}

--- a/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
@@ -369,9 +369,9 @@ Ring: {
 	}
 
 	Suffixes: {
-		// 0: Forgotten
+		// 0: of Embers
 		// 1: of Memories
-		// 2: Nevermore
+		// 2: of Nevermore
 		// 3: of Hatred
 		// 4: of Fury
 	}

--- a/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
@@ -369,9 +369,9 @@ Ring: {
 	}
 
 	Suffixes: {
-		// 0: Forgotten
+		// 0: of Embers
 		// 1: of Memories
-		// 2: Nevermore
+		// 2: of Nevermore
 		// 3: of Hatred
 		// 4: of Fury
 	}

--- a/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-// Broadsword.Name: Broadsword
+Broadsword: {
+	// Name: Broadsword
+	// AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		// 0: "{$Sword.Prefixes.0}"
+		// 1: "{$Sword.Prefixes.1}"
+		// 2: "{$Sword.Prefixes.2}"
+		// 3: "{$Sword.Prefixes.3}"
+		// 4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		// 0: "{$Sword.Suffixes.0}"
+		// 1: "{$Sword.Suffixes.1}"
+		// 2: "{$Sword.Suffixes.2}"
+		// 3: "{$Sword.Suffixes.3}"
+		// 4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	// Name: Sword

--- a/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ Shield: {
 // Melee.Name: Melee
 // Summon.Name: Summon
 // Accessory.Name: Accessory
+
+Ring: {
+	// Name: Ring
+
+	Prefixes: {
+		// 0: Cursed
+		// 1: Hollow
+		// 2: Shattered
+		// 3: Sturdy
+		// 4: Reinforced
+	}
+
+	Suffixes: {
+		// 0: Forgotten
+		// 1: of Memories
+		// 2: Nevermore
+		// 3: of Hatred
+		// 4: of Fury
+	}
+}

--- a/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
@@ -173,7 +173,26 @@ Staff: {
 	}
 }
 
-// Broadsword.Name: Broadsword
+Broadsword: {
+	// Name: Broadsword
+	// AltUse: Right-click to summon a spirit from your blade that lunges forward, healing you for 15 health on hitting an enemy.
+
+	Prefixes: {
+		// 0: "{$Sword.Prefixes.0}"
+		// 1: "{$Sword.Prefixes.1}"
+		// 2: "{$Sword.Prefixes.2}"
+		// 3: "{$Sword.Prefixes.3}"
+		// 4: "{$Sword.Prefixes.4}"
+	}
+
+	Suffixes: {
+		// 0: "{$Sword.Suffixes.0}"
+		// 1: "{$Sword.Suffixes.1}"
+		// 2: "{$Sword.Suffixes.2}"
+		// 3: "{$Sword.Suffixes.3}"
+		// 4: "{$Sword.Suffixes.4}"
+	}
+}
 
 Sword: {
 	Name: Меч

--- a/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
@@ -369,9 +369,9 @@ Ring: {
 	}
 
 	Suffixes: {
-		// 0: Forgotten
+		// 0: of Embers
 		// 1: of Memories
-		// 2: Nevermore
+		// 2: of Nevermore
 		// 3: of Hatred
 		// 4: of Fury
 	}

--- a/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
@@ -356,3 +356,23 @@ Ranged.Name: Дистанционный
 Melee.Name: Рукопашный
 Summon.Name: Призвать
 Accessory.Name: Аксессуар
+
+Ring: {
+	// Name: Ring
+
+	Prefixes: {
+		// 0: Cursed
+		// 1: Hollow
+		// 2: Shattered
+		// 3: Sturdy
+		// 4: Reinforced
+	}
+
+	Suffixes: {
+		// 0: Forgotten
+		// 1: of Memories
+		// 2: Nevermore
+		// 3: of Hatred
+		// 4: of Fury
+	}
+}


### PR DESCRIPTION
## Note: This PR depends on as-of-yet unfinished PoT API changes, and a PR for PoTO: https://github.com/Path-of-Terraria/PathOfTerrariaOnline/pull/44

### Description of Work
- Clickable projectiles can only be clicked once in a frame, in case they overlap for some reason (which causes issues)
- Fixed Empress domain being wide enough to slip under
- Fixed issue where dying enough to fail a multiplayer mapping domain would return you to the overworld but not sync spawn properly, causing major issues 
- Added safety measure for quests being loaded with an out of bounds current step, bricking players
- Simplified logic for Queen Bee larva removal generation step, which should make it much less likely for them to somehow still appear in-world
- Fixed niche multiplayer issue where NPCs that can't be frozen ever would check for frozen, causing a crash
- Fixed issue where Void Pearl would spawn more than one portal projectile
- Fixed issues where Void Pearl dramatics would also spawn more than one explosion projectile per player
- Added Ring prefixes/suffixes & localized name
- Switched items to store a prefix and suffix ID instead of the special name directly, allowing languages to be changed dynamically and item names to change alongside them
- Internal: Fixed the Quest debug hotkey loading/trying to be used on servers

### Comments

## This breaks the online mod.
The online mod depends on the SpecialName property stored by instance data, which this removes in favor of the more easily [re]-localizable affix ID pair.
I can update the online mod tomorrow to account for this, but note that if you're using the online mod until then, it will be broken.