### PR TITLE
Boss fixes

### DIFF
--- a/Common/Subworlds/BossDomains/Hardmode/LunaticDomain/LunaticStartEventNPC.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/LunaticDomain/LunaticStartEventNPC.cs
@@ -13,6 +13,12 @@ internal class LunaticStartEventNPC : GlobalNPC
 	public override void Load()
 	{
 		On_WorldGen.StartImpendingDoom += NoSubworldDoom;
+		On_WorldGen.UpdateLunarApocalypse += Help;
+	}
+
+	private void Help(On_WorldGen.orig_UpdateLunarApocalypse orig)
+	{
+		orig();
 	}
 
 	private void NoSubworldDoom(On_WorldGen.orig_StartImpendingDoom orig, int countdownTime)

--- a/Common/Subworlds/BossDomains/Hardmode/LunaticDomain/LunaticStartEventNPC.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/LunaticDomain/LunaticStartEventNPC.cs
@@ -13,12 +13,6 @@ internal class LunaticStartEventNPC : GlobalNPC
 	public override void Load()
 	{
 		On_WorldGen.StartImpendingDoom += NoSubworldDoom;
-		On_WorldGen.UpdateLunarApocalypse += Help;
-	}
-
-	private void Help(On_WorldGen.orig_UpdateLunarApocalypse orig)
-	{
-		orig();
 	}
 
 	private void NoSubworldDoom(On_WorldGen.orig_StartImpendingDoom orig, int countdownTime)

--- a/Common/Systems/BossTrackingSystems/BossTracker.cs
+++ b/Common/Systems/BossTrackingSystems/BossTracker.cs
@@ -210,8 +210,8 @@ internal sealed class BossTracker : ModSystem
 
 			// These calls are counted as "fromSync" since they don't need to sync - incoming players will have the result synced for them, and
 			// at the time this is loaded players can't be joined to the server already
-			if (oldMask[0]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds, null, true); }
-			if (oldMask[1]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds, null, true); }
+			if (oldMask[0]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds, fromSync: true); }
+			if (oldMask[1]) { EventTracker.CompleteEvent(EventFlags.DefeatedBrainOfCthulhu, fromSync: true); }
 		}
 	}
 

--- a/Common/Systems/BossTrackingSystems/BossTracker.cs
+++ b/Common/Systems/BossTrackingSystems/BossTracker.cs
@@ -98,8 +98,9 @@ internal sealed class BossTracker : ModSystem
 	private static void HijackDeathEffects(On_NPC.orig_DoDeathEvents orig, NPC self, Player closestPlayer)
 	{
 		bool isBoss = ContentSamples.NpcsByNetId[self.netID].boss || NPCID.Sets.ShouldBeCountedAsBoss[self.type];
+		bool isPillar = self.type is NPCID.LunarTowerNebula or NPCID.LunarTowerSolar or NPCID.LunarTowerStardust or NPCID.LunarTowerVortex;
 
-		if (SubworldSystem.Current is BossDomainSubworld && isBoss)
+		if (SubworldSystem.Current is BossDomainSubworld && isBoss && !isPillar)
 		{
 			// Spawns the Wall of Flesh's box around itself, which is overriden by this method
 			OnDeathNPC.OnDeathEffects(self);
@@ -149,11 +150,7 @@ internal sealed class BossTracker : ModSystem
 			return false;
 		}
 
-		if (type is NPCID.LunarTowerNebula or NPCID.LunarTowerSolar or NPCID.LunarTowerStardust or NPCID.LunarTowerVortex) // Towers don't count
-		{
-			return false;
-		}
-		else if (type == NPCID.Spazmatism) // Spazmatism/Retinazer only count if the other is defeated
+		if (type == NPCID.Spazmatism) // Spazmatism/Retinazer only count if the other is defeated
 		{
 			return !NPC.AnyNPCs(NPCID.Retinazer);
 		}
@@ -210,8 +207,11 @@ internal sealed class BossTracker : ModSystem
 		if (tag.ContainsKey("DownedFlags"))
 		{
 			BitsByte oldMask = tag.GetByte("DownedFlags");
-			if (oldMask[0]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds); }
-			if (oldMask[1]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds); }
+
+			// These calls are counted as "fromSync" since they don't need to sync - incoming players will have the result synced for them, and
+			// at the time this is loaded players can't be joined to the server already
+			if (oldMask[0]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds, null, true); }
+			if (oldMask[1]) { EventTracker.CompleteEvent(EventFlags.DefeatedEaterOfWorlds, null, true); }
 		}
 	}
 

--- a/Common/Systems/BossTrackingSystems/EventTracker.cs
+++ b/Common/Systems/BossTrackingSystems/EventTracker.cs
@@ -253,7 +253,7 @@ internal sealed class EventTracker : ModSystem
 			cachedEventCompletions.Add((singleEvent, gameEventId));
 		}
 
-		if (Main.netMode == NetmodeID.Server && !fromSync)
+		if (Main.netMode == NetmodeID.Server && !fromSync && SubworldSystem.Current is not null)
 		{
 			ModPacket packet = Networking.GetPacket(Networking.Message.SyncEventCompletion, capacity: 12);
 			packet.Write((ulong)singleEvent);
@@ -331,6 +331,11 @@ internal sealed class EventTracker : ModSystem
 	private static void OnSetEventFlagCleared(On_NPC.orig_SetEventFlagCleared orig, ref bool eventFlag, int gameEventId)
 	{
 		orig(ref eventFlag, gameEventId);
+
+		if (SubworldSystem.Current is null)
+		{
+			return;
+		}
 
 		foreach (EventFlags flag in EventFlagsValues)
 		{

--- a/Common/Systems/VanillaModifications/AntiDespawnSystem/ForceNoDespawning.cs
+++ b/Common/Systems/VanillaModifications/AntiDespawnSystem/ForceNoDespawning.cs
@@ -40,7 +40,8 @@ internal class ForceNoDespawning : GlobalNPC
 		// Aggressively stop despawning by forcing bosses that have health and were active to continue to be active, if we're in a boss domain and any player is alive
 		// Note - excludes EoW's Head and Tail, which caused a crazy bug that spammed exp and item drops infinitely
 		if ((self.boss || NPCID.Sets.ShouldBeCountedAsBoss[self.type]) && SubworldSystem.Current is BossDomainSubworld && !self.active && life > 0 && AnyPlayerIsAlive
-			&& !(self.type is NPCID.EaterofWorldsHead or NPCID.EaterofWorldsTail or NPCID.MoonLordCore or NPCID.MoonLordFreeEye or NPCID.MoonLordHead or NPCID.MoonLordHand))
+			&& !(self.type is NPCID.EaterofWorldsHead or NPCID.EaterofWorldsTail or NPCID.MoonLordCore or NPCID.MoonLordFreeEye or NPCID.MoonLordHead or NPCID.MoonLordHand 
+			or NPCID.LunarTowerVortex or NPCID.LunarTowerStardust or NPCID.LunarTowerSolar or NPCID.LunarTowerNebula))
 		{
 			self.active = true;
 			self.life = life;


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1444 

### Description of Work
- Fixes Pirates lasting forever due to a packet being sent from the main server to the main server - this may also fix other events or bosses
- Fixed Pillars having their on death effects being suppressed, stopping the Moon Lord portal from spawning in the Cultist domain

### Comments
EventTracker CompleteEvent may be using a redundant "is in subworld" check, preceded by OnSetEventFlagCleared's check. I can't tell if the CompleteEvent method would run outside of OnSetEventFlagCleared in a way that needs more checks.