### PR TITLE
some soft desert area nerfs, hard crit chance map affix nerf

### DIFF
--- a/Common/Data/Affixes/MapAffixes.json
+++ b/Common/Data/Affixes/MapAffixes.json
@@ -44,16 +44,30 @@
 		"equipTypes": "Map",
 		"tiers": [
 			{
-				"minValue": 60,
-				"maxValue": 65,
+				"minValue": 18,
+				"maxValue": 25,
 				"minimumLevel": 45,
 				"weight": 1,
 				"strength": 10
 			},
 			{
-				"minValue": 75,
-				"maxValue": 85,
+				"minValue": 26,
+				"maxValue": 34,
 				"minimumLevel": 65,
+				"weight": 1,
+				"strength": 12
+			},
+			{
+				"minValue": 35,
+				"maxValue": 48,
+				"minimumLevel": 75,
+				"weight": 1,
+				"strength": 12
+			},
+			{
+				"minValue": 49,
+				"maxValue": 60,
+				"minimumLevel": 85,
 				"weight": 1,
 				"strength": 12
 			}

--- a/Common/Systems/Affixes/ItemTypes/MapAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/MapAffixes.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using Terraria.ID;
 using Terraria.ModLoader.IO;
-using static PathOfTerraria.Common.Data.Models.ItemAffixData;
 
 namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
@@ -63,7 +62,7 @@ public class MapDamageAffix : MapAffix
 {
 	public override void ModifyNewNPC(NPC npc)
 	{
-		npc.damage = (int)(npc.damage * (1 + Value / 100f));
+		npc.damage = (int)(npc.damage * (1 + (Value / 100f)));
 	}
 }
 

--- a/Content/NPCs/Mapping/Desert/ScarabSwarmController.cs
+++ b/Content/NPCs/Mapping/Desert/ScarabSwarmController.cs
@@ -1,9 +1,4 @@
-﻿using NPCUtils;
-using PathOfTerraria.Common.NPCs.Components;
-using PathOfTerraria.Common.NPCs.Effects;
-using PathOfTerraria.Common.Systems;
-using System.Collections.Specialized;
-using Terraria.GameContent.Bestiary;
+﻿using PathOfTerraria.Common.Systems;
 using Terraria.ID;
 
 namespace PathOfTerraria.Content.NPCs.Mapping.Desert;
@@ -87,7 +82,7 @@ internal class ScarabSwarmController : ModNPC
 		}
 		else if (State == AIState.Chase)
 		{
-			const float MaxSpeed = 4;
+			const float MaxSpeed = 3.5f;
 
 			if (UnderlingCount <= 0 && Main.netMode != NetmodeID.MultiplayerClient && !SpeedUpNPC.Boosting)
 			{

--- a/Content/NPCs/Mapping/Desert/SwarmScarab.cs
+++ b/Content/NPCs/Mapping/Desert/SwarmScarab.cs
@@ -64,7 +64,7 @@ internal class SwarmScarab : ModNPC
 	public override void ApplyDifficultyAndPlayerScaling(int numPlayers, float balance, float bossAdjustment)
 	{
 		NPC.lifeMax = ModeUtils.ByMode(70, 115, 160);
-		NPC.damage = ModeUtils.ByMode(70, 80, 110);
+		NPC.damage = ModeUtils.ByMode(50, 65, 95);
 		NPC.defense = ModeUtils.ByMode(0, 5, 10, 20);
 	}
 


### PR DESCRIPTION
### Description of Work
- Reduce the damage that Swarm Scarabs can do
- Reduces the max speed that Swarm Scarabs go at
- Significantly reduced the "+x% npc crit chance" map affix, tier 1 went from 60-75% to 18-25%