### PR TITLE
Some misc fixes yay

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -36,15 +36,13 @@ public class AffixRegistry : ILoadable
 	/// <returns><see cref="Models.ItemAffixData"/> instance of the given type.</returns>
 	public static ItemAffixData TryGetAffixData(Type type)
 	{
-		try
+		if (ItemAffixData.TryGetValue(type, out ItemAffixData value))
 		{
-			return ItemAffixData[type];
+			return value;
 		}
-		catch (KeyNotFoundException exception)
-		{
-			Console.WriteLine($"ItemAffixData with type {type.Name} not found.\n\n{exception}");
-			return null;
-		}
+
+		Console.WriteLine($"ItemAffixData with type {type.Name} not found.");
+		return null;
 	}
 
 	/// <summary>

--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -41,7 +41,7 @@ public class AffixRegistry : ILoadable
 			return value;
 		}
 
-		Console.WriteLine($"ItemAffixData with type {type.Name} not found.");
+		PoTMod.Instance.Logger.Error($"ItemAffixData with type {type.Name} not found.");
 		return null;
 	}
 

--- a/Common/Subworlds/BossDomains/Prehardmode/BoCDomain/BoCDomainSystem.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/BoCDomain/BoCDomainSystem.cs
@@ -80,7 +80,7 @@ internal class BoCDomainSystem : ModSystem
 			}
 		}
 
