### PR TITLE
Quick fixes

### DIFF
--- a/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/PassiveAffixes.cs
@@ -36,7 +36,7 @@ internal class AddedDamageAffix : ItemAffix
 	
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Damage.Base += Value;
+		player.GetDamage(DamageClass.Generic).Flat += Value;
 	}
 }
 

--- a/Common/Systems/EntityModifier.cs
+++ b/Common/Systems/EntityModifier.cs
@@ -94,11 +94,10 @@ public partial class EntityModifier : EntityModifierSegment
 
 		player.endurance *= DamageReduction.ApplyTo(player.endurance); // i think this is right..?
 		player.moveSpeed = MovementSpeed.ApplyTo(player.moveSpeed);
+
 		player.GetDamage(DamageClass.Generic) = player.GetDamage(DamageClass.Generic).CombineWith(Damage);
 		player.GetAttackSpeed(DamageClass.Generic) = AttackSpeed.ApplyTo(player.GetAttackSpeed(DamageClass.Generic));
-		
 		player.GetCritChance(DamageClass.Generic) = CriticalChance.ApplyTo(player.GetCritChance(DamageClass.Generic));
-
 		player.GetKnockback(DamageClass.Generic) = player.GetKnockback(DamageClass.Generic).CombineWith(Knockback);
 		player.GetArmorPenetration(DamageClass.Generic) = ArmorPenetration.ApplyTo(player.GetArmorPenetration(DamageClass.Generic));
 		

--- a/Common/Systems/ModPlayers/SkillCombatPlayer.cs
+++ b/Common/Systems/ModPlayers/SkillCombatPlayer.cs
@@ -107,9 +107,9 @@ internal class SkillCombatPlayer : ModPlayer
 		return false;
 	}
 
-	public override void ProcessTriggers(TriggersSet triggersSet)
+	public override void PostUpdateMiscEffects()
 	{
-		if (Player.dead || !NewHotbar.LocalCombatMode)
+		if (Main.myPlayer != Player.whoAmI || Player.dead || !NewHotbar.LocalCombatMode)
 		{
 			return;
 		}

--- a/Common/Systems/ModPlayers/SkillCombatPlayer.cs
+++ b/Common/Systems/ModPlayers/SkillCombatPlayer.cs
@@ -107,7 +107,7 @@ internal class SkillCombatPlayer : ModPlayer
 		return false;
 	}
 
-	public override void PostUpdateMiscEffects()
+	public override void ProcessTriggers(TriggersSet triggersSet)
 	{
 		if (Main.myPlayer != Player.whoAmI || Player.dead || !NewHotbar.LocalCombatMode)
 		{

--- a/Common/World/Utilities/WorldUtils.cs
+++ b/Common/World/Utilities/WorldUtils.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace PathOfTerraria.Common.World.Utilities;
+
+internal static class WorldUtils
+{
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool SolidTile(int i, int j)
+	{
+		return SolidTile(Main.tile[i, j]);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool SolidTile(Tile tile)
+	{
+		return Main.tileSolid[tile.TileType] && tile.HasTile;
+	}
+}

--- a/Content/Items/Gear/Weapons/Staff/StaffProjectile.cs
+++ b/Content/Items/Gear/Weapons/Staff/StaffProjectile.cs
@@ -46,6 +46,7 @@ internal abstract class StaffProjectile : ModProjectile
 		Projectile.hide = true;
 		Projectile.timeLeft = 3000;
 		Projectile.tileCollide = false;
+		Projectile.DamageType = DamageClass.Magic;
 	}
 
 	public override bool? CanDamage()

--- a/Content/Items/Gear/Weapons/Staff/SunsoulStaff/SunsoulHead.cs
+++ b/Content/Items/Gear/Weapons/Staff/SunsoulStaff/SunsoulHead.cs
@@ -22,6 +22,7 @@ internal class SunsoulHead : StaffProjectile
 		Projectile.localNPCHitCooldown = 20;
 		Projectile.usesLocalNPCImmunity = true;
 		Projectile.tileCollide = false;
+		Projectile.DamageType = DamageClass.Magic;
 	}
 
 	public override void AI()

--- a/Content/Items/Gear/Weapons/Staff/SunsoulStaff/SunsoulSummon.cs
+++ b/Content/Items/Gear/Weapons/Staff/SunsoulStaff/SunsoulSummon.cs
@@ -36,6 +36,7 @@ public class SunsoulSummon : ModProjectile
 		Projectile.penetrate = -1;
 		Projectile.Opacity = 0f;
 		Projectile.hide = true;
+		Projectile.DamageType = DamageClass.Magic;
 	}
 
 	public override void DrawBehind(int index, List<int> bNaT, List<int> bN, List<int> bP, List<int> overPlayers, List<int> oWUI)

