### PR TITLE
a bunch of fixes

### DIFF
--- a/Common/Subworlds/RavencrestContent/TavernManager.cs
+++ b/Common/Subworlds/RavencrestContent/TavernManager.cs
@@ -95,7 +95,10 @@ internal class TavernManager : ModSystem
 				types.Enqueue(entry);
 				entries.elements.RemoveAll(x => x.Item1 == entry);
 			}
+		}
 
+		for (int i = 0; i < types.Count; ++i)
+		{
 			seatsToUse.Enqueue(Seats[i]);
 		}
 

--- a/Common/Systems/MapContent/QuestMarkerHook.cs
+++ b/Common/Systems/MapContent/QuestMarkerHook.cs
@@ -10,7 +10,7 @@ using Terraria.ID;
 
 namespace PathOfTerraria.Common.Systems.MapContent;
 
-internal class QuestMarkerHook : ILoadable
+internal class QuestMarkerHook : GlobalNPC
 {
 	public static Dictionary<int, IQuestMarkerNPC> VanillaQuestMarkerNPCs = new()
 	{
@@ -20,9 +20,9 @@ internal class QuestMarkerHook : ILoadable
 
 	private static Asset<Texture2D> _markers = null;
 
-	public void Load(Mod mod)
+	public override void Load()
 	{
-		_markers = mod.Assets.Request<Texture2D>("Assets/UI/QuestMarkers");
+		_markers = Mod.Assets.Request<Texture2D>("Assets/UI/QuestMarkers");
 
 		On_NPCHeadRenderer.DrawWithOutlines += Draw;
 		IL_Main.DrawMap += HideOldManText;
@@ -92,16 +92,29 @@ internal class QuestMarkerHook : ILoadable
 
 		if (entity is NPC npc && (npc.ModNPC is IQuestMarkerNPC questNPC || VanillaQuestMarkerNPCs.TryGetValue(npc.type, out questNPC)) && revealed)
 		{
-			QuestMarkerType markerType = DetermineMarker(questNPC);
-
-			if (markerType == QuestMarkerType.None)
-			{
-				return;
-			}
-
-			Rectangle source = new(0, (sbyte)markerType * 32, 32, 32);
-			Main.spriteBatch.Draw(_markers.Value, position - new Vector2(0, 36 * scale), source, color, 0f, source.Size() / 2f, scale, SpriteEffects.None, 0);
+			DrawMarkerIcon(position, color, scale, questNPC);
 		}
+	}
+
+	public override void PostDraw(NPC npc, SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
+	{
+		if (!npc.IsABestiaryIconDummy && npc.ModNPC is IQuestMarkerNPC questNPC || VanillaQuestMarkerNPCs.TryGetValue(npc.type, out questNPC))
+		{
+			DrawMarkerIcon(npc.Top - new Vector2(0, -12) - screenPos, Lighting.GetColor(npc.Top.ToTileCoordinates()), npc.scale, questNPC);
+		}
+	}
+
+	private static void DrawMarkerIcon(Vector2 position, Color color, float scale, IQuestMarkerNPC questNPC)
+	{
+		QuestMarkerType markerType = DetermineMarker(questNPC);
+
+		if (markerType == QuestMarkerType.None)
+		{
+			return;
+		}
+
+		Rectangle source = new(0, (sbyte)markerType * 32, 32, 32);
+		Main.spriteBatch.Draw(_markers.Value, position - new Vector2(0, 36 * scale), source, color, 0f, source.Size() / 2f, scale, SpriteEffects.None, 0);
 	}
 
 	public static QuestMarkerType DetermineMarker(IQuestMarkerNPC questNPC)
@@ -128,9 +141,5 @@ internal class QuestMarkerHook : ILoadable
 		}
 
 		return markerType;
-	}
-
-	public void Unload()
-	{
 	}
 }

--- a/Common/Systems/ModPlayers/SkillCombatPlayer.cs
+++ b/Common/Systems/ModPlayers/SkillCombatPlayer.cs
@@ -1,5 +1,7 @@
-﻿using PathOfTerraria.Common.Mechanics;
+﻿using Microsoft.Xna.Framework.Input;
+using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.UI.Guide;
+using PathOfTerraria.Common.UI.Hotbar;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.GameInput;
@@ -47,9 +49,62 @@ internal class SkillCombatPlayer : ModPlayer
 #endif
 	}
 
