### PR TITLE
fix alt hover on custom context slots

### DIFF
--- a/Common/UI/Elements/UIImageItemSlot.cs
+++ b/Common/UI/Elements/UIImageItemSlot.cs
@@ -53,6 +53,8 @@ public class UIImageItemSlot
 		}
 	}
 
+	private static Asset<Texture2D>? FavoriteBack = null;
+
 	protected readonly float IconSize = iconScalingSize;
 
 	private readonly SlotWrapper handler = itemHandler;
@@ -206,6 +208,13 @@ public class UIImageItemSlot
 
 		float baseScale = 1f * Icon.ImageScale;
 		float sizeLimit = IconSize; //Math.Min(dimensions.Width, dimensions.Height);
+
+		if (Item.favorited)
+		{
+			FavoriteBack ??= ModContent.Request<Texture2D>("PathOfTerraria/Assets/Slots/FavoriteOverlay");
+			Texture2D tex = FavoriteBack.Value;
+			Main.spriteBatch.Draw(tex, center, null, Color.White, 0f, tex.Size() / 2f, MathHelper.Lerp(baseScale, 0.8f, 0.5f), SpriteEffects.None, 0);
+		}
 
 		ItemSlot.DrawItemIcon(Item, ItemSlot.Context.InventoryItem, sb, center, baseScale, sizeLimit, Color.White);
 

--- a/Common/UI/Utilities/FixFavoritingFunctionality.cs
+++ b/Common/UI/Utilities/FixFavoritingFunctionality.cs
@@ -1,0 +1,107 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using PathOfTerraria.Utilities;
+using Terraria.ID;
+using Terraria.UI;
+
+namespace PathOfTerraria.Common.UI.Utilities;
+
+internal class FixFavoritingFunctionality : ILoadable
+{
+	/// <summary>
+	/// If the player should be able to favorite equipped armor/accessories. Defaults to false to match vanilla.
+	/// </summary>
+	private static bool ArmorFavoritingEnabled => false;
+
+	public void Load(Mod mod)
+	{
+		On_ItemSlot.OverrideHover_ItemArray_int_int += FixFavoriting;
+		IL_ItemSlot.OverrideLeftClick += ModifyFavoritingFunctionality;
+	}
+
+	private void ModifyFavoritingFunctionality(ILContext il)
+	{
+		ILCursor c = new(il);
+
+		// Anchor at ItemSlot.canFavoriteAt check
+		if (!c.TryGotoNext(x => x.MatchLdsfld<ItemSlot>("canFavoriteAt")))
+		{
+			return;
+		}
+
+		int context = -1;
+
+		// Match the argument indx of "context"
+		if (!c.TryGotoNext(x => x.MatchLdarg(out context)))
+		{
+			return;
+		}
+
+		// Move after the bool value is placed on the stack approaching the brtrue that skips returning
+		if (!c.TryGotoNext(MoveType.After, x => x.MatchLdelemU1()))
+		{
+			return;
+		}
+
+		// originalValue is already pushed, push context & additional check delegate
+		c.Emit(OpCodes.Ldarg_S, (byte)context);
+		c.EmitDelegate(HijackFavoriteValue);
+	}
+
+	private static bool HijackFavoriteValue(bool originalValue, int context)
+	{
+		// This method effectively changes the first line in this snippet:
+
+		// if (!canFavoriteAt[Math.Abs(context)])
+		//		return false;
+		// item.favorited = !item.favorited;
+
+		// into this:
+
+		// if (!canFavoriteAt[Math.Abs(context)] && context >= 0)
+
+		// This allows for us to use the negative context we have and still allow favoriting.
+
+		if (!ArmorFavoritingEnabled)
+		{
+			return originalValue;
+		}
+
+		return originalValue || context < 0;
+	}
+
+	private void FixFavoriting(On_ItemSlot.orig_OverrideHover_ItemArray_int_int orig, Item[] inv, int context, int slot)
+	{
+		bool invalidFavorite = context < 0;
+
+		// Define scope for override
+		// This forces the code that checks for favoriting to fail as Keys 50,000 doesn't exist, stopping the OOB check on ItemSlot.canFavoriteSlot
+		{
+			using var _ = ValueOverride.Create(ref Main.FavoriteKey, invalidFavorite ? (Microsoft.Xna.Framework.Input.Keys)50000 : Main.FavoriteKey);
+			orig(inv, context, slot);
+		}
+
+		if (!invalidFavorite || !ArmorFavoritingEnabled)
+		{
+			return;
+		}
+
+		Item item = inv[slot];
+
+		if (Main.keyState.IsKeyDown(Main.FavoriteKey))
+		{
+			if (item.type > ItemID.None && item.stack > 0 && Main.drawingPlayerChat)
+			{
+				Main.cursorOverride = 2;
+			}
+			else if (item.type > ItemID.None && item.stack > 0)
+			{
+				Main.cursorOverride = 3;
+			}
+		}
+	}
+
+	public void Unload()
+	{
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1598 

### Description of Work
- Fixes trying to favorite some custom slots throwing an error
- Adds in functionality to allow favoriting in the custom slots, although disabled
- Adds in favorite slot element to UIImageItemSlot

### Comments
I added favoriting functionality before realizing vanilla didn't let you do that. That being said, the functionality therein may be used in the future, so I kept it in.