### PR TITLE
fix(#1573): Add in menu pausing system for full screen menu openings

### DIFF
--- a/Common/Looting/VirtualBagUI/VirtualBagStoragePlayer.cs
+++ b/Common/Looting/VirtualBagUI/VirtualBagStoragePlayer.cs
@@ -11,6 +11,7 @@ using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.UI;
 using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Common.Systems.FullMenuPausing;
 
 namespace PathOfTerraria.Common.Looting.VirtualBagUI;
 
@@ -19,8 +20,8 @@ internal class VirtualBagStoragePlayer : ModPlayer
 	/// <summary>
 	/// If the local player is using the virtual bag config.
 	/// </summary>
-	public static bool LocalUseVirtualBag => Main.LocalPlayer.GetModPlayer<VirtualBagStoragePlayer>().UsesVirtualBag &&
-	                                         IsVirtualBagActiveContext();
+	public static bool LocalUseVirtualBag => Main.LocalPlayer.GetModPlayer<VirtualBagStoragePlayer>().UsesVirtualBag 
+	                                         && IsVirtualBagActiveContext();
 
 	public static ModKeybind BagKeybind;
 
@@ -56,10 +57,15 @@ internal class VirtualBagStoragePlayer : ModPlayer
 			if (UIManager.TryGet(VirtualBagUIState.Identifier, out UIManager.UIStateData data) && data.Enabled)
 			{
 				SoundEngine.PlaySound(SoundID.MenuOpen);
+				if (Main.netMode != NetmodeID.SinglePlayer)
+				{
+					MenuSafeSystem.MenuOpen = true;
+				}
 			}
 			else
 			{
 				SoundEngine.PlaySound(SoundID.MenuClose);
+				MenuSafeSystem.MenuOpen = false;
 			}
 		}
 	}
@@ -78,6 +84,10 @@ internal class VirtualBagStoragePlayer : ModPlayer
 
 		confirmed = true;
 		UIManager.TryToggleOrRegister(VirtualBagUIState.Identifier, "Vanilla: Mouse Text", new VirtualBagUIState());
+		if (Main.netMode != NetmodeID.SinglePlayer)
+		{
+			MenuSafeSystem.MenuOpen = true;
+		}
 	}
 
 	public override void OnEnterWorld()
@@ -96,6 +106,7 @@ internal class VirtualBagStoragePlayer : ModPlayer
 		}
 
 		Storage.Clear();
+		MenuSafeSystem.MenuOpen = false;
 	}
 
 	private void OverrideRightClickForVirtualBag(On_ItemSlot.orig_RightClick_ItemArray_int_int orig, Item[] inv,

--- a/Common/Systems/FullMenuPausing/MenuSafeNPC.cs
+++ b/Common/Systems/FullMenuPausing/MenuSafeNPC.cs
@@ -1,0 +1,11 @@
+﻿namespace PathOfTerraria.Common.Systems.FullMenuPausing;
+
+public class MenuSafeNPC : GlobalNPC
+{
+	public override void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns) {
+		if (MenuSafeSystem.MenuOpen) {
+			spawnRate = int.MaxValue;
+			maxSpawns = 0;
+		}
+	}
+}

--- a/Common/Systems/FullMenuPausing/MenuSafePlayer.cs
+++ b/Common/Systems/FullMenuPausing/MenuSafePlayer.cs
@@ -1,0 +1,58 @@
+﻿namespace PathOfTerraria.Common.Systems.FullMenuPausing;
+
+public class MenuSafePlayer : ModPlayer
+{
+	/// <summary>
+	/// Prevents the player from being hit by NPCs.
+	/// </summary>
+	/// <param name="npc"></param>
+	/// <param name="cooldownSlot"></param>
+	/// <returns></returns>
+	public override bool CanBeHitByNPC(NPC npc, ref int cooldownSlot) {
+		return !MenuSafeSystem.MenuOpen;
+	}
+
+	/// <summary>
+	/// Prevents the player from being hit by projectiles.
+	/// </summary>
+	/// <param name="proj"></param>
+	/// <returns></returns>
+	public override bool CanBeHitByProjectile(Projectile proj) {
+		return !MenuSafeSystem.MenuOpen;
+	}
+
+	/// <summary>
+	/// Turns off damage and knockback when in a menu.
+	/// </summary>
+	/// <param name="modifiers"></param>
+	public override void ModifyHurt(ref Player.HurtModifiers modifiers) {
+		if (MenuSafeSystem.MenuOpen) {
+			modifiers.FinalDamage *= 0f;
+			modifiers.Knockback *= 0f;
+			modifiers.DisableSound();
+			modifiers.SetMaxDamage(0);
+		}
+	}
+	
+	/// <summary>
+	/// Updates life regen when in a menu.
+	/// </summary>
+	public override void UpdateBadLifeRegen() {
+		if (MenuSafeSystem.MenuOpen) {
+			Player.lifeRegen = 0;
+			Player.lifeRegenTime = 0;
+		}
+	}
+
+	/// <summary>
+	/// Makes player immune while menu is open.
+	/// </summary>
+	public override void PostUpdate() {
+		if (MenuSafeSystem.MenuOpen) {
+			Player.immune = true;
+			Player.immuneTime = 2;
+			Player.noKnockback = true;
+			Player.velocity *= 0.01f;
+		}
+	}
+}

--- a/Common/Systems/FullMenuPausing/MenuSafeSystem.cs
+++ b/Common/Systems/FullMenuPausing/MenuSafeSystem.cs
@@ -1,0 +1,9 @@
+﻿namespace PathOfTerraria.Common.Systems.FullMenuPausing;
+
+public class MenuSafeSystem : ModSystem
+{
+	/// <summary>
+	/// Toggle true when the menu is open. This is used to prevent certain things from happening.
+	/// </summary>
+	public static bool MenuOpen;
+}

--- a/Common/Systems/FullMenuPausing/MenuSafeWorld.cs
+++ b/Common/Systems/FullMenuPausing/MenuSafeWorld.cs
@@ -1,0 +1,23 @@
+﻿namespace PathOfTerraria.Common.Systems.FullMenuPausing;
+
+public class MenuSafeWorld : ModSystem
+{
+	/// <summary>
+	/// Prevents the world from updating while the menu is open.
+	/// </summary>
+	public override void PreUpdateWorld() {
+		if (!MenuSafeSystem.MenuOpen)
+		{
+			return;
+		}
+
+		Main.bloodMoon = false;
+		Main.eclipse = false;
+
+		if (Main.invasionType != 0) {
+			Main.invasionDelay = int.MaxValue;
+			Main.invasionSize = 0; 
+			Main.invasionType = 0;
+		}
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1573

### Description of Work
* Adds in a menu pausing system for disabling certain world and player events from occuring
* Adds in this menu pausing system to the looting bag

### Comments