+	public override void SetControls()
+	{
+		if (!NewHotbar.LocalCombatMode)
+		{
+			return;
+		}
+
+		for (int i = 1; i < 11; ++i)
+		{
+			CheckHotbarOverlap("Hotbar" + i);
+		}
+	}
+
+	/// <summary>
+	/// "Unsets" a hotbar hotkey if it overlaps with a skill keybind, so you can use a skill and not switch items.
+	/// </summary>
+	/// <param name="hotbarKey"></param>
+	private static void CheckHotbarOverlap(string hotbarKey)
+	{
+		if (PlayerInput.Triggers.Current.KeyStatus[hotbarKey] && SkillMatchesVanillaKeyBind(hotbarKey))
+		{
+			PlayerInput.Triggers.Current.KeyStatus[hotbarKey] = false;
+		}
+	}
+
+	private static bool SkillMatchesVanillaKeyBind(string key)
+	{
+		if (PlayerInput.CurrentProfile.InputModes[InputMode.Keyboard].KeyStatus[key].Count == 0)
+		{
+			return false;
+		}
+
+		foreach (string hotkey in PlayerInput.CurrentProfile.InputModes[InputMode.Keyboard].KeyStatus[key])
+		{
+			if (Skill1Keybind.GetAssignedKeys().Contains(hotkey))
+			{
+				return true;
+			}
+
+			if (Skill2Keybind.GetAssignedKeys().Contains(hotkey))
+			{
+				return true;
+			}
+
+			if (Skill3Keybind.GetAssignedKeys().Contains(hotkey))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public override void ProcessTriggers(TriggersSet triggersSet)
 	{
-		if (Player.dead)
+		if (Player.dead || !NewHotbar.LocalCombatMode)
 		{
 			return;
 		}

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -52,6 +52,11 @@ public sealed class NewHotbar : SmartUiState
 
 	public readonly static Dictionary<string, Asset<Texture2D>> Textures = [];
 
+	/// <summary>
+	/// Whether the <see cref="Main.LocalPlayer"/> is in "combat mode" (the weapon is selected and skills are displaying).
+	/// </summary>
+	public static bool LocalCombatMode => InCombatMode(Main.LocalPlayer);
+
 	private readonly Selector specialSelector = new();
 	private readonly Selector buildingSelector = new();
 	private readonly DynamicSpriteFont _font = FontAssets.DeathText.Value;
@@ -59,6 +64,11 @@ public sealed class NewHotbar : SmartUiState
 	private int _animation;
 
 	public override bool Visible => !Main.playerInventory;
+
+	public static bool InCombatMode(Player player)
+	{
+		return player.selectedItem == 0;
+	}
 
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{
@@ -86,7 +96,7 @@ public sealed class NewHotbar : SmartUiState
 
 		float prog;
 
-		if (Main.LocalPlayer.selectedItem == 0)
+		if (LocalCombatMode)
 		{
 			if (_animation > 0)
 			{
@@ -557,16 +567,9 @@ public sealed class NewHotbar : SmartUiState
 
 public class HijackHotbarClick : ModSystem
 {
-	private static bool WasInInventory = false;
-
 	public override void Load()
 	{
 		On_Main.GUIHotbarDrawInner += StopClickOnHotbar;
-	}
-
-	public override void PreUpdateNPCs()
-	{
-		WasInInventory = Main.playerInventory; // Needs manual check for old value because HotbarHijack.cs overrides this value for the below method
 	}
 
 	private void StopClickOnHotbar(On_Main.orig_GUIHotbarDrawInner orig, Main self)
@@ -582,7 +585,7 @@ public class HijackHotbarClick : ModSystem
 			Main.LocalPlayer.hbLocked = hbLocked;
 		}
 
-		bool combatMode = Main.LocalPlayer.selectedItem == 0;
+		bool combatMode = NewHotbar.LocalCombatMode;
 
 		if (combatMode)
 		{

--- a/Content/NPCs/HellEvent/AshWraith.cs
+++ b/Content/NPCs/HellEvent/AshWraith.cs
@@ -5,6 +5,7 @@ using PathOfTerraria.Common.Systems.HellEvent;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
 using Terraria.ID;
+using Terraria.ModLoader.Utilities;
 
 namespace PathOfTerraria.Content.NPCs.HellEvent;
 
@@ -67,7 +68,7 @@ public sealed class AshWraith : ModNPC
 			return 0f;
 		}
 
-		return 0.6f;
+		return SpawnCondition.Underworld.Chance * 0.6f;
 	}
 
 	public override void AI()

--- a/Content/NPCs/Town/GarrickNPC.cs
+++ b/Content/NPCs/Town/GarrickNPC.cs
@@ -9,7 +9,6 @@ using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using PathOfTerraria.Common.Utilities.Extensions;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Quest;
-using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1356 
Resolves: #1503 
Resolves: #1497 

### Description of Work
- Fixes issue where multiple guaranteed NPCs in Ravencrest's tavern would not spawn properly
- Added in-world overhead quest markers for NPCs
- Skills used, if they overlap with a hotbar hotkey, will not switch to the associated hotbar key unless not in "combat mode" (not on hotbar slot 0)
- Fixed Ash Wraiths spawning everywhere during the hell earthquake event