### PR TITLE
Fixed crashes and visual issues in Wikithis

### DIFF
--- a/Common/ModCompatibility/Wikithis/StopWikithisFromDrawing.cs
+++ b/Common/ModCompatibility/Wikithis/StopWikithisFromDrawing.cs
@@ -1,0 +1,51 @@
+﻿using MonoMod.RuntimeDetour;
+
+namespace PathOfTerraria.Common.ModCompatibility.Wikithis;
+
+internal class StopWikithisFromDrawing : ModSystem
+{
+	private delegate bool PreDrawTooltipLineDetour(GlobalItem self, Item item, DrawableTooltipLine line, ref int yOffset);
+
+	/// <summary>
+	/// Stops Wikithis's global item from drawing when we don't want do. Automatically turned to on when the update loop is running.
+	/// </summary>
+	internal static bool StopDrawcode = false;
+
+	private static Hook WikithisItemPreDrawTooltipHook = null;
+
+	public override void Load()
+	{
+		if (!ModLoader.TryGetMod("Wikithis", out Mod wiki))
+		{
+			return;
+		}
+
+		Type itemType = wiki.GetType().Assembly.GetType("Wikithis.WikithisItem");
+		WikithisItemPreDrawTooltipHook = new Hook(itemType.GetMethod(nameof(GlobalItem.PreDrawTooltipLine)), DetourWikithisPreDrawTooltipLine);
+
+		On_Main.Update += JustStopDrawcode;
+	
+		if (wiki != null && !Main.dedServ)
+		{
+			// I'm pretty sure our custom wiki format doesn't work for Wikithis, but it's good to have I guess
+			wiki.Call("AddModURL", this, "https://wiki.pathofterraria.com/{}");
+		}
+	}
+
+	private void JustStopDrawcode(On_Main.orig_Update orig, Main self, GameTime gameTime)
+	{
+		StopDrawcode = true;
+		orig(self, gameTime);
+		StopDrawcode = false;
+	}
+
+	private static bool DetourWikithisPreDrawTooltipLine(PreDrawTooltipLineDetour orig, GlobalItem self, Item item, DrawableTooltipLine line, ref int yOffset)
+	{
+		if (StopDrawcode)
+		{
+			return true;
+		}
+
+		return orig(self, item, line, ref yOffset);
+	}
+}

--- a/Common/ModCompatibility/WikithisCompatibility.cs
+++ b/Common/ModCompatibility/WikithisCompatibility.cs
@@ -36,11 +36,18 @@ internal class WikithisCompatibility : ModSystem
 
 		On_Main.Update += JustStopDrawcode;
 	
-		if (wiki != null && !Main.dedServ)
+		// TODO: Our custom wiki is organized differently, in manner of /en/Gear/ItemName. This is not what Wikithis expects.
+		/*
+		if (!Main.dedServ)
 		{
-			// I'm pretty sure our custom wiki format doesn't work for Wikithis, but it's good to have I guess
-			wiki.Call("AddModURL", this, "https://wiki.pathofterraria.com/{}");
+			try
+			{
+				// I'm pretty sure our custom wiki format doesn't work for Wikithis, but it's good to have I guess
+				wiki.Call("AddModURL", PoTMod.Instance, "https://wiki.pathofterraria.com/{}");
+			}
+			catch { }
 		}
+		*/
 	}
 
 	private static void JustStopDrawcode(On_Main.orig_Update orig, Main self, GameTime gameTime)

--- a/Common/ModCompatibility/WikithisCompatibility.cs
+++ b/Common/ModCompatibility/WikithisCompatibility.cs
@@ -1,4 +1,5 @@
-﻿using MonoMod.RuntimeDetour;
+﻿using System.Reflection;
+using MonoMod.Cil;
 
 #nullable enable
 
@@ -13,8 +14,6 @@ internal class WikithisCompatibility : ModSystem
 	/// </summary>
 	internal static bool StopDrawcode = false;
 
-	private static Hook? WikithisItemPreDrawTooltipHook = null;
-
 	public override void Load()
 	{
 		if (!ModLoader.TryGetMod("Wikithis", out Mod wiki))
@@ -22,8 +21,18 @@ internal class WikithisCompatibility : ModSystem
 			return;
 		}
 
