### PR TITLE
Quick misc fixes

### DIFF
--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -157,12 +157,10 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 {
 	public override bool HoverSlot(Item[] inventory, int context, int slot)
 	{
-		if (context != ItemSlot.Context.InventoryItem)
-		{
-			return false;
-		}
-
-		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null && ItemSlot.ShiftInUse)
+		if (ItemSlot.ShiftInUse
+		&& context == ItemSlot.Context.InventoryItem
+		&& SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null
+		&& inventory[slot] is { IsAir: false })
 		{
 			Main.cursorOverride = CursorOverrideID.InventoryToChest;
 			return true;
@@ -173,12 +171,10 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 
 	public override bool ShiftClickSlot(Item[] inventory, int context, int slot)
 	{
-		if (context != ItemSlot.Context.InventoryItem)
-		{
-			return false;
-		}
-
-		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
+		if (ItemSlot.ShiftInUse
+		&& context == ItemSlot.Context.InventoryItem
+		&& inventory[slot] is { IsAir: false }
+		&& SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
 		{
 			Item[] storage = MapDeviceInterface.Entity.Storage;
 
@@ -190,7 +186,7 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 				Item invItem = inventory[slot].Clone();
 				inventory[slot].TurnToAir();
 				item = invItem;
-				SoundEngine.PlaySound(SoundID.MenuTick);
+				SoundEngine.PlaySound(SoundID.Grab);
 				break;
 			}
 

--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -182,16 +182,16 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 		{
 			Item[] storage = MapDeviceInterface.Entity.Storage;
 
-			for (int i = 0; i < MapDeviceEntity.StorageSize; ++i)
+			for (int i = 0; i < MapDeviceEntity.StorageSize; i++)
 			{
 				ref Item item = ref storage[i];
+				if (!item.IsAir) { continue; }
 
-				if (item.IsAir)
-				{
-					Item invItem = inventory[slot].Clone();
-					inventory[slot].TurnToAir();
-					item = invItem;
-				}
+				Item invItem = inventory[slot].Clone();
+				inventory[slot].TurnToAir();
+				item = invItem;
+				SoundEngine.PlaySound(SoundID.MenuTick);
+				break;
 			}
 
 			return true;

--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -153,6 +153,55 @@ internal sealed class MapDeviceInterface : ModSystem
 	}
 }
 
+internal class MapDeviceShiftClickPlayer : ModPlayer
+{
+	public override bool HoverSlot(Item[] inventory, int context, int slot)
+	{
+		if (inventory.Length != Main.InventorySlotsTotal + 1)
+		{
+			return false;
+		}
+
+		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null && ItemSlot.ShiftInUse)
+		{
+			Main.cursorOverride = CursorOverrideID.InventoryToChest;
+			return true;
+		}
+		
+		return false;
+	}
+
+	public override bool ShiftClickSlot(Item[] inventory, int context, int slot)
+	{
+		// Inventory length check is an awkward way to check if the inventory given is the player's actual inventory, not storage - perhaps find something better?
+		if (inventory.Length != Main.InventorySlotsTotal + 1)
+		{
+			return false;
+		}
+
+		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
+		{
+			Item[] storage = MapDeviceInterface.Entity.Storage;
+
+			for (int i = 0; i < MapDeviceEntity.StorageSize; ++i)
+			{
+				ref Item item = ref storage[i];
+
+				if (item.IsAir)
+				{
+					Item invItem = inventory[slot].Clone();
+					inventory[slot].TurnToAir();
+					item = invItem;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+}
+
 internal sealed class MapDeviceState : SmartUiState //UIState
 {
 	// Drawers have to be UI elements to render in time for scissoring areas to function.

--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -157,7 +157,7 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 {
 	public override bool HoverSlot(Item[] inventory, int context, int slot)
 	{
-		if (inventory.Length != Main.InventorySlotsTotal + 1)
+		if (context != ItemSlot.Context.InventoryItem)
 		{
 			return false;
 		}
@@ -173,8 +173,7 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 
 	public override bool ShiftClickSlot(Item[] inventory, int context, int slot)
 	{
-		// Inventory length check is an awkward way to check if the inventory given is the player's actual inventory, not storage - perhaps find something better?
-		if (inventory.Length != Main.InventorySlotsTotal + 1)
+		if (context != ItemSlot.Context.InventoryItem)
 		{
 			return false;
 		}

--- a/Common/NPCs/DropRules/HasQuest.cs
+++ b/Common/NPCs/DropRules/HasQuest.cs
@@ -1,0 +1,24 @@
+﻿using PathOfTerraria.Common.Systems.Questing;
+using Terraria.GameContent.ItemDropRules;
+
+namespace PathOfTerraria.Common.NPCs.DropRules;
+
+internal class HasQuest(string questKey) : IItemDropRuleCondition
+{
+	private readonly string _questKey = questKey;
+
+	public bool CanDrop(DropAttemptInfo info)
+	{
+		return Quest.PlayerHasQuest(info.player.whoAmI, _questKey);
+	}
+
+	public bool CanShowItemDropInUI()
+	{
+		return false;
+	}
+
+	public string GetConditionDescription()
+	{
+		return "";
+	}
+}

--- a/Common/Subworlds/BossDomains/Hardmode/QueenDomain/QueenDomainCoreDrop.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenDomain/QueenDomainCoreDrop.cs
@@ -1,0 +1,20 @@
+﻿using PathOfTerraria.Common.NPCs.DropRules;
+using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
+using PathOfTerraria.Content.Items.Quest;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.Subworlds.BossDomains.Hardmode.QueenDomain;
+
+internal class QueenDomainCoreDrop : GlobalNPC
+{
+	public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
+	{
+		if (npc.type == NPCID.QueenSlimeBoss)
+		{
+			LeadingConditionRule rule = new(new HasQuest(ModContent.GetInstance<QueenSlimeQuest>().FullName));
+			rule.OnSuccess(ItemDropRule.Common(ModContent.ItemType<RoyalJellyCore>()));
+			npcLoot.Add(rule);
+		}
+	}
+}

--- a/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
@@ -6,7 +6,6 @@ using PathOfTerraria.Content.Tiles.BossDomain;
 using PathOfTerraria.Core.Items;
 using System.Collections.Generic;
 using System.Linq;
-using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Content.Items.Quest;
@@ -460,8 +459,7 @@ internal class QueenSlimeDomain : BossDomainSubworld
 				Main.spawnTileX = ArenaPos.X;
 				Main.spawnTileY = ArenaPos.Y;
 
-				NPC.NewNPC(Entity.GetSource_NaturalSpawn(), ArenaPos.X * 16, (ArenaPos.Y + 20) * 16,
-					NPCID.QueenSlimeBoss);
+				NPC.NewNPC(Entity.GetSource_NaturalSpawn(), ArenaPos.X * 16, (ArenaPos.Y + 20) * 16, NPCID.QueenSlimeBoss);
 
 				if (Main.netMode == NetmodeID.Server)
 				{
@@ -473,16 +471,6 @@ internal class QueenSlimeDomain : BossDomainSubworld
 		{
 			IEntitySource src = Entity.GetSource_NaturalSpawn();
 			Projectile.NewProjectile(src, ArenaPos.ToWorldCoordinates(), Vector2.Zero, ModContent.ProjectileType<ExitPortal>(), 0, 0, Main.myPlayer);
-			
-			// Drop RoyalJellyCore for players with active Queen Slime quest
-			foreach (Player player in Main.ActivePlayers)
-			{
-				var queenSlimeQuest = Quest.GetLocalPlayerInstance<QueenSlimeQuest>();
-				if (queenSlimeQuest.Active)
-				{
-					player.QuickSpawnItem(src, ModContent.ItemType<RoyalJellyCore>());
-				}
-			}
 		}
 	}
 }

--- a/Common/Systems/Questing/Quest.cs
+++ b/Common/Systems/Questing/Quest.cs
@@ -1,5 +1,7 @@
 ﻿using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using System.Collections.Generic;
+using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.IO;
 
@@ -14,6 +16,9 @@ public abstract class Quest : ModType, ILocalizedModType
 		Completed,
 	}
 
+	/// <summary>
+	/// A non-synced dictionary filled with singletons of every quest in the mod. Should not be modified.
+	/// </summary>
 	private static readonly Dictionary<string, Quest> QuestsByName = [];
 
 	private State state;
@@ -110,7 +115,8 @@ public abstract class Quest : ModType, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Gets the actual instance of the given quest on the local player. If the instance does not exist for some reason, adds it.
+	/// Gets the actual instance of the given quest on the local player. If the instance does not exist for some reason, adds it.<br/>
+	/// <b>This does not work in multiplayer.</b> It's just shorthand, use 
 	/// </summary>
 	/// <param name="name">The name of the quest to get.</param>
 	/// <returns>The in-use quest instance for the local player.</returns>
@@ -133,6 +139,20 @@ public abstract class Quest : ModType, ILocalizedModType
 	public static Quest GetLocalPlayerInstance<T>() where T : Quest
 	{
 		return GetLocalPlayerInstance(ModContent.GetInstance<T>().FullName);
+	}
+
+	/// <summary>
+	/// Used to check if the given player has a given quest in multiplayer, as <see cref="GetLocalPlayerInstance(string)"/> is not synced.
+	/// </summary>
+	public static bool PlayerHasQuest(int who, string questName)
+	{
+		return Main.player[who].GetModPlayer<QuestModPlayer>().EnabledQuestsByName.Contains(questName);
+	}
+
+	/// <inheritdoc cref="PlayerHasQuest(int, string)"/>
+	public static bool PlayerHasQuest<T>(int who) where T : Quest
+	{
+		return PlayerHasQuest(who, ModContent.GetInstance<T>().FullName);
 	}
 
 	public virtual void OnCompleted()
@@ -159,6 +179,13 @@ public abstract class Quest : ModType, ILocalizedModType
 
 		GiveRewards(player);
 		OnCompleted();
+
+		player.GetModPlayer<QuestModPlayer>().EnabledQuestsByName.Remove(Name);
+
+		if (player.whoAmI == Main.myPlayer && Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			SyncPlayerQuestActive.Send(FullName, false);
+		}
 	}
 
 	public void GiveRewards(Player player)

--- a/Common/Systems/Questing/QuestModPlayer.cs
+++ b/Common/Systems/Questing/QuestModPlayer.cs
@@ -2,10 +2,12 @@
 using System.Linq;
 using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using PathOfTerraria.Common.UI.Quests;
 using PathOfTerraria.Core.UI.SmartUI;
 using Terraria.Audio;
 using Terraria.GameInput;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Systems.Questing;
@@ -15,10 +17,18 @@ public class QuestModPlayer : ModPlayer
 	// ReSharper disable once InconsistentNaming
 	internal static ModKeybind ToggleQuestUIKey;
 
+	/// <summary>
+	/// A non-synced list of every quest this player can have.
+	/// </summary>
 	public Dictionary<string, Quest> QuestsByName = [];
 
 	public Dictionary<string, QuestMarkerType> MarkerTypeByLocation = [];
-	
+
+	/// <summary>
+	/// A fully synced list of the quests this player currently has active.
+	/// </summary>
+	public readonly HashSet<string> EnabledQuestsByName = [];
+
 	internal bool FirstQuest = true;
 	/// <summary> The full name of this player's pinned quest. </summary>
 	public string PinnedQuest;
@@ -39,6 +49,7 @@ public class QuestModPlayer : ModPlayer
 	public void StartQuest(string name, int step = -1, bool fromLoad = false)
 	{
 		QuestsByName[name].Start(Player, step == -1 ? 0 : step);
+		EnabledQuestsByName.Add(name);
 
 		if (Main.myPlayer == Player.whoAmI && !fromLoad)
 		{
@@ -50,6 +61,27 @@ public class QuestModPlayer : ModPlayer
 				UIQuestPopupState.FlashQuestButton = 600;
 
 				FirstQuest = false;
+			}
+
+			if (Main.netMode != NetmodeID.SinglePlayer)
+			{
+				SyncPlayerQuestActive.Send(name, true);
+			}
+		}
+	}
+
+	public override void OnEnterWorld()
+	{
+		foreach (Quest quest in QuestsByName.Values)
+		{
+			if (quest.Active)
+			{
+				EnabledQuestsByName.Add(quest.FullName);
+
+				if (Main.netMode != NetmodeID.SinglePlayer)
+				{
+					SyncPlayerQuestActive.Send(quest.FullName, true);
+				}
 			}
 		}
 	}

--- a/Common/Systems/Skills/SkillTree.cs
+++ b/Common/Systems/Skills/SkillTree.cs
@@ -118,7 +118,7 @@ public abstract class SkillTree : ILoadable
 	{
 		string skillName = skill.Name;
 
-		IList<string> names = tag.GetList<string>("passives"); //Load passives
+		IList<string> names = tag.GetList<string>("passives");
 		IList<int> levels = tag.GetList<int>("levels");
 
 		for (int i = 0; i < names.Count; i++)
@@ -128,6 +128,8 @@ public abstract class SkillTree : ILoadable
 
 		var special = (SkillSpecial)Nodes.FirstOrDefault(x => x is SkillSpecial && x.Name == tag.GetString("special"));
 		Specialization = special;
+
+		Augments.Clear(); // Reset augments so we don't infinitely add augments every load
 
 		IList<string> augmentNames = tag.GetList<string>("augmentNames");
 		IList<bool> augmentUnlocked = tag.GetList<bool>("augmentUnlocks");

--- a/Common/Systems/Synchronization/Handlers/SyncPlayerQuestActive.cs
+++ b/Common/Systems/Synchronization/Handlers/SyncPlayerQuestActive.cs
@@ -1,0 +1,37 @@
+﻿using PathOfTerraria.Common.Systems.Questing;
+using System.IO;
+
+namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
+
+internal class SyncPlayerQuestActive : Handler
+{
+	public override Networking.Message MessageType => Networking.Message.PlayerQuestActive;
+
+	public static void Send(string quest, bool enabled, int toClient = -1, int ignoreClient = -1)
+	{
+		ModPacket packet = Networking.GetPacket(Networking.Message.PlayerQuestActive);
+		packet.Write(quest);
+		packet.Write(enabled);
+		packet.Send(toClient, ignoreClient);
+	}
+
+	internal override void Receive(BinaryReader reader, byte sender)
+	{
+		string questName = reader.ReadString();
+		bool enabled = reader.ReadBoolean();
+
+		if (enabled)
+		{
+			Main.player[sender].GetModPlayer<QuestModPlayer>().EnabledQuestsByName.Add(questName);
+		}
+		else
+		{
+			Main.player[sender].GetModPlayer<QuestModPlayer>().EnabledQuestsByName.Remove(questName);
+		}
+
+		if (Main.dedServ)
+		{
+			Send(questName, enabled, -1, sender);
+		}
+	}
+}

--- a/Common/Systems/Synchronization/Networking.cs
+++ b/Common/Systems/Synchronization/Networking.cs
@@ -194,10 +194,10 @@ internal static class Networking
 		/// </summary>
 		PlayerUseSackOfHolding,
 
-    /// <summary>
-    /// Flags a quest as enabled on all clients + server.<br/>Signature<br/>
-    /// <c>string questName, bool enabled</c>
-    /// </summary>
+		/// <summary>
+		/// Flags a quest as enabled on all clients + server.<br/>Signature<br/>
+		/// <c>string questName, bool enabled</c>
+		/// </summary>
 		PlayerQuestActive,
     
 		/// <summary>

--- a/Common/Systems/Synchronization/Networking.cs
+++ b/Common/Systems/Synchronization/Networking.cs
@@ -193,6 +193,8 @@ internal static class Networking
 		/// <c>byte player, bool enabled</c>
 		/// </summary>
 		PlayerUseSackOfHolding,
+
+		PlayerQuestActive,
 	}
 
 	internal static void HandlePacket(BinaryReader reader, byte sender)

--- a/Content/Passives/Magic/Masteries/MagicGuardMastery.cs
+++ b/Content/Passives/Magic/Masteries/MagicGuardMastery.cs
@@ -11,7 +11,7 @@ internal class MagicGuardMastery : Passive
 		{
 			if (Player.GetModPlayer<PassiveTreePlayer>().HasNode<MagicGuardMastery>() && Player.statMana > Player.statManaMax2 * 0.5f)
 			{
-				modifiers.FinalDamage -= 0.92f;
+				modifiers.FinalDamage -= 0.08f;
 			}
 		}
 	}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1642 
Resolves: #1637 
Resolves: #1632 
Resolves: #1594 

### Description of Work
- Fixed augments not being reset on load before being loaded from save, causing exponentially duplicating augments
- Added functionality for the Map Device's UI to have shift click in/out
- Added system to have a synced way for all players/server to know what quest(s) a player has on for future use
- Fixed Queen Slime quest drop not dropping properly in multiplayer
- Fixed Magic Guard reducing damage by 92% instead of 8% lol