--- a/Content/Items/Gear/Weapons/Wand/EbonwoodWand.cs
+++ b/Content/Items/Gear/Weapons/Wand/EbonwoodWand.cs
@@ -36,6 +36,7 @@ internal class EbonwoodWand : Wand
 			Projectile.timeLeft = 250;
 			Projectile.usesLocalNPCImmunity = true;
 			Projectile.localNPCHitCooldown = 20;
+			Projectile.DamageType = DamageClass.Magic;
 		}
 
 		public override void AI()

--- a/Content/Items/Gear/Weapons/Wand/GemWand.cs
+++ b/Content/Items/Gear/Weapons/Wand/GemWand.cs
@@ -43,6 +43,7 @@ internal class GemWand : Wand
 			Projectile.friendly = true;
 			Projectile.penetrate = 1;
 			Projectile.timeLeft = 250;
+			Projectile.DamageType = DamageClass.Magic;
 		}
 
 		public override void AI()

--- a/Content/Items/Gear/Weapons/Wand/MahoganyWand.cs
+++ b/Content/Items/Gear/Weapons/Wand/MahoganyWand.cs
@@ -34,6 +34,7 @@ internal class MahoganyWand : Wand
 			Projectile.friendly = true;
 			Projectile.penetrate = 1;
 			Projectile.timeLeft = 220;
+			Projectile.DamageType = DamageClass.Magic;
 		}
 
 		public override void AI()

--- a/Content/Items/Gear/Weapons/Wand/ShadewoodWand.cs
+++ b/Content/Items/Gear/Weapons/Wand/ShadewoodWand.cs
@@ -34,6 +34,7 @@ internal class ShadewoodWand : Wand
 			Projectile.friendly = true;
 			Projectile.penetrate = 1;
 			Projectile.timeLeft = 250;
+			Projectile.DamageType = DamageClass.Magic;
 		}
 
 		public override void AI()

--- a/Content/Items/Gear/Weapons/Wand/WoodenWand.cs
+++ b/Content/Items/Gear/Weapons/Wand/WoodenWand.cs
@@ -25,6 +25,7 @@ internal class WoodenWand : Wand
 			Projectile.friendly = true;
 			Projectile.penetrate = 1;
 			Projectile.timeLeft = 200;
+			Projectile.DamageType = DamageClass.Magic;
 		}
 
 		public override void AI()

--- a/Content/Passives/Magic/Masteries/ArcaneSurgeMastery.cs
+++ b/Content/Passives/Magic/Masteries/ArcaneSurgeMastery.cs
@@ -16,7 +16,10 @@ internal class ArcaneSurgeMastery : Passive
 
 		public void OnUseSkill(Skill skill)
 		{
-			AddTimer();
+			if (skill.Tags().HasFlag(SkillTags.Magic))
+			{
+				AddTimer();
+			}
 		}
 
 		internal void AddTimer()

