### PR TITLE
add in skip quest step functionality, update all boss quests

### DIFF
--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -232,6 +232,22 @@ public sealed class QuestDebugState : SmartUiState
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
 
+				e.OnRightClick += (evt, self) =>
+				{
+					if (!quest.Active && !quest.Completed)
+					{
+						return;
+					}
+
+					if (!quest.Completed && quest.CurrentStep <= 1)
+					{
+						return;
+					}
+
+					quest.Advance(Main.LocalPlayer, delta: -2);
+					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
+				};
+
 				buttonX += e.Width.Pixels;
 			});
 			// State info panel. Button, but doesn't do anything.
@@ -274,6 +290,25 @@ public sealed class QuestDebugState : SmartUiState
 					else
 					{
 						quest.Advance(Main.LocalPlayer, delta: 1);
+					}
+
+					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
+				};
+
+				e.OnRightClick += (evt, self) =>
+				{
+					if (quest.Completed)
+					{
+						return;
+					}
+
+					if (!quest.Active)
+					{
+						Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest(quest.FullName);
+					}
+					else
+					{
+						quest.Advance(Main.LocalPlayer, delta: 2);
 					}
 
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();

--- a/Common/Quests/QuestUtils.cs
+++ b/Common/Quests/QuestUtils.cs
@@ -1,4 +1,6 @@
-﻿using Terraria.DataStructures;
+﻿using PathOfTerraria.Common.Systems.BossTrackingSystems;
+using PathOfTerraria.Common.Systems.Questing;
+using Terraria.DataStructures;
 using Terraria.ID;
 
 namespace PathOfTerraria.Common.Quests;
@@ -18,5 +20,10 @@ internal static class QuestUtils
 		}
 
 		return item;
+	}
+
+	public static Func<QuestStep, bool> BossSkipCheck(int npcId)
+	{
+		return _ => BossTracker.TotalBossesDowned.Contains(npcId);
 	}
 }

--- a/Common/Systems/Questing/QuestStep.cs
+++ b/Common/Systems/Questing/QuestStep.cs
@@ -36,6 +36,8 @@ public abstract class QuestStep(string id)
 		init => countsAsCompleteDefault = value; 
 	}
 
+	public Func<QuestStep, bool> SkipCheck { get; internal set; } = null;
+
 	/// <summary>
 	/// Called every frame on the player. This should be used to complete steps, check conditions, so on and so on.
 	/// </summary>

--- a/Common/Systems/Questing/Quests/MainPath/BoCQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/BoCQuest.cs
@@ -1,11 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
 using PathOfTerraria.Common.Systems.VanillaModifications.BossItemRemovals;
 using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
+using System.Collections.Generic;
 using Terraria.ID;
 using Terraria.Localization;
 
@@ -27,7 +29,10 @@ internal class BoCQuest : Quest
 		[
 			new ConditionCheck("SmashOrbs", (_) => DisableEvilOrbBossSpawning.ActualOrbsSmashed > 0, 1, this.GetLocalization("SmashOrb")),
 			new ConditionCheck("EnterDomain", (_) => SubworldSystem.Current is BrainDomain, 1, this.GetLocalization("EnterDomain")),
-			new KillCount("KillBrain", NPCID.BrainofCthulhu, 1, this.GetLocalization("KillBrain")),
+			new ConditionCheck("KillBrain", _ => BossTracker.DownedInDomain<BrainDomain>(NPCID.BrainofCthulhu), 1, this.GetLocalization("KillBrain"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.BrainofCthulhu)
+			},
 			new InteractWithNPC("TalkLloyd", ModContent.NPCType<LloydNPC>(), LocalizedText.Empty, Language.GetText("Mods.PathOfTerraria.NPCs.LloydNPC.Dialogue.Complete"))
 			{
 				CountsAsCompletedOnMarker = true

--- a/Common/Systems/Questing/Quests/MainPath/DeerclopsQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/DeerclopsQuest.cs
@@ -1,4 +1,7 @@
-﻿using PathOfTerraria.Common.Systems.ModPlayers;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
+using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
@@ -40,7 +43,10 @@ internal class DeerclopsQuest : Quest
 						NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
 					}
 				}),
