### PR TITLE
More fixes again

### DIFF
--- a/Common/Systems/PersistentBuffSystem.cs
+++ b/Common/Systems/PersistentBuffSystem.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using Terraria.ID;
+using Terraria.ModLoader.IO;
+
+namespace PathOfTerraria.Common.Systems;
+
+internal class PersistentBuffSystem : ModPlayer
+{
+	private readonly record struct SavedProjectile(int type, int time, int damage, float knockBack);
+
+	private readonly List<SavedProjectile> _savedProjectiles = [];
+
+	public override void SaveData(TagCompound tag)
+	{
+		TagCompound projectiles = [];
+		int count = 0;
+
+		foreach (Projectile projectile in Main.ActiveProjectiles)
+		{
+			if (projectile.owner == Player.whoAmI && projectile.minion)
+			{
+				projectiles.Add("projType_" + count, projectile.type);
+				projectiles.Add("projTime_" + count, projectile.timeLeft);
+				projectiles.Add("projDamage_" + count, projectile.timeLeft);
+				projectiles.Add("projKnockback_" + count, projectile.knockBack);
+				count++;
+			}
+		}
+
+		if (count > 0)
+		{
+			projectiles.Add("count", count);
+			tag.Add("savedProjectiles", projectiles);
+		}
+	}
+
+	public override void LoadData(TagCompound tag)
+	{
+		if (tag.TryGet("savedProjectiles", out TagCompound projectiles))
+		{
+			int count = projectiles.GetInt("count");
+
+			for (int i = 0; i < count; ++i)
+			{
+				int type = projectiles.GetInt("projType_" + i);
+				int time = projectiles.GetInt("projTime_" + i);
+				int damage = projectiles.GetInt("projDamage_" + i);
+				float knockBack = projectiles.GetInt("projKnockback_" + i);
+
+				_savedProjectiles.Add(new SavedProjectile(type, time, damage, knockBack));
+			}
+		}
+	}
+
+	public override void OnEnterWorld()
+	{
+		Vector2 pos = Player.Center - new Vector2(0, 10);
+
+		foreach (SavedProjectile item in _savedProjectiles)
+		{
+			int proj = Projectile.NewProjectile(Player.GetSource_FromThis(), pos, Vector2.Zero, item.type, item.damage, item.knockBack, Player.whoAmI);
+			Main.projectile[proj].timeLeft = item.time;
+			Main.projectile[proj].netUpdate = true;
+		}
+
+		_savedProjectiles.Clear();
+	}
+}

--- a/Common/Systems/PersistentMinionsPlayer.cs
+++ b/Common/Systems/PersistentMinionsPlayer.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Systems;
 
-internal class PersistentBuffSystem : ModPlayer
+internal class PersistentMinionsPlayer : ModPlayer
 {
 	private readonly record struct SavedProjectile(int type, int time, int damage, float knockBack);
 
@@ -24,9 +23,13 @@ internal class PersistentBuffSystem : ModPlayer
 				projectiles.Add("projDamage_" + count, projectile.timeLeft);
 				projectiles.Add("projKnockback_" + count, projectile.knockBack);
 				count++;
+
+				// Store the projectile so this works in singleplayer, as while players ARE saved between subworlds,
+				// they are NOT loaded
+				_savedProjectiles.Add(new SavedProjectile(projectile.type, projectile.timeLeft, projectile.damage, projectile.knockBack));
 			}
 		}
-
+		
 		if (count > 0)
 		{
 			projectiles.Add("count", count);
@@ -45,7 +48,7 @@ internal class PersistentBuffSystem : ModPlayer
 				int type = projectiles.GetInt("projType_" + i);
 				int time = projectiles.GetInt("projTime_" + i);
 				int damage = projectiles.GetInt("projDamage_" + i);
-				float knockBack = projectiles.GetInt("projKnockback_" + i);
+				float knockBack = projectiles.GetFloat("projKnockback_" + i);
 
 				_savedProjectiles.Add(new SavedProjectile(type, time, damage, knockBack));
 			}

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Linq;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Content.Passives.Utility.Masteries;
 using Terraria.UI;
 
 #nullable enable
@@ -31,7 +31,7 @@ internal class MultiPassiveElement : PassiveElement
 		base.SafeUpdate(gameTime);
 
 		bool showsRadials = Children.Any();
-		bool shouldHaveRadials = ActivePassive == null && Passive.CanAllocate(Main.LocalPlayer);
+		bool shouldHaveRadials = (ActivePassive == null && Passive.CanAllocate(Main.LocalPlayer)) || GetDimensions().Center().DistanceSQ(Main.MouseScreen) < GetRadius();
 		bool shouldShowRadials = shouldHaveRadials || AnimationTime > 0;
 
 		AnimationTime = shouldHaveRadials ? Math.Min(AnimationTimeMax, AnimationTime + 1) : Math.Max(0, AnimationTime - 1);