--- a/Content/Passives/Magic/Masteries/OverloadingEnergyMastery.cs
+++ b/Content/Passives/Magic/Masteries/OverloadingEnergyMastery.cs
@@ -8,7 +8,7 @@ internal class OverloadingEnergyMastery : Passive
 	{
 		private float _timer = 0;
 
-		public override void ResetEffects()
+		public override void PostUpdateEquips()
 		{
 			if (Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<OverloadingEnergyMastery>(out float value))
 			{

--- a/Content/Passives/Summon/SmallPassives/IncreasedSentryDamagePassive.cs
+++ b/Content/Passives/Summon/SmallPassives/IncreasedSentryDamagePassive.cs
@@ -13,7 +13,7 @@ internal class IncreasedSentryDamagePassive : Passive
 
 			if (proj.sentry || ProjectileID.Sets.SentryShot[proj.type])
 			{
-				modifiers.FinalDamage += level * (ModContent.GetInstance<IncreasedSentryDamagePassive>().Value / 100.0f);
+				modifiers.FinalDamage += level * (level / 100.0f);
 			}
 		}
 	}

--- a/Content/Projectiles/PassiveProjectiles/StarcallerStar.cs
+++ b/Content/Projectiles/PassiveProjectiles/StarcallerStar.cs
@@ -20,6 +20,7 @@ internal class StarcallerStar : ModProjectile
 	{
 		Projectile.Size = new Vector2(24);
 		Projectile.friendly = true;
+		Projectile.hostile = false;
 		Projectile.DamageType = DamageClass.Magic;
 		Projectile.timeLeft = 2;
 		Projectile.extraUpdates = 1;

--- a/Content/Skills/Summon/Swarm.cs
+++ b/Content/Skills/Summon/Swarm.cs
@@ -5,6 +5,7 @@ using PathOfTerraria.Common.NPCs;
 using PathOfTerraria.Common.Projectiles;
 using PathOfTerraria.Common.Systems.ElementalDamage;
 using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Common.World.Utilities;
 using PathOfTerraria.Content.Buffs;
 using PathOfTerraria.Content.Buffs.ElementalBuffs;
 using PathOfTerraria.Content.Projectiles.Utility;
@@ -67,6 +68,7 @@ public class Swarm : Skill
 			failReason = new SkillFailure(SkillFailReason.NeedsSummon);
 			return false;
 		}
+
 		if (Tree.Specialization is not LocustBrood && Collision.SolidCollision(GetTarget(player) - new Vector2(12, 12), 24, 24))
 		{
 			failReason = new SkillFailure(SkillFailReason.Other, "Blocked");
@@ -89,11 +91,11 @@ public class Swarm : Skill
 		else
 		{
 			int type = ModContent.ProjectileType<LocustSpawnCircle>();
-			int damage = 10 * Level;
+			int damage = (int)player.GetDamage(DamageClass.Summon).ApplyTo(10 * Level);
 
 			if (Tree.Specialization is AntlionSwarm)
 			{
-			    damage = 6 * Level;
+			    damage = (int)player.GetDamage(DamageClass.Summon).ApplyTo(6 * Level);
 			    
 			    // Spawn two Antlion Swarmers
 			    Vector2 offset1 = new Vector2(-24, 0);
@@ -115,7 +117,7 @@ public class Swarm : Skill
 					    Main.projectile[proj].damage += bonusDamage;
 				    }
 
-				    var elementalProj = Main.projectile[proj].GetGlobalProjectile<ElementalProjectile>();
+					ElementalProjectile elementalProj = Main.projectile[proj].GetGlobalProjectile<ElementalProjectile>();
 				    elementalProj.Container[ElementType.Cold].DamageModifier = elementalProj.Container[ElementType.Cold].DamageModifier.AddModifiers(bonusDamage, 1);
 			    }
 			}
@@ -142,8 +144,7 @@ public class Swarm : Skill
 			Tile cur = Main.tile[point];
 			Tile above = Main.tile[point.X, point.Y - 1];
 
-			//TODO: Replace these utilities, as they needlessly include a try-catch.
-			if (WorldGen.SolidTile(cur) && !WorldGen.SolidTile(above))
+			if ((WorldUtils.SolidTile(cur) || TileID.Sets.Platforms[cur.TileType]) && !WorldUtils.SolidTile(above))
 			{
 				points.Add(point);
 			}
@@ -151,11 +152,12 @@ public class Swarm : Skill
 
 		int type = ModContent.ProjectileType<LocustEgg>();
 		var src = new EntitySource_UseSkill(player, this);
+		int damage = (int)player.GetDamage(DamageClass.Summon).ApplyTo(6 * Level);
 
 		foreach (Point16 point in points)
 		{
 			float duration = 30 * Main.rand.NextFloat(0.9f, 2.5f) * (1 - player.GetPassiveStrength<PestSwarmTree, QuickerHatching>() * 0.2f);
-			Projectile.NewProjectile(src, point.ToWorldCoordinates(8, -22), Vector2.Zero, type, 6 * Level, 0, player.whoAmI, duration, 0, TotalDuration);
+			Projectile.NewProjectile(src, point.ToWorldCoordinates(8, -22), Vector2.Zero, type, damage, 0, player.whoAmI, duration, 0, TotalDuration);
 		}
 	}
 