-			new ConditionCheck("KillDeerclops", (_) => NPC.downedDeerclops, 1, this.GetLocalization("KillDeerclops")),
+			new ConditionCheck("KillDeerclops", _ => BossTracker.DownedInDomain<DeerclopsDomain>(NPCID.Deerclops), 1, this.GetLocalization("KillDeerclops"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.Deerclops)
+			},
 			new InteractWithNPC("Finish", ModContent.NPCType<RhineNPC>(), LocalizedText.Empty, Language.GetText("Mods.PathOfTerraria.NPCs.RhineNPC.Dialogue.Success"))
 			{
 				CountsAsCompletedOnMarker = true

--- a/Common/Systems/Questing/Quests/MainPath/EoCQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/EoCQuest.cs
@@ -1,4 +1,7 @@
 ﻿using PathOfTerraria.Common.NPCs.ConditionalDropping;
+using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -66,7 +69,10 @@ internal class EoCQuest : Quest
 						NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
 					}
 				}),
-			new KillCount("KillEoC", NPCID.EyeofCthulhu, 1, this.GetLocalization("Kill.EoC")),
+			new ConditionCheck("KillEoC", _ => BossTracker.DownedInDomain<EyeDomain>(NPCID.EyeofCthulhu), 1, this.GetLocalization("Kill.EoC"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.EyeofCthulhu)
+			},
 			new ActionStep((_, _) =>
 			{
 				RavencrestSystem.UpgradeBuilding("Observatory");

--- a/Common/Systems/Questing/Quests/MainPath/EoWQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/EoWQuest.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
@@ -8,6 +10,7 @@ using PathOfTerraria.Common.Systems.VanillaModifications;
 using PathOfTerraria.Common.Systems.VanillaModifications.BossItemRemovals;
 using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
+using System.Collections.Generic;
 using Terraria.ID;
 using Terraria.Localization;
 
@@ -46,7 +49,10 @@ internal class EoWQuest : Quest
 				return true;
 			}),
 			new ConditionCheck("Orbs", (_) => DisableEvilOrbBossSpawning.ActualOrbsSmashed > 2, 1, this.GetLocalization("SmashOrbs")),
-			new ConditionCheck("KillEoW", (_) => NPC.downedBoss2, 1, this.GetLocalization("KillEoW")),
+			new ConditionCheck("KillEoW", _ => BossTracker.DownedInDomain<EaterDomain>(NPCID.EaterofWorldsHead), 1, this.GetLocalization("KillEoW"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.EaterofWorldsHead)
+			},
 			new InteractWithNPC("Finish", ModContent.NPCType<MorvenNPC>(), LocalizedText.Empty, Language.GetText("Mods.PathOfTerraria.NPCs.MorvenNPC.Dialogue.AfterBeatingEoW"))
 			{
 				CountsAsCompletedOnMarker = true

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/CultistQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/CultistQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -39,7 +40,10 @@ internal class CultistQuest() : HardmodeQuest(9)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is CultistDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<CultistDomain>(NPCID.CultistBoss), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<CultistDomain>(NPCID.CultistBoss), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.CultistBoss)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/DestroyerQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/DestroyerQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -39,7 +40,10 @@ internal class DestroyerQuest() : HardmodeQuest(3)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is DestroyerDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<DestroyerDomain>(NPCID.TheDestroyer), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<DestroyerDomain>(NPCID.TheDestroyer), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.TheDestroyer)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/EoLQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/EoLQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -39,7 +40,10 @@ internal class EoLQuest() : HardmodeQuest(8)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is EmpressDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<EmpressDomain>(NPCID.HallowBoss), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<EmpressDomain>(NPCID.HallowBoss), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.HallowBoss)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/FishronQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/FishronQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -39,7 +40,10 @@ internal class FishronQuest() : HardmodeQuest(7)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is FishronDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<FishronDomain>(NPCID.DukeFishron), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<FishronDomain>(NPCID.DukeFishron), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.DukeFishron)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/GolemQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/GolemQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -39,7 +40,10 @@ internal class GolemQuest() : HardmodeQuest(6)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is GolemDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<GolemDomain>(NPCID.Golem), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<GolemDomain>(NPCID.Golem), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.Golem)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/HardmodeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/HardmodeQuest.cs
@@ -1,13 +1,4 @@
 ﻿using PathOfTerraria.Common.Subworlds;