-		Type itemType = wiki.GetType().Assembly.GetType("Wikithis.WikithisItem");
-		WikithisItemPreDrawTooltipHook = new Hook(itemType.GetMethod(nameof(GlobalItem.PreDrawTooltipLine)), DetourWikithisPreDrawTooltipLine);
+		const string WikithisItemType = "Wikithis.WikithisItem";
+
+		if (wiki.Code.GetType(WikithisItemType) is Type itemType
+		&& itemType.GetMethod(nameof(GlobalItem.PreDrawTooltipLine)) is MethodInfo preDrawTooltip)
+		{
+			try { MonoModHooks.Modify(preDrawTooltip, WsPreDrawTooltipLineInjection); }
+			catch { } // TML will log this on its own.
+		}
+		else
+		{
+			Mod.Logger.Warn($"Could not inject into {WikithisItemType}.{nameof(GlobalItem.PreDrawTooltipLine)} method!");
+		}
 
 		On_Main.Update += JustStopDrawcode;
 	
@@ -34,20 +43,23 @@ internal class WikithisCompatibility : ModSystem
 		}
 	}
 
-	private void JustStopDrawcode(On_Main.orig_Update orig, Main self, GameTime gameTime)
+	private static void JustStopDrawcode(On_Main.orig_Update orig, Main self, GameTime gameTime)
 	{
 		StopDrawcode = true;
 		orig(self, gameTime);
 		StopDrawcode = false;
 	}
 
-	private static bool DetourWikithisPreDrawTooltipLine(PreDrawTooltipLineDetour orig, GlobalItem self, Item item, DrawableTooltipLine line, ref int yOffset)
+	private static void WsPreDrawTooltipLineInjection(ILContext ctx)
 	{
-		if (StopDrawcode)
-		{
-			return true;
-		}
+		var il = new ILCursor(ctx);
 
-		return orig(self, item, line, ref yOffset);
+		// Return true if StopDrawcode is true.
+		ILLabel skipReturn = il.DefineLabel();
+		il.EmitDelegate(() => StopDrawcode);
+		il.EmitBrfalse(skipReturn);
+		il.EmitLdcI4(1);
+		il.EmitRet();
+		il.MarkLabel(skipReturn);
 	}
 }

--- a/Common/ModCompatibility/WikithisCompatibility.cs
+++ b/Common/ModCompatibility/WikithisCompatibility.cs
@@ -1,8 +1,10 @@
 ﻿using MonoMod.RuntimeDetour;
 
-namespace PathOfTerraria.Common.ModCompatibility.Wikithis;
+#nullable enable
 
