### PR TITLE
minor balance patches

### DIFF
--- a/Common/Buffs/ChilledFunctionality.cs
+++ b/Common/Buffs/ChilledFunctionality.cs
@@ -17,17 +17,31 @@ internal class ChilledFunctionality : GlobalBuff
 				modifier = Main.player[npc.lastInteraction].GetModPlayer<UniversalBuffingPlayer>().UniversalModifier.ChilledEffectiveness.ApplyTo(0.2f);
 			}
 
+			if (npc.boss)
+			{
+				modifier *= 0.33f;
+			}
+
 			npc.GetGlobalNPC<SlowDownNPC>().SpeedModifier += modifier;
 
 			if (Main.rand.NextBool(20))
 			{
 				Dust.NewDust(npc.position, npc.width, npc.height, DustID.Ice, npc.velocity.X, npc.velocity.Y);
 			}
+
+			if (npc.buffTime[buffIndex] == 2 && npc.TryGetGlobalNPC(out ChilledNPC chilled) && npc.boss)
+			{
+				chilled.BossChilledCooldown = 10 * 60;
+			}
 		}
 	}
 
 	private class ChilledNPC : GlobalNPC
 	{
+		public override bool InstancePerEntity => true;
+
+		internal int BossChilledCooldown = 0;
+
 		public override Color? GetAlpha(NPC npc, Color drawColor)
 		{
 			if (npc.HasBuff(BuffID.Chilled))

--- a/Common/Buffs/ChilledFunctionality.cs
+++ b/Common/Buffs/ChilledFunctionality.cs
@@ -8,7 +8,7 @@ internal class ChilledFunctionality : GlobalBuff
 {
 	public override void Update(int type, NPC npc, ref int buffIndex)
 	{
-		if (type == BuffID.Chilled)
+		if (type == BuffID.Chilled && npc.TryGetGlobalNPC(out ChilledNPC chilled) && chilled.BossChilledCooldown <= 0)
 		{
 			float modifier = 0.2f;
 
@@ -29,7 +29,7 @@ internal class ChilledFunctionality : GlobalBuff
 				Dust.NewDust(npc.position, npc.width, npc.height, DustID.Ice, npc.velocity.X, npc.velocity.Y);
 			}
 
-			if (npc.buffTime[buffIndex] == 2 && npc.TryGetGlobalNPC(out ChilledNPC chilled) && npc.boss)
+			if (npc.buffTime[buffIndex] == 2 && npc.boss)
 			{
 				chilled.BossChilledCooldown = 10 * 60;
 			}

--- a/Content/Passives/Magic/Masteries/CenterOfTheUniverseMastery.cs
+++ b/Content/Passives/Magic/Masteries/CenterOfTheUniverseMastery.cs
@@ -37,7 +37,7 @@ internal class CenterOfTheUniverseMastery : Passive
 
 				if (GetNextPlanetIndex(player, out int planetIndex, out _) && value / 100f > Main.rand.NextFloat())
 				{
-					int damage = (int)(damageDone * 0.2f);
+					int damage = (int)(damageDone * 0.35f);
 
 					Projectile.NewProjectile(source, player.Center, Vector2.Zero, type, damage, 6, player.whoAmI, 0, planetIndex, planetIndex switch
 					{

--- a/Content/Projectiles/PassiveProjectiles/OrbitingPlanet.cs
+++ b/Content/Projectiles/PassiveProjectiles/OrbitingPlanet.cs
@@ -26,6 +26,7 @@ internal class OrbitingPlanet : ModProjectile
 		Projectile.timeLeft = 2;
 		Projectile.tileCollide = false;
 		Projectile.frame = Main.rand.Next(5);
+		Projectile.penetrate = 2;
 	}
 
 	public override void AI()


### PR DESCRIPTION
### Description of Work
May fix #1612, #1613 

- Increased the amount of damage that planets from Center of the Universe deal
- Increased the penetration of planets from Center of the Universe from 1 to 2
- Gave Chilled on bosses a 10 second cooldown from being re-applied, 67% effectiveness reduction

### Comments
Didn't mark both issues listed as fixed as this may be too weak still or too strong (or both).