-using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
-using PathOfTerraria.Common.Systems.BossTrackingSystems;
-using PathOfTerraria.Common.Systems.ModPlayers;
-using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
-using PathOfTerraria.Common.Systems.Questing.RewardTypes;
-using PathOfTerraria.Content.NPCs.Town;
-using SubworldLibrary;
-using System.Collections.Generic;
-using Terraria.ID;
 
 namespace PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/MoonLordQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/MoonLordQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
@@ -25,7 +26,10 @@ internal class MoonLordQuest() : HardmodeQuest(10)
 		return
 		[
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is MoonLordDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<MoonLordDomain>(NPCID.MoonLordCore), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<MoonLordDomain>(NPCID.MoonLordCore), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.MoonLordCore)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/PlanteraQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/PlanteraQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -38,7 +39,10 @@ internal class PlanteraQuest() : HardmodeQuest(5)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is PlanteraDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<PlanteraDomain>(NPCID.Plantera), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<PlanteraDomain>(NPCID.Plantera), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.Plantera)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/QueenSlimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/QueenSlimeQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -38,7 +39,10 @@ internal class QueenSlimeQuest() : HardmodeQuest(1)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is QueenSlimeDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<QueenSlimeDomain>(NPCID.QueenSlimeBoss), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<QueenSlimeDomain>(NPCID.QueenSlimeBoss), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.QueenSlimeBoss)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/SkelePrimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/SkelePrimeQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -39,7 +40,10 @@ internal class SkelePrimeQuest() : HardmodeQuest(4)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is PrimeDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<PrimeDomain>(NPCID.SkeletronPrime), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<PrimeDomain>(NPCID.SkeletronPrime), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.SkeletronPrime)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/TwinsQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/TwinsQuest.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Subworlds;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -38,7 +39,10 @@ internal class TwinsQuest() : HardmodeQuest(2)
 				MappingDomainSystem.RequiredCompletionsPerTier
 			)),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is TwinsDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<TwinsDomain>(NPCID.Retinazer, NPCID.Spazmatism), 1, this.GetLocalization("Boss")),
+			new ConditionCheck("Finish", _ => BossTracker.DownedInDomain<TwinsDomain>(NPCID.Retinazer, NPCID.Spazmatism), 1, this.GetLocalization("Boss"))
+			{
+				SkipCheck = _ => BossTracker.TotalBossesDowned.Contains(NPCID.Retinazer) && BossTracker.TotalBossesDowned.Contains(NPCID.Spazmatism)
+			},
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
@@ -55,7 +55,10 @@ internal class KingSlimeQuest : Quest
 			}),
 
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is KingSlimeDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Kill", _ => BossTracker.DownedInDomain<KingSlimeDomain>(NPCID.KingSlime), 1, this.GetLocalization("Kill.KingSlime")),
+			new ConditionCheck("Kill", _ => BossTracker.DownedInDomain<KingSlimeDomain>(NPCID.KingSlime), 1, this.GetLocalization("Kill.KingSlime"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.KingSlime)
+			},
 			new InteractWithNPC("Finish", ModContent.NPCType<GarrickNPC>(), LocalizedText.Empty, this.GetLocalization("ThanksDialogue")) { CountsAsCompletedOnMarker = true }
 		];
 	}

--- a/Common/Systems/Questing/Quests/MainPath/QueenBeeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/QueenBeeQuest.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Common.Quests;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
 using PathOfTerraria.Content.Items.Pickups.GrimoirePickups;
 using PathOfTerraria.Content.NPCs.Town;
+using System.Collections.Generic;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
@@ -39,7 +42,10 @@ internal class QueenBeeQuest : Quest
 						}
 					}
 				}),