-internal class StopWikithisFromDrawing : ModSystem
+namespace PathOfTerraria.Common.ModCompatibility;
+
+internal class WikithisCompatibility : ModSystem
 {
 	private delegate bool PreDrawTooltipLineDetour(GlobalItem self, Item item, DrawableTooltipLine line, ref int yOffset);
 
@@ -11,7 +13,7 @@ internal class StopWikithisFromDrawing : ModSystem
 	/// </summary>
 	internal static bool StopDrawcode = false;
 
-	private static Hook WikithisItemPreDrawTooltipHook = null;
+	private static Hook? WikithisItemPreDrawTooltipHook = null;
 
 	public override void Load()
 	{

--- a/Common/ModCompatibility/WikithisCompatibility.cs
+++ b/Common/ModCompatibility/WikithisCompatibility.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using MonoMod.Cil;
+using PathOfTerraria.Utilities;
 
 #nullable enable
 
@@ -52,9 +53,8 @@ internal class WikithisCompatibility : ModSystem
 
 	private static void JustStopDrawcode(On_Main.orig_Update orig, Main self, GameTime gameTime)
 	{
-		StopDrawcode = true;
+		using var _ = ValueOverride.Create(ref StopDrawcode, true);
 		orig(self, gameTime);
-		StopDrawcode = false;
 	}
 
 	private static void WsPreDrawTooltipLineInjection(ILContext ctx)

--- a/Common/Systems/VanillaModifications/TooltipBackingFix.cs
+++ b/Common/Systems/VanillaModifications/TooltipBackingFix.cs
@@ -1,6 +1,7 @@
 ﻿using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using PathOfTerraria.Common.ModCompatibility;
+using PathOfTerraria.Utilities;
 using System.Collections.Generic;
 using Terraria.UI.Chat;
 
@@ -41,7 +42,7 @@ internal class TooltipBackingFix : ILoadable
 	{
 		float maxWidth = 0;
 
-		WikithisCompatibility.StopDrawcode = true;
+		using var _ = ValueOverride.Create(ref WikithisCompatibility.StopDrawcode, true);
 
 		foreach (DrawableTooltipLine tooltip in tooltips)
 		{
@@ -59,8 +60,6 @@ internal class TooltipBackingFix : ILoadable
 			maxWidth = MathF.Max(maxWidth, lineSize.X);
 			tooltip.BaseScale = oldScale;
 		}
-
-		WikithisCompatibility.StopDrawcode = false;
 
 		size.X = maxWidth; // Max width is accurately calculated by the above
 		size.Y -= tooltips.Count * 1.2f; // Max height isn't accurately calculated by the above for whatever reason, use bandaid

--- a/Common/Systems/VanillaModifications/TooltipBackingFix.cs
+++ b/Common/Systems/VanillaModifications/TooltipBackingFix.cs
@@ -1,5 +1,6 @@
 ﻿using Mono.Cecil.Cil;
 using MonoMod.Cil;
+using PathOfTerraria.Common.ModCompatibility;
 using System.Collections.Generic;
 using Terraria.UI.Chat;
 
@@ -40,6 +41,8 @@ internal class TooltipBackingFix : ILoadable
 	{
 		float maxWidth = 0;
 
+		WikithisCompatibility.StopDrawcode = true;
+
 		foreach (DrawableTooltipLine tooltip in tooltips)
 		{
 			int yOffset = 0; // Used for getting real height
@@ -56,6 +59,8 @@ internal class TooltipBackingFix : ILoadable
 			maxWidth = MathF.Max(maxWidth, lineSize.X);
 			tooltip.BaseScale = oldScale;
 		}
+
+		WikithisCompatibility.StopDrawcode = false;
 
 		size.X = maxWidth; // Max width is accurately calculated by the above
 		size.Y -= tooltips.Count * 1.2f; // Max height isn't accurately calculated by the above for whatever reason, use bandaid

--- a/Common/UI/Tooltip.cs
+++ b/Common/UI/Tooltip.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using PathOfTerraria.Common.ModCompatibility.Wikithis;
+using PathOfTerraria.Common.ModCompatibility;
 using PathOfTerraria.Core.Time;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
@@ -174,7 +174,7 @@ public class Tooltip : SmartUiState
 		Array.Fill(cache.LineMeasures, default, 0, lineCount);
 
 		// This stops PreDrawTooltipLine from returning false, and thus gives an accurate line count.
-		StopWikithisFromDrawing.StopDrawcode = true;
+		WikithisCompatibility.StopDrawcode = true;
 
 		for (int i = 0; i < lineCount; i++)
 		{
@@ -202,7 +202,7 @@ public class Tooltip : SmartUiState
 			cache.OuterSize.Y += cache.LineMeasures[i].Y + lineSpacing;
 		}
 
-		StopWikithisFromDrawing.StopDrawcode = false;
+		WikithisCompatibility.StopDrawcode = false;
 
 		// Add padding.
 		cache.OuterSize += args.Padding * 2f;

--- a/Common/UI/Tooltip.cs
+++ b/Common/UI/Tooltip.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using PathOfTerraria.Common.ModCompatibility.Wikithis;
 using PathOfTerraria.Core.Time;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
@@ -172,6 +173,9 @@ public class Tooltip : SmartUiState
 		cache.OuterSize = default;
 		Array.Fill(cache.LineMeasures, default, 0, lineCount);
 
+		// This stops PreDrawTooltipLine from returning false, and thus gives an accurate line count.
+		StopWikithisFromDrawing.StopDrawcode = true;
+
 		for (int i = 0; i < lineCount; i++)
 		{
 			DrawableTooltipLine line = cache.Lines[i].Base;
@@ -197,6 +201,9 @@ public class Tooltip : SmartUiState
 			cache.OuterSize.X = Math.Max(cache.OuterSize.X, cache.LineMeasures[i].X);
 			cache.OuterSize.Y += cache.LineMeasures[i].Y + lineSpacing;
 		}
+
+		StopWikithisFromDrawing.StopDrawcode = false;
+
 		// Add padding.
 		cache.OuterSize += args.Padding * 2f;
 

--- a/Common/UI/Tooltip.cs
+++ b/Common/UI/Tooltip.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using PathOfTerraria.Common.ModCompatibility;
 using PathOfTerraria.Core.Time;
 using PathOfTerraria.Core.UI.SmartUI;
+using PathOfTerraria.Utilities;
 using ReLogic.Content;
 using Terraria.UI;
 using Terraria.UI.Chat;
@@ -173,36 +174,37 @@ public class Tooltip : SmartUiState
 		cache.OuterSize = default;
 		Array.Fill(cache.LineMeasures, default, 0, lineCount);
 
-		// This stops PreDrawTooltipLine from returning false, and thus gives an accurate line count.
-		WikithisCompatibility.StopDrawcode = true;
-
-		for (int i = 0; i < lineCount; i++)
+		// Scope for usings.
 		{
-			DrawableTooltipLine line = cache.Lines[i].Base;
+			// This stops PreDrawTooltipLine from rendering and returning false, and thus gives an accurate line count.
+			using var _ = ValueOverride.Create(ref WikithisCompatibility.StopDrawcode, true);
 
-			// Make a cursed copy of the tooltip line for later.
-			cache.Lines[i].Copy = new DrawableTooltipLine(line, i, 0, 0, line.Color);
-
-			// Point of caution:
-			// To acquire information necessary for correct bounding box calculations, there is no choice but to call PreDrawTooltipLine twice.
-			// This is a TML design issue -- Mirsario.
-			int spacingOffset = 0;
-			if (args.AssociatedItem != null && !ItemLoader.PreDrawTooltipLine(args.AssociatedItem, line, ref spacingOffset))
+			for (int i = 0; i < lineCount; i++)
 			{
-				lineCount--;
-				continue;
+				DrawableTooltipLine line = cache.Lines[i].Base;
+
+				// Make a cursed copy of the tooltip line for later.
+				cache.Lines[i].Copy = new DrawableTooltipLine(line, i, 0, 0, line.Color);
+
+				// Point of caution:
+				// To acquire information necessary for correct bounding box calculations, there is no choice but to call PreDrawTooltipLine twice.
+				// This is a TML design issue -- Mirsario.
+				int spacingOffset = 0;
+				if (args.AssociatedItem != null && !ItemLoader.PreDrawTooltipLine(args.AssociatedItem, line, ref spacingOffset))
+				{
+					lineCount--;
+					continue;
+				}
+
+				Vector2 measure = ChatManager.GetStringSize(line.Font, line.Text, line.BaseScale, line.MaxWidth);
+				int newLineCount = line.Text.Count(c => c == '\n');
+				float lineSpacing = BaseLineSpacing + spacingOffset;
+
+				cache.LineMeasures[i] = measure;
+				cache.OuterSize.X = Math.Max(cache.OuterSize.X, cache.LineMeasures[i].X);
+				cache.OuterSize.Y += cache.LineMeasures[i].Y + lineSpacing;
 			}
-
-			Vector2 measure = ChatManager.GetStringSize(line.Font, line.Text, line.BaseScale, line.MaxWidth);
-			int newLineCount = line.Text.Count(c => c == '\n');
-			float lineSpacing = BaseLineSpacing + spacingOffset;
-
-			cache.LineMeasures[i] = measure;
-			cache.OuterSize.X = Math.Max(cache.OuterSize.X, cache.LineMeasures[i].X);
-			cache.OuterSize.Y += cache.LineMeasures[i].Y + lineSpacing;
 		}
-
-		WikithisCompatibility.StopDrawcode = false;
 
 		// Add padding.
 		cache.OuterSize += args.Padding * 2f;

--- a/Utilities/ValueOverride.cs
+++ b/Utilities/ValueOverride.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2020-2025 Mirsario & Contributors.
+// Released under the GNU General Public License 3.0.
+// See LICENSE.md for details.
+
+using System.Runtime.CompilerServices;
+
+namespace PathOfTerraria.Utilities;
+
+/// <summary> Temporarily overrides a given reference. Usage: <code>using var _ = ValueOverride.Create(ref value, newValue);</code> </summary>
+internal static class ValueOverride
+{
+	public static ValueOverride<T> Create<T>(ref T reference, T value)
+	{
+		return new(ref reference, value);
+	}
+}
+
+/// <inheritdoc cref="ValueOverride"/>
+internal ref struct ValueOverride<T>
+{
+	private T oldValue;
+	private ref T reference;
+
+	public ValueOverride(ref T reference, T value)
+	{
+		this.reference = ref reference;
+		oldValue = reference;
+		reference = value;
+	}
+
+	public void Dispose()
+	{
+		if (!Unsafe.IsNullRef(ref reference)) {
+			reference = oldValue;
+			oldValue = default!;
+			reference = ref Unsafe.NullRef<T>();
+		}
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1518 

### Description of Work
- Fixes the Wikithis mod freezing the game when hovering over items that have their tooltips set in the update loop.
- Fixes multiple visual issues with the Wikithis mod.
- Internal: Adds in functionality that would, hypothetically, make Wikithis functionality work with PoT, if the format is appropriate.
    - It is commented-out until we make our wiki use a compatible format.

### Comments
The Wikithis functionality probably doesn't and may never work because our wiki is neither fandom nor wiki.gg, and is formatted completely differently.