### PR TITLE
remove useless method

### DIFF
--- a/Common/Systems/Affixes/MobAffix.cs
+++ b/Common/Systems/Affixes/MobAffix.cs
@@ -86,12 +86,4 @@ internal abstract class MobAffix : Affix
 		MaxValue = reader.ReadSingle();
 		MinValue = reader.ReadSingle();
 	}
-
-	/// <summary>
-	/// Generates an affix from a tag, used on load to re-populate affixes.
-	/// </summary>
-	public static MobAffix FromTag(TagCompound tag)
-	{
-		return FromTag<MobAffix>(tag);
-	}
 }


### PR DESCRIPTION
### Description of Work
- Removed unused method

### Comments
I originally had another change, which turned out to be useless. So it's just this.