-			new KillCount("Kill", NPCID.QueenBee, 1, this.GetLocalization("KillQueen")),
+			new ConditionCheck("Kill", _ => BossTracker.DownedInDomain<QueenBeeDomain>(NPCID.QueenBee), 1, this.GetLocalization("KillQueen"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.QueenBee)
+			},
 			new InteractWithNPC("Finish", NPCQuestGiver, LocalizedText.Empty, Language.GetText("Mods.PathOfTerraria.NPCs.MorganaNPC.Dialogue.QueenBeeKilled"))
 			{
 				CountsAsCompletedOnMarker = true

--- a/Common/Systems/Questing/Quests/MainPath/SkeletronQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/SkeletronQuest.cs
@@ -1,11 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
 using PathOfTerraria.Content.Items.Quest;
 using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
+using System.Collections.Generic;
 using Terraria.ID;
 using Terraria.Localization;
 
@@ -32,7 +34,10 @@ internal class SkeletronQuest : Quest
 				[new GiveItem(2, ItemID.Candle, ItemID.PlatinumCandle), new GiveItem(1, ItemID.CrimtaneBar, ItemID.DemoniteBar),
 					new GiveItem(1, ModContent.ItemType<AncientEvilBook>())]),
 			new ConditionCheck("Enter", (_) => SubworldSystem.Current is SkeletronDomain, 1, this.GetLocalization("EnterDomain")),
-			new ConditionCheck("Kill", (_) => NPC.downedBoss3, 1, this.GetLocalization("KillSkeletron")),
+			new ConditionCheck("Kill", _ => BossTracker.DownedInDomain<SkeletronDomain>(NPCID.SkeletronHead), 1, this.GetLocalization("KillSkeletron"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.SkeletronHead)
+			},
 			new InteractWithNPC("Finish", NPCID.Clothier, LocalizedText.Empty, Language.GetText("Mods.PathOfTerraria.NPCs.OldMan.Dialogue.Complete"))
 			{
 				CountsAsCompletedOnMarker = true

--- a/Common/Systems/Questing/Quests/MainPath/WoFQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/WoFQuest.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
@@ -10,6 +12,7 @@ using PathOfTerraria.Content.Items.Gear.Weapons.Wand;
 using PathOfTerraria.Content.Items.Pickups.GrimoirePickups;
 using PathOfTerraria.Content.Items.Quest;
 using PathOfTerraria.Content.NPCs.Town;
+using System.Collections.Generic;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
@@ -68,7 +71,10 @@ internal class WoFQuest : Quest
 						NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
 					}
 				}),
-			new ConditionCheck("Kill", _ => Main.hardMode, 1, this.GetLocalization("KillWall")),
+			new ConditionCheck("Kill", _ => BossTracker.DownedInDomain<WallOfFleshDomain>(NPCID.WallofFlesh), 1, this.GetLocalization("KillWall"))
+			{
+				SkipCheck = QuestUtils.BossSkipCheck(NPCID.WallofFlesh)
+			},
 			new InteractWithNPC("Finish", NPCQuestGiver, this.GetLocalization("WizardFinish"), 
 				onSuccess: _ => Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest<QueenSlimeQuest>()),
 		];

--- a/Common/UI/Quests/QuestsUIState.cs
+++ b/Common/UI/Quests/QuestsUIState.cs
@@ -1,6 +1,8 @@
 ﻿using PathOfTerraria.Common.Systems.Questing;
+using PathOfTerraria.Common.UI.Components;
 using PathOfTerraria.Common.UI.Guide;
 using PathOfTerraria.Common.UI.Utilities;
+using PathOfTerraria.Core.UI;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
 using System.Collections.Generic;
@@ -10,15 +12,13 @@ using Terraria.GameContent;
 using Terraria.GameContent.ItemDropRules;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.UI;
 
 namespace PathOfTerraria.Common.UI.Quests;
 
 public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 {
-	//private QuestDetailsPanel _questDetails;
-	//private QuestDetailsPanel _completedQuestDetails;
-
 	public const float SelectedOpacity = 0.25f;
 	public const float HoveredOpacity = 0.1f;
 
@@ -29,6 +29,7 @@ public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 	private UIList _questDetails;
 	private UIList _questList;
 	private UIList _completedQuestList;
+	private int _skipConfirm = 0;
 
 	protected override int TopPadding => 0;
 	protected override int PanelHeight => 1000;
@@ -68,6 +69,8 @@ public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 		{
 			Toggle();
 		}
+
+		_skipConfirm--;
 	}
 
 	public override void Refresh()
