### PR TITLE
Workaround for external CurrentPlayerOverride leaks.

### DIFF
--- a/Common/UI/Armor/Elements/UIArmorPage.cs
+++ b/Common/UI/Armor/Elements/UIArmorPage.cs
@@ -84,7 +84,10 @@ public abstract class UIArmorPage : UIElement
 	{
 		base.Update(gameTime);
 
-		// Recreate the UI every time it is opened, just so that it doesn't lag back in case of unpredictable changes with the accessory slots.
+		// Casually patch up the game in case someone broke it.
+		CheckAndFixPlayerOverrides();
+
+		// Recreate the UI every time it is opened, just so that it does not lag back in case of unpredictable changes with the accessory slots.
 		if (Main.playerInventory && !wasInventoryOpen)
 		{
 			Main.QueueMainThreadAction(() =>
@@ -190,9 +193,39 @@ public abstract class UIArmorPage : UIElement
 				uiSlot.HAlign = (numLocationsTaken % 3) * 0.5f;
 				uiSlot.VAlign = (numLocationsTaken / 3) * 0.25f;
 				numLocationsTaken++;
-
-				Debug.Assert(ModAccessorySlot.Player == Main.LocalPlayer);
 			}
 		}
+	}
+
+	private static void CheckAndFixPlayerOverrides()
+	{
+		// Current player should never be overridden during UI updates! If it is, then someone is to blame.
+		if (ModAccessorySlot.Player != Main.LocalPlayer)
+		{
+			(Player? loc, Player? cur) = (Main.LocalPlayer, Main.CurrentPlayer);
+			string errorText = $"""
+				A leak of Main.CurrentPlayerOverride's effects have been detected due to actions of an unknown mod.
+				LocalPlayer is:   {loc?.GetHashCode().ToString("x") ?? "null"}, named '{loc?.name ?? "null"}';
+				CurrentPlayer is: {cur?.GetHashCode().ToString("x") ?? "null"}, named '{cur?.name ?? "null"}';
+				Correcting.
+				""";
+			PoTMod.Instance.Logger.Error(errorText);
+
+			Debugger.Break();
+
+			// We do not dispose this on purpose, to override effects of another override that hasn't been disposed.
+			// Using null means that the override will be disabled.
+			var leakToFixLeaks = new Main.CurrentPlayerOverride(player: null);
+		}
+#if DEBUG && false
+		// Issue reproduction:
+		else if (Main.keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.OemCloseBrackets)
+		&& !Main.oldKeyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.OemCloseBrackets)
+		&& Main.mouseXButton2Release)
+		{
+			var badPlayerOverride = new Main.CurrentPlayerOverride(new Player());
+			Main.mouseXButton2Release = false; // Just to prevent double activations, not actually checking for mouse presses.
+		}
+#endif
 	}
 }

--- a/Common/UI/Armor/Elements/UIArmorPage.cs
+++ b/Common/UI/Armor/Elements/UIArmorPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using PathOfTerraria.Common.AccessorySlots;
@@ -37,6 +38,7 @@ public abstract class UIArmorPage : UIElement
 
 	private readonly List<(ModAccessorySlot Slot, UIHoverImageItemSlot UI)> customSlots = [];
 	private UIHoverImageItemSlot?[] defaultSlots = [];
+	private bool wasInventoryOpen;
 
 	protected abstract Asset<Texture2D> DefaultFrameTexture { get; }
 
@@ -82,7 +84,22 @@ public abstract class UIArmorPage : UIElement
 	{
 		base.Update(gameTime);
 
-		MaintainCustomAccessorySlots(CollectionsMarshal.AsSpan(customSlots));
+		// Recreate the UI every time it is opened, just so that it doesn't lag back in case of unpredictable changes with the accessory slots.
+		if (Main.playerInventory && !wasInventoryOpen)
+		{
+			Main.QueueMainThreadAction(() =>
+			{
+				RemoveAllChildren();
+				AddChildren();
+				Recalculate();
+			});
+		}
+		else
+		{
+			MaintainCustomAccessorySlots(CollectionsMarshal.AsSpan(customSlots));
+		}
+
+		wasInventoryOpen = Main.playerInventory;
 	}
 
 	public void AddChildren()
