### PR TITLE
middle click skill hotbar for skill tree

### DIFF
--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -2,6 +2,7 @@ using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.UI.SkillSelect;
+using PathOfTerraria.Common.UI.SkillsTree;
 using PathOfTerraria.Core.Items;
 using PathOfTerraria.Core.UI;
 using PathOfTerraria.Core.UI.SmartUI;
@@ -379,6 +380,14 @@ public sealed class NewHotbar : SmartUiState
 			{
 				skillCombatPlayer.HotbarSkills[skillIndex] = null;
 			}
+
+			if (Main.mouseMiddle && Main.mouseMiddleRelease && !SmartUiLoader.GetUiState<TreeState>().Visible && skill.Tree is not null)
+			{
+				TreeState tree = SmartUiLoader.GetUiState<TreeState>();
+				tree.Toggle();
+				tree.TabPanel.SetActivePage("SkillTree");
+				tree.SetSkillTree(skill);
+			}
 		}
 	}
 
@@ -447,7 +456,9 @@ public sealed class NewHotbar : SmartUiState
 			tooltips.Add(new("NoTags", $"[c/888888:{Language.GetTextValue("Mods.PathOfTerraria.Skills.ShowTags")}]", 0.25f));
 		}
 
+		tooltips.Add(new("TreeLine", $"[c/888888:{Language.GetTextValue("Mods.PathOfTerraria.Skills." + (skill.Tree is null ? "NoTree" : "OpenTree"))}]", 0.2f));
 		tooltips.Add(new("Empty", "\n", 0.3f));
+
 		skill.ModifyTooltips(tooltips);
 		tooltips.Sort(static (x, y) => x.Slot.CompareTo(y.Slot));
 
@@ -459,7 +470,7 @@ public sealed class NewHotbar : SmartUiState
 			Vector2 scale = Vector2.One;
 			Color color = Color.White;
 
-			if (line.Name is "Tags" or "Keybind" or "NoKeybind" or "NoTags")
+			if (line.Name is "Tags" or "Keybind" or "NoKeybind" or "NoTags" or "TreeLine")
 			{
 				scale = new(0.8f);
 			}

--- a/Common/UI/Hotbar/NewHotbar.cs
+++ b/Common/UI/Hotbar/NewHotbar.cs
@@ -383,6 +383,7 @@ public sealed class NewHotbar : SmartUiState
 
 			if (Main.mouseMiddle && Main.mouseMiddleRelease && !SmartUiLoader.GetUiState<TreeState>().Visible && skill.Tree is not null)
 			{
+				Main.mouseMiddleRelease = false;
 				TreeState tree = SmartUiLoader.GetUiState<TreeState>();
 				tree.Toggle();
 				tree.TabPanel.SetActivePage("SkillTree");

--- a/Common/UI/SkillsTree/SkillSelectionPanel.cs
+++ b/Common/UI/SkillsTree/SkillSelectionPanel.cs
@@ -6,10 +6,8 @@ using PathOfTerraria.Content.SkillAugments;
 using PathOfTerraria.Core.UI.SmartUI;
 using System.Collections.Generic;
 using Terraria.Localization;
-using Terraria.ModLoader.Core;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
-using static PathOfTerraria.Common.UI.SkillsTree.SkillSelectionElement;
 
 namespace PathOfTerraria.Common.UI.SkillsTree;
 

--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -165,6 +165,12 @@ internal class TreeState : TabsUiState
 		AvailablePassivePointsText.DrawAvailablePassivePoint(spriteBatch, points, GetRectangle().TopLeft() + pointsDrawPoin);
 	}
 
+	internal void SetSkillTree(Skill skill)
+	{
+		_skillSelection.SelectedSkill = skill;
+		_skillSelection.RebuildTree();
+	}
+
 	// ReSharper disable once UnusedType.Local
 	private class StopInvPlayer : ModPlayer
 	{

--- a/Localization/de-DE/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Skills.hjson
@@ -12,7 +12,11 @@
 # This is for the hover text in the skills menu.
 // CantEquip: Can't equip skill: {0}
 // TagsLine: Tags:
+// CantBeAdded: Skill cannot be added.
+// AlreadyAdded: Skill is already equipped.
 // ShowTags: (Shift to show tag names)
+// NoTree: (This skill has no tree)
+// OpenTree: Middle click to open tree
 
 Tags: {
 	// None: None

--- a/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Skills.hjson
@@ -15,6 +15,8 @@ TagsLine: Tags:
 CantBeAdded: Skill cannot be added.
 AlreadyAdded: Skill is already equipped.
 ShowTags: (Shift to show tag names)
+NoTree: (This skill has no tree)
+OpenTree: Middle click to open tree
 
 Tags: {
 	None: None

--- a/Localization/es-ES/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Skills.hjson
@@ -12,7 +12,11 @@
 # This is for the hover text in the skills menu.
 // CantEquip: Can't equip skill: {0}
 // TagsLine: Tags:
+// CantBeAdded: Skill cannot be added.
+// AlreadyAdded: Skill is already equipped.
 // ShowTags: (Shift to show tag names)
+// NoTree: (This skill has no tree)
+// OpenTree: Middle click to open tree
 
 Tags: {
 	// None: None

--- a/Localization/fr-FR/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Skills.hjson
@@ -12,7 +12,11 @@ BaseDamage: Inflige {0} de dommage de base
 # This is for the hover text in the skills menu.
 CantEquip: Ne peut équiper la compétence : {0}
 // TagsLine: Tags:
+// CantBeAdded: Skill cannot be added.
+// AlreadyAdded: Skill is already equipped.
 // ShowTags: (Shift to show tag names)
+// NoTree: (This skill has no tree)
+// OpenTree: Middle click to open tree
 
 Tags: {
 	// None: None

--- a/Localization/pl-PL/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Skills.hjson
@@ -12,7 +12,11 @@ BaseDamage: Zadaje bazowe {0} obrażeń
 # This is for the hover text in the skills menu.
 CantEquip: Nie można nałożyć umiejętności: {0}
 // TagsLine: Tags:
+// CantBeAdded: Skill cannot be added.
+// AlreadyAdded: Skill is already equipped.
 // ShowTags: (Shift to show tag names)
+// NoTree: (This skill has no tree)
+// OpenTree: Middle click to open tree
 
 Tags: {
 	// None: None

--- a/Localization/pt-BR/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Skills.hjson
@@ -12,7 +12,11 @@
 # This is for the hover text in the skills menu.
 // CantEquip: Can't equip skill: {0}
 // TagsLine: Tags:
+// CantBeAdded: Skill cannot be added.
+// AlreadyAdded: Skill is already equipped.
 // ShowTags: (Shift to show tag names)
+// NoTree: (This skill has no tree)
+// OpenTree: Middle click to open tree
 
 Tags: {
 	// None: None

--- a/Localization/ru-RU/Mods.PathOfTerraria.Skills.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Skills.hjson
@@ -12,7 +12,11 @@ BaseDamage: Наносит {0} базового урона
 # This is for the hover text in the skills menu.
 CantEquip: Невозможно оснастить умение: {0}
 // TagsLine: Tags:
+// CantBeAdded: Skill cannot be added.
+// AlreadyAdded: Skill is already equipped.
 // ShowTags: (Shift to show tag names)
+// NoTree: (This skill has no tree)
+// OpenTree: Middle click to open tree
 
 Tags: {
 	// None: None


### PR DESCRIPTION
### Description of Work
- Middle clicking a hotbar skill with a tree now opens the skill tree directly
- Tooltips to inform players of that