@@ -168,11 +171,42 @@ public class QuestsUIState : CloseableSmartUi, IMutuallyExclusiveUI
 				continue;
 			}
 
-			_questDetails.Add(new UISelectableQuestStep(i, quest)
+			var stepUI = new UISelectableQuestStep(i, quest)
 			{
 				Width = StyleDimension.Fill,
 				Height = StyleDimension.FromPixels(step.LineCount * 22)
-			});
+			};
+			_questDetails.Add(stepUI);
+
+			if (quest.CurrentStep == i && step.SkipCheck?.Invoke(step) == true)
+			{
+				var skip = new UIText(Language.GetTextValue("Mods.PathOfTerraria.Quests.Skip"), 0.8f)
+				{
+					HAlign = 1f,
+					Width = StyleDimension.FromPixels(60),
+					Height = StyleDimension.FromPixels(30),
+					Top = StyleDimension.FromPixels(-6),
+					TextColor = QuestStep.DefaultTextColor,
+					ShadowColor = Color.Transparent,
+				};
+
+				skip.AddComponent(new UIDynamicText(_ => Language.GetTextValue("Mods.PathOfTerraria.Quests." + (_skipConfirm <= 0 ? "Skip" : "Sure"))));
+				skip.OnLeftClick += (_, _) => SkipStep(quest);
+				stepUI.Append(skip);
+			}
+		}
+	}
+
+	private void SkipStep(Quest quest)
+	{
+		if (_skipConfirm <= 0)
+		{
+			_skipConfirm = 60 * 5;
+		}
+		else
+		{
+			quest.Advance(Main.LocalPlayer, 1);
+			PopulateQuestSteps(quest);
 		}
 	}
 

--- a/Localization/de-DE/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	// GiveItTo: and give it to the {0}
 }
 
+// Skip: Skip?
+// Sure: You sure?
 // TalkTo: Talk to {0}
 // GiveThem: " and give them:"
 // Exploration.Ice: Explore the Ice/Snow biome ({0}%)

--- a/Localization/en-US/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	GiveItTo: and give it to the {0}
 }
 
+Skip: Skip?
+Sure: You sure?
 TalkTo: Talk to {0}
 GiveThem: " and give them:"
 Exploration.Ice: Explore the Ice/Snow biome ({0}%)

--- a/Localization/es-ES/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	// GiveItTo: and give it to the {0}
 }
 
+// Skip: Skip?
+// Sure: You sure?
 TalkTo: Habla con {0}
 GiveThem: y dale:
 // Exploration.Ice: Explore the Ice/Snow biome ({0}%)

--- a/Localization/fr-FR/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	GiveItTo: et donnez le à {0}
 }
 
+// Skip: Skip?
+// Sure: You sure?
 TalkTo: Parlez à {0}
 GiveThem: et lui donner:
 Exploration.Ice: Explorez le biome de Glace/Neige ({0}%)

--- a/Localization/pl-PL/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	GiveItTo: i daj to {0}
 }
 
+// Skip: Skip?
+// Sure: You sure?
 TalkTo: Porozmawiaj z {0}
 GiveThem: oraz daj im:
 Exploration.Ice: Odkryj biom Lodowy/Śnieżny ({0}%)

--- a/Localization/pt-BR/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	// GiveItTo: and give it to the {0}
 }
 
+// Skip: Skip?
+// Sure: You sure?
 // TalkTo: Talk to {0}
 // GiveThem: " and give them:"
 // Exploration.Ice: Explore the Ice/Snow biome ({0}%)

--- a/Localization/ru-RU/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Quests.hjson
@@ -11,6 +11,8 @@ Bring: {
 	GiveItTo: и отдайте это в {0}
 }
 
+// Skip: Skip?
+// Sure: You sure?
 TalkTo: Поговорите с {0}
 GiveThem: и дайте:
 Exploration.Ice: Исследуйте ледяной/снежный биом ({0}%)


### PR DESCRIPTION
﻿### Link Issues
Resolves: #544

### Description of Work
- Adds in quest step "Skip?" functionality, used only for already-downed bosses atm

### Comments
I had an issue with one quest where using the quest debugging UI would skip a step somehow, but still leave the "Skip?" text up, which allowed the following step to be completed out of turn - I doubt this is an issue we'll have in production, so whatever.