@@ -90,6 +107,7 @@ public abstract class UIArmorPage : UIElement
 		int numAccessorySlots = 0;
 
 		defaultSlots = GetDefaultSlots(ref numAccessorySlots);
+		customSlots.Clear();
 
 		AccessorySlotLoader accessoryLoader = LoaderManager.Get<AccessorySlotLoader>();
 		ModAccessorySlotPlayer accessoryPlayer = Player.GetModPlayer<ModAccessorySlotPlayer>();
@@ -135,6 +153,9 @@ public abstract class UIArmorPage : UIElement
 				uiSlot.VAlign = (numLocationsTaken / 3) * 0.25f;
 				numLocationsTaken++;
 
+				// Make sure the slot is properly initialized before appending
+				if (uiSlot.Icon == null) { uiSlot.OnInitialize(); }
+
 				Append(uiSlot);
 			}
 		}
@@ -169,6 +190,8 @@ public abstract class UIArmorPage : UIElement
 				uiSlot.HAlign = (numLocationsTaken % 3) * 0.5f;
 				uiSlot.VAlign = (numLocationsTaken / 3) * 0.25f;
 				numLocationsTaken++;
+
+				Debug.Assert(ModAccessorySlot.Player == Main.LocalPlayer);
 			}
 		}
 	}

--- a/Common/UI/Armor/Elements/UIArmorPage.cs
+++ b/Common/UI/Armor/Elements/UIArmorPage.cs
@@ -84,9 +84,6 @@ public abstract class UIArmorPage : UIElement
 	{
 		base.Update(gameTime);
 
-		// Casually patch up the game in case someone broke it.
-		CheckAndFixPlayerOverrides();
-
 		// Recreate the UI every time it is opened, just so that it does not lag back in case of unpredictable changes with the accessory slots.
 		if (Main.playerInventory && !wasInventoryOpen)
 		{
@@ -195,37 +192,5 @@ public abstract class UIArmorPage : UIElement
 				numLocationsTaken++;
 			}
 		}
-	}
-
-	private static void CheckAndFixPlayerOverrides()
-	{
-		// Current player should never be overridden during UI updates! If it is, then someone is to blame.
-		if (ModAccessorySlot.Player != Main.LocalPlayer)
-		{
-			(Player? loc, Player? cur) = (Main.LocalPlayer, Main.CurrentPlayer);
-			string errorText = $"""
-				A leak of Main.CurrentPlayerOverride's effects have been detected due to actions of an unknown mod.
-				LocalPlayer is:   {loc?.GetHashCode().ToString("x") ?? "null"}, named '{loc?.name ?? "null"}';
-				CurrentPlayer is: {cur?.GetHashCode().ToString("x") ?? "null"}, named '{cur?.name ?? "null"}';
-				Correcting.
-				""";
-			PoTMod.Instance.Logger.Error(errorText);
-
-			Debugger.Break();
-
-			// We do not dispose this on purpose, to override effects of another override that hasn't been disposed.
-			// Using null means that the override will be disabled.
-			var leakToFixLeaks = new Main.CurrentPlayerOverride(player: null);
-		}
-#if DEBUG && false
-		// Issue reproduction:
-		else if (Main.keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.OemCloseBrackets)
-		&& !Main.oldKeyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.OemCloseBrackets)
-		&& Main.mouseXButton2Release)
-		{
-			var badPlayerOverride = new Main.CurrentPlayerOverride(new Player());
-			Main.mouseXButton2Release = false; // Just to prevent double activations, not actually checking for mouse presses.
-		}
-#endif
 	}
 }


### PR DESCRIPTION
### Description of Work
- ~~Introduced a workaround for an issue where modded accessory slots (3 & 4) can begin pointing to the wrong player instance's inventory, thus becoming "locked out" from swapping, and eventually causing item duplication. This is suspected to be caused by a wrongdoing of an external mod, though it is yet to be linked to a concrete line of code.~~
    - This is now fixed from tModLoader's side, workaround now reverted here.
- Made inventory UI more robust when it comes to handling unloaded modded accessory slots.

### Comments
Will send testers a special build of tModLoader to help log and fix the proper cause of the issue. Earlier one the nature of  the issue has been confirmed with a debug assertion being hit.