@@ -259,6 +261,7 @@ public class Swarm : Skill
 			Projectile.friendly = true;
 			Projectile.hostile = false;
 			Projectile.DamageType = DamageClass.Summon;
+			Projectile.minion = true;
 			Projectile.aiStyle = -1;
 			Projectile.penetrate = -1;
 			Projectile.usesLocalNPCImmunity = true;
@@ -386,6 +389,12 @@ public class Swarm : Skill
 			return false;
 		}
 
+		public override bool TileCollideStyle(ref int width, ref int height, ref bool fallThrough, ref Vector2 hitboxCenterFrac)
+		{
+			fallThrough = false;
+			return true;
+		}
+
 		public override Color? GetAlpha(Color lightColor)
 		{
 			if (TimeLeft < 60)
@@ -449,6 +458,7 @@ public class Swarm : Skill
 			Projectile.friendly = true;
 			Projectile.hostile = false;
 			Projectile.DamageType = DamageClass.Summon;
+			Projectile.minion = true;
 			Projectile.aiStyle = -1;
 			Projectile.penetrate = -1;
 			Projectile.usesLocalNPCImmunity = true;
@@ -761,6 +771,12 @@ public class Swarm : Skill
 			return false;
 		}
 
+		public override bool TileCollideStyle(ref int width, ref int height, ref bool fallThrough, ref Vector2 hitboxCenterFrac)
+		{
+			fallThrough = false;
+			return true;
+		}
+
 		public override bool PreDraw(ref Color lightColor)
 		{
 			Texture2D tex = TextureAssets.Projectile[Type].Value;
@@ -769,8 +785,9 @@ public class Swarm : Skill
 			int frameHeight = tex.Height / Main.projFrames[Type];
 			Rectangle frame = new(frameWidth * (int)(Projectile.alpha / 90f), Projectile.frame * frameHeight, frameWidth, frameHeight);
 			var scale = new Vector2(2 - Projectile.scale, Projectile.scale);
+			Color color = Color.Lerp(lightColor, Color.White, 0.3f) * Projectile.Opacity;
 			
-			Main.spriteBatch.Draw(tex, position, frame, Color.White * Projectile.Opacity, Projectile.rotation, frame.Size() * new Vector2(0.5f, 1), scale, SpriteEffects.None, 0);
+			Main.spriteBatch.Draw(tex, position, frame, color, Projectile.rotation, frame.Size() * new Vector2(0.5f, 1), scale, SpriteEffects.None, 0);
 			return false;
 		}
 	}
@@ -808,6 +825,7 @@ public class Swarm : Skill
 			Projectile.friendly = true;
 			Projectile.hostile = false;
 			Projectile.DamageType = DamageClass.Summon;
+			Projectile.minion = true;
 			Projectile.aiStyle = -1;
 			Projectile.penetrate = -1;
 			Projectile.usesLocalNPCImmunity = true;

--- a/Content/Skills/Summon/Swarm.cs
+++ b/Content/Skills/Summon/Swarm.cs
@@ -949,6 +949,12 @@ public class Swarm : Skill
 			return false;
 		}
 
+		public override bool TileCollideStyle(ref int width, ref int height, ref bool fallThrough, ref Vector2 hitboxCenterFrac)
+		{
+			fallThrough = false;
+			return true;
+		}
+
 		public override Color? GetAlpha(Color lightColor)
 		{
 			if (TimeLeft < 60)


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1604
Resolves: #1597
Resolves: #1588
Resolves: #1587
Resolves: #1600
Resolves: #1592

### Description of Work
- Fixes a bunch of projectiles not counting as Magic damage despite being magic projectiles
- Fixed IncreasedSentryDamage affix making all sentries unusable lol
- Fixed Overloading Energy reducing mana occasionally instead of regenerating
- Made Locust Brood (Swarm specialization) able to spawn on platforms
- Fixed Swarm not using damage boosts
- Made all Swarm minions except the Antlion Swarmer one not fall through platforms
- Made Arcane Surge only apply to magic skills