@@ -49,6 +49,20 @@ internal class MultiPassiveElement : PassiveElement
 				RemoveAllChildren();
 			}
 		}
+	}
+
+	private float GetRadius()
+	{
+		float distance = 0f;
+		Vector2 center = Node.TreePos;
+
+		foreach (Passive line in InnerPassives)
+		{
+			Vector2 target = line.TreePos;
+			distance = MathF.Max(distance, center.DistanceSQ(target));
+		}
+
+		return distance + 120 * 120;
 	}
 
 	protected override void DrawSelf(SpriteBatch spriteBatch)

--- a/Common/UI/SkillsTree/AugmentSlotElement.cs
+++ b/Common/UI/SkillsTree/AugmentSlotElement.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers;

--- a/Content/Passives/Magic/Masteries/ManaBombMastery.cs
+++ b/Content/Passives/Magic/Masteries/ManaBombMastery.cs
@@ -11,20 +11,46 @@ internal class ManaBombMastery : Passive
 	{
 		int manaUsed = 0;
 
+		public override void Load()
+		{
+			On_Player.CheckMana_int_bool_bool += HijackCheckMana;
+		}
+
+		private static bool HijackCheckMana(On_Player.orig_CheckMana_int_bool_bool orig, Player self, int amount, bool pay, bool blockQuickMana)
+		{
+			bool success = orig(self, amount, pay, blockQuickMana);
+
+			if (!self.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ManaBombMastery>(out float value))
+			{
+				return success;
+			}
+
+			if (pay && success)
+			{
+				self.GetModPlayer<ManaBombPlayer>().manaUsed += amount;
+				self.GetModPlayer<ManaBombPlayer>().CheckSpawnManaBomb(self.GetSource_FromThis(), value);
+			}
+
+			return success;
+		}
+
 		public override void OnConsumeMana(Item item, int manaConsumed)
 		{
-			if (!Player.GetModPlayer<PassiveTreePlayer>().HasNode<ManaBombMastery>())
+			if (!Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ManaBombMastery>(out float value))
 			{
 				return;
 			}
 
 			manaUsed += manaConsumed;
+			CheckSpawnManaBomb(new EntitySource_ItemUse(Player, item), value);
+		}
 
+		private void CheckSpawnManaBomb(IEntitySource src, float value)
+		{
 			while (manaUsed > 100 && Main.myPlayer == Player.whoAmI)
 			{
 				float manaAdd = Player.statManaMax2 * 0.025f;
-				int damage = (int)Player.GetDamage(DamageClass.Magic).ApplyTo(Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<ManaBombMastery>() + manaAdd);
-				var src = new EntitySource_ItemUse(Player, item);
+				int damage = (int)Player.GetDamage(DamageClass.Magic).ApplyTo(value + manaAdd);
 				int target = GetTarget(out Vector2 fallback);
 				Projectile.NewProjectile(src, Player.Top, new Vector2(0, -6), ModContent.ProjectileType<ManaBomb>(), damage, 8, Player.whoAmI, target, fallback.X, fallback.Y);
 

--- a/Core/Items/PoTGlobalItem.IO.cs
+++ b/Core/Items/PoTGlobalItem.IO.cs
@@ -71,7 +71,7 @@ partial class PoTGlobalItem : GlobalItem
 	{
 		PoTInstanceItemData data = item.GetInstanceData();
 
-		writer.Write((byte)data.ItemType);
+		writer.Write((long)data.ItemType);
 		writer.Write((byte)data.Rarity);
 		writer.Write((byte)data.Influence);
 		writer.Write((byte)data.ImplicitCount);
@@ -93,7 +93,7 @@ partial class PoTGlobalItem : GlobalItem
 	{
 		PoTInstanceItemData data = item.GetInstanceData();
 
-		data.ItemType = (ItemType)reader.ReadByte();
+		data.ItemType = (ItemType)reader.ReadInt64();
 		data.Rarity = (ItemRarity)reader.ReadByte();
 		data.Influence = (Influence)reader.ReadByte();
 		data.ImplicitCount = reader.ReadByte();


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1560 
Resolves: #1589 
Resolves: #1583 
Resolves: #1566

### Description of Work
- Adds persistence systems for all summoned minions (but NOT sentries)
- Allowed hovering over unavailable masteries to see their options
- Fixed item types not being synced properly (sent as a byte instead of a long), causing several mostly visual issues
- Fixed Mana Bomb not accounting for all forms of mana usage