-		if (SubworldSystem.Current is null && !SubworldSystem.IsActive<BrainDomain>())
+		if (SubworldSystem.Current is null)
 		{
 			if (HasLloyd)
 			{

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -97,7 +97,6 @@ public class RavencrestSystem : ModSystem
 
 	public override void PreUpdateTime()
 	{
-		Main.NewText(Main.MouseWorld.ToTileCoordinates());
 		ReturnNativeNpcs();
 
 		if (NPC.downedBoss2 && !DisableOrbBreaking.CanBreakOrb)

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -97,6 +97,7 @@ public class RavencrestSystem : ModSystem
 
 	public override void PreUpdateTime()
 	{
+		Main.NewText(Main.MouseWorld.ToTileCoordinates());
 		ReturnNativeNpcs();
 
 		if (NPC.downedBoss2 && !DisableOrbBreaking.CanBreakOrb)
@@ -223,7 +224,7 @@ public class RavencrestSystem : ModSystem
 			
 				// Only try to read signs if the tile is actually a sign
 				Tile tile = Main.tile[i, j];
-				if (tile.HasTile && (tile.TileType == TileID.Signs || tile.TileType == TileID.AnnouncementBox))
+				if (tile.HasTile && (tile.TileType == TileID.Signs || tile.TileType == TileID.AnnouncementBox || tile.TileType == TileID.TatteredWoodSign))
 				{
 					int sign = Sign.ReadSign(i, j, true);
 
@@ -231,9 +232,9 @@ public class RavencrestSystem : ModSystem
 					{
 						string text = i switch
 						{
-							< 220 => "the Iron Anvil",
-							< 360 => "The Lodge",
-							_ => "<-- Lodge, Forge\nLibrary, Hovel -->"
+							< 220 => Language.GetTextValue("Mods.PathOfTerraria.Misc.RavencrestSigns.Anvil"),
+							< 310 => Language.GetTextValue("Mods.PathOfTerraria.Misc.RavencrestSigns.Lodge"),
+							_ => Language.GetTextValue("Mods.PathOfTerraria.Misc.RavencrestSigns.Split")
 						};
 
 						Sign.TextSign(sign, text);

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -6,10 +6,12 @@ using Terraria.Localization;
 
 namespace PathOfTerraria.Common.Systems.Affixes;
 
+#nullable enable
+
 public abstract class ItemAffix : Affix
 {
-	public Influence RequiredInfluence => GetData().GetInfluences();
-	public ItemType PossibleTypes => GetData().GetEquipTypes();
+	public Influence RequiredInfluence => GetData()?.GetInfluences() ?? Influence.None;
+	public ItemType PossibleTypes => GetData()?.GetEquipTypes() ?? ItemType.None;
 
 	public virtual void ApplyAffix(Player player, EntityModifier modifier, Item item) { }
 
@@ -29,7 +31,21 @@ public abstract class ItemAffix : Affix
 
 	protected virtual AffixTooltipLine CreateDefaultTooltip(Player player, int itemLevel)
 	{
-		ItemAffixData data = GetData();
+		ItemAffixData? data = GetData();
+
+		if (data is null) // Data can be null if the affix doesn't exist in the json data. This skips the checks below.
+		{
+			return new AffixTooltipLine
+			{
+				Text = this.GetLocalization("Description"),
+				Value = Value,
+				Tier = null,
+				ValueRollRange = null,
+				Corrupt = IsCorruptedAffix,
+				Implicit = IsImplicit,
+			};
+		}
+
 		ItemAffixData.TierData tierData = data.Tiers[Tier];
 		
 		(int tierMin, int tierMax) = data.GetPossibleTierRange(itemLevel);
@@ -55,7 +71,7 @@ public abstract class ItemAffix : Affix
 	/// Retrieves the affix data for the current <see cref="ItemAffix"/> instance.
 	/// </summary>
 	/// <returns></returns>
-	public ItemAffixData GetData()
+	public ItemAffixData? GetData()
 	{
 		return AffixRegistry.TryGetAffixData(GetType());
 	}

--- a/Common/UI/GrimoireSelection/GrimoireInvButton.cs
+++ b/Common/UI/GrimoireSelection/GrimoireInvButton.cs
@@ -41,6 +41,7 @@ public class GrimoireInvButton : SmartUiState
 			player.noThrow = 2;
 			player.cursorItemIconID = -1;
 			player.cursorItemIconEnabled = true;
+			player.mouseInterface = true;
 		}
 
 		if (hover != _lastHover)
@@ -65,7 +66,12 @@ public class GrimoireInvButton : SmartUiState
 		if (index != -1)
 		{
 			// Set held item to Grimoire so the UI doesn't instantly close
-			Main.LocalPlayer.selectedItem = index;
+			if (!SmartUiLoader.GetUiState<GrimoireSelectionUIState>().Visible)
+			{
+				GrimoireSelectionUIState.OldSelectedItem = Main.LocalPlayer.selectedItem;
+				Main.LocalPlayer.selectedItem = index;
+			}
+
 			SmartUiLoader.GetUiState<GrimoireSelectionUIState>().Toggle();
 			SoundEngine.PlaySound(SoundID.MenuOpen);
 		}

--- a/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
+++ b/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
@@ -47,6 +47,8 @@ internal class GrimoireSelectionUIState : CloseableSmartUi, IMutuallyExclusiveUI
 		}
 	}
 
+	internal static int OldSelectedItem = -1;
+
 	private readonly static Player _modificationsPlayer = new();
 
 	private static UIGrid _storageGrid = null;
@@ -213,6 +215,13 @@ internal class GrimoireSelectionUIState : CloseableSmartUi, IMutuallyExclusiveUI
 		{
 			_storageGrid.Clear();
 			_storageGrid = null;
+
+			if (OldSelectedItem != -1)
+			{
+				Main.LocalPlayer.selectedItem = OldSelectedItem;
+				OldSelectedItem = -1;
+			}
+
 			return;
 		}
 
@@ -242,6 +251,7 @@ internal class GrimoireSelectionUIState : CloseableSmartUi, IMutuallyExclusiveUI
 			Toggle();
 			SoundEngine.PlaySound(SoundID.MenuClose, Main.LocalPlayer.Center);
 		};
+
 		CloseButton.SetVisibility(1, 1);
 		Panel.Append(CloseButton);
 

--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -6,6 +6,7 @@ using PathOfTerraria.Common.UI.PassiveTree;
 using PathOfTerraria.Common.UI.SkillsTree;
 using PathOfTerraria.Common.UI.Utilities;
 using PathOfTerraria.Content.Passives;
+using PathOfTerraria.Content.Passives.Misc;
 using PathOfTerraria.Core.UI.SmartUI;
 using Terraria.GameContent.UI.Elements;
 using Terraria.Localization;
@@ -170,7 +171,7 @@ internal class TreeState : TabsUiState
 		{
 			foreach (Passive node in LocalPassiveTreePlayer.ActiveNodes)
 			{
-				if (node is AnchorPassive)
+				if (node is AnchorPassive or MasteryPassive)
 				{
 					continue;
 				}

--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -26,9 +26,11 @@ internal class TreeState : TabsUiState
 
 	public override List<SmartUiElement> TabPanels => [_passiveTreeInner, _skillSelection];
 
-	protected static PassiveTreePlayer PassiveTreeSystem => Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
+	protected static PassiveTreePlayer LocalPassiveTreePlayer => Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>();
 
 	public override int DepthPriority => 1;
+
+	private int _confirmTimer = 0;
 
 	public override int InsertionIndex(List<GameInterfaceLayer> layers)
 	{
@@ -37,6 +39,8 @@ internal class TreeState : TabsUiState
 
 	public override void SafeUpdate(GameTime gameTime)
 	{
+		_confirmTimer--;
+
 		if (Panel is not null)
 		{
 			Panel.Left = StyleDimension.FromPixels(ShrinkX);
@@ -89,11 +93,11 @@ internal class TreeState : TabsUiState
 	{
 		_passiveTreeInner.RemoveAllChildren();
 
-		PassiveTreeSystem.CreateTree();
+		LocalPassiveTreePlayer.CreateTree();
 
 		// Add nodes
-		var mapping = new Dictionary<int, AllocatableElement>(capacity: PassiveTreeSystem.ActiveNodes.Count);
-		foreach (Passive passive in PassiveTreeSystem.ActiveNodes)
+		var mapping = new Dictionary<int, AllocatableElement>(capacity: LocalPassiveTreePlayer.ActiveNodes.Count);
+		foreach (Passive passive in LocalPassiveTreePlayer.ActiveNodes)
 		{
 			if (passive.IsHidden)
 			{
@@ -116,8 +120,8 @@ internal class TreeState : TabsUiState
 
 		// Add edges
 		_passiveTreeInner.Connections.Clear();
-		_passiveTreeInner.Connections.EnsureCapacity(PassiveTreeSystem.Edges.Count);
-		foreach (Edge<Allocatable> edge in PassiveTreeSystem.Edges)
+		_passiveTreeInner.Connections.EnsureCapacity(LocalPassiveTreePlayer.Edges.Count);
+		foreach (Edge<Allocatable> edge in LocalPassiveTreePlayer.Edges)
 		{
 			if (edge is { Start: Passive start, End: Passive end }
 			&& mapping.TryGetValue(start.ReferenceId, out AllocatableElement uiStart)
@@ -162,7 +166,23 @@ internal class TreeState : TabsUiState
 			return;
 		}
 		
-		AvailablePassivePointsText.DrawAvailablePassivePoint(spriteBatch, points, GetRectangle().TopLeft() + pointsDrawPoin);
+		AvailablePassivePointsText.DrawResettablePoints(spriteBatch, points, GetRectangle().TopLeft() + pointsDrawPoin, ref _confirmTimer, () =>
+		{
+			foreach (Passive node in LocalPassiveTreePlayer.ActiveNodes)
+			{
+				if (node is AnchorPassive)
+				{
+					continue;
+				}
+
+				// Level will rarely be >0 but whatever, free check
+				while (node.Level > 0)
+				{
+					node.OnDeallocate(Main.LocalPlayer);
+					LocalPassiveTreePlayer.Points++;
+				}
+			}
+		});
 	}
 
 	internal void SetSkillTree(Skill skill)

--- a/Common/UI/Utilities/AvailablePassivePointsText.cs
+++ b/Common/UI/Utilities/AvailablePassivePointsText.cs
@@ -1,13 +1,49 @@
-﻿using Terraria.Localization;
+﻿using Terraria.GameContent;
+using Terraria.Localization;
+using Terraria.UI.Chat;
 
 namespace PathOfTerraria.Common.UI.Utilities;
 
 public class AvailablePassivePointsText
 {
+	public static void DrawResettablePoints(SpriteBatch spriteBatch, int points, Vector2 position, ref int confirmTimer, Action onReset)
+	{
+		DrawAvailablePassivePoint(spriteBatch, points, position);
+
+		string text = Language.GetTextValue("Mods.PathOfTerraria.UI." + (confirmTimer <= 0 ? "ResetPoints" : "Confirm"));
+		Vector2 size = ChatManager.GetStringSize(FontAssets.DeathText.Value, text, new(0.6f));
+		size.Y = 28; // For some reason the string size above is twice the height
+		Vector2 resetPosition = position + new Vector2(-20, 30);
+		bool hover = new Rectangle((int)resetPosition.X, (int)resetPosition.Y, (int)size.X, (int)size.Y).Contains(Main.MouseScreen.ToPoint());
+		Color col = hover ? Color.Gray : Color.White;
+
+		if (confirmTimer > 0)
+		{
+			col = hover ? Color.DarkRed : Color.Red;
+		}
+
+		Utils.DrawBorderStringBig(spriteBatch, text, resetPosition, col, 0.6f, 0f, 0f);
+
+		if (hover && Main.mouseLeft && Main.mouseLeftRelease)
+		{
+			Main.mouseLeftRelease = false;
+
+			if (confirmTimer <= 0)
+			{
+				confirmTimer = 120;
+			}
+			else
+			{
+				confirmTimer = 0;
+				onReset();
+			}
+		}
+	}
+
 	public static void DrawAvailablePassivePoint(SpriteBatch spriteBatch, int points, Vector2 position)
 	{
 		Texture2D tex = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/PassiveFrameSmall").Value;
-		
+
 		spriteBatch.Draw(tex, position, null, Color.White, 0, tex.Size() / 2f, 1, 0, 0);
 		Utils.DrawBorderStringBig(spriteBatch, $"{points}", position, points > 0 ? Color.Yellow : Color.Gray, 0.5f, 0.5f, 0.35f);
 		Utils.DrawBorderStringBig(spriteBatch, Language.GetTextValue("Mods.PathOfTerraria.UI.PointsRemaining"),

--- a/Content/Projectiles/Utility/Teleportal.cs
+++ b/Content/Projectiles/Utility/Teleportal.cs
@@ -75,7 +75,12 @@ internal class Teleportal : ModProjectile, IRightClickableProjectile, IMapIcon
 		if (Main.mouseRight && Main.mouseRightRelease)
 		{
 			player.Teleport(TeleportLocation);
-			RequestCheckSectionHandler.Send(TeleportLocation);
+
+			if (Main.netMode == NetmodeID.MultiplayerClient)
+			{
+				RequestCheckSectionHandler.Send(TeleportLocation);
+			}
+
 			return true;
 		}
 

--- a/Localization/de-DE/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	// NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	// Anvil: the Iron Anvil
+	// Lodge: the Lodge
+	/* Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		''' */
+}
+
 // RiftStability: Rift Stability

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -626,7 +626,7 @@ SwiftPlacementsMastery: {
 
 WitheringBoltsMastery: {
 	// Name: Withering Bolts
-	// Tooltip: Enemies hit by your sentries are slowed by 40% for {0} seconds. 15% vs Bosses.
+	// Tooltip: Enemies hit by your sentries are slowed by 40% (15% for bosses) for {0} seconds
 }
 
 MaximumSentryPassive: {

--- a/Localization/de-DE/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.UI.hjson
@@ -306,6 +306,7 @@ Tips: {
 }
 
 // PointsRemaining: Points Remaining
+// ResetPoints: Reset Points
 /* ExpBarHover:
 	'''
 	Level {0}

--- a/Localization/en-US/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	Anvil: the Iron Anvil
+	Lodge: the Lodge
+	Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		'''
+}
+
 RiftStability: Rift Stability

--- a/Localization/en-US/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.UI.hjson
@@ -306,6 +306,7 @@ Tips: {
 }
 
 PointsRemaining: Points Remaining
+ResetPoints: Reset Points
 ExpBarHover:
 	'''
 	Level {0}

--- a/Localization/es-ES/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	// NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	// Anvil: the Iron Anvil
+	// Lodge: the Lodge
+	/* Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		''' */
+}
+
 // RiftStability: Rift Stability

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -626,7 +626,7 @@ SwiftPlacementsMastery: {
 
 WitheringBoltsMastery: {
 	// Name: Withering Bolts
-	// Tooltip: Enemies hit by your sentries are slowed by 40% for {0} seconds. 15% vs Bosses.
+	// Tooltip: Enemies hit by your sentries are slowed by 40% (15% for bosses) for {0} seconds
 }
 
 MaximumSentryPassive: {

--- a/Localization/es-ES/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.UI.hjson
@@ -306,6 +306,7 @@ Tips: {
 }
 
 // PointsRemaining: Points Remaining
+// ResetPoints: Reset Points
 /* ExpBarHover:
 	'''
 	Level {0}

--- a/Localization/fr-FR/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	// NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	// Anvil: the Iron Anvil
+	// Lodge: the Lodge
+	/* Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		''' */
+}
+
 // RiftStability: Rift Stability

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -626,7 +626,7 @@ SwiftPlacementsMastery: {
 
 WitheringBoltsMastery: {
 	// Name: Withering Bolts
-	// Tooltip: Enemies hit by your sentries are slowed by 40% for {0} seconds. 15% vs Bosses.
+	// Tooltip: Enemies hit by your sentries are slowed by 40% (15% for bosses) for {0} seconds
 }
 
 MaximumSentryPassive: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.UI.hjson
@@ -299,6 +299,7 @@ Tips: {
 }
 
 // PointsRemaining: Points Remaining
+// ResetPoints: Reset Points
 /* ExpBarHover:
 	'''
 	Level {0}

--- a/Localization/pl-PL/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	// NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	// Anvil: the Iron Anvil
+	// Lodge: the Lodge
+	/* Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		''' */
+}
+
 // RiftStability: Rift Stability

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -626,7 +626,7 @@ SwiftPlacementsMastery: {
 
 WitheringBoltsMastery: {
 	// Name: Withering Bolts
-	// Tooltip: Enemies hit by your sentries are slowed by 40% for {0} seconds. 15% vs Bosses.
+	// Tooltip: Enemies hit by your sentries are slowed by 40% (15% for bosses) for {0} seconds
 }
 
 MaximumSentryPassive: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.UI.hjson
@@ -275,6 +275,7 @@ Tips: {
 }
 
 // PointsRemaining: Points Remaining
+// ResetPoints: Reset Points
 /* ExpBarHover:
 	'''
 	Level {0}

--- a/Localization/pt-BR/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	// NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	// Anvil: the Iron Anvil
+	// Lodge: the Lodge
+	/* Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		''' */
+}
+
 // RiftStability: Rift Stability

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -626,7 +626,7 @@ SwiftPlacementsMastery: {
 
 WitheringBoltsMastery: {
 	// Name: Withering Bolts
-	// Tooltip: Enemies hit by your sentries are slowed by 40% for {0} seconds. 15% vs Bosses.
+	// Tooltip: Enemies hit by your sentries are slowed by 40% (15% for bosses) for {0} seconds
 }
 
 MaximumSentryPassive: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.UI.hjson
@@ -306,6 +306,7 @@ Tips: {
 }
 
 // PointsRemaining: Points Remaining
+// ResetPoints: Reset Points
 /* ExpBarHover:
 	'''
 	Level {0}

--- a/Localization/ru-RU/Mods.PathOfTerraria.Misc.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Misc.hjson
@@ -52,4 +52,14 @@ ShardInvalidations: {
 	// NotNormal: Needs a Normal rarity item
 }
 
+RavencrestSigns: {
+	// Anvil: the Iron Anvil
+	// Lodge: the Lodge
+	/* Split:
+		'''
+		<-- Lodge, Forge
+		    Library, Hovel -->
+		''' */
+}
+
 // RiftStability: Rift Stability

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -626,7 +626,7 @@ SwiftPlacementsMastery: {
 
 WitheringBoltsMastery: {
 	// Name: Withering Bolts
-	// Tooltip: Enemies hit by your sentries are slowed by 40% for {0} seconds. 15% vs Bosses.
+	// Tooltip: Enemies hit by your sentries are slowed by 40% (15% for bosses) for {0} seconds
 }
 
 MaximumSentryPassive: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.UI.hjson
@@ -313,6 +313,7 @@ Tips: {
 }
 
 PointsRemaining: очков осталось
+// ResetPoints: Reset Points
 ExpBarHover:
 	'''
 	Уровень {0}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1373 
Resolves: #1586 
Resolves: #1590 

### Description of Work
- Fixed opening the Grimoire UI allowing you to use the Grimoire on the extra hotbar slot vanilla uses for smart cursor erroneously
- Fixed affixes without json entries breaking tooltips
- Fixed the Tattered Wood Ravencrest signs not being written on properly
- Localized the Ravencrest signs
- Added "Reset Points" option in Passive Tree
- Fixed Teleportal throwing in singleplayer