### PR TITLE
feat: Support multiple item type stat ranges per affix type.

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -31,7 +31,9 @@ public class AffixRegistry : ILoadable
 
 		foreach (string entry in AllItemData.Select(d => $"'{d.EquipTypes}'->'{d.AffixType}'").OrderBy(x => x))
 		{
-			Console.WriteLine($"Affix data registered: {entry}.");
+#if DEBUG
+			mod.Logger.Debug($"Affix data registered: {entry}.");
+#endif
 		}
 	}
 
@@ -45,13 +47,15 @@ public class AffixRegistry : ILoadable
 	public static ItemAffixData? TryGetAffixData(Type affixType, ItemType itemType)
 	{
 		Debug.Assert(BitOperations.PopCount((ulong)itemType) == 1);
-		
+
 		if (ByAffixAndItemType.TryGetValue((affixType, itemType), out ItemAffixData? values))
 		{
 			return values;
 		}
 
-		PoTMod.Instance.Logger.Error($"ItemAffixData not found for affix-item type pair ({affixType.Name}, {itemType}).");
+		string msg = $"ItemAffixData not found for affix-item type pair ({affixType.Name}, {itemType}).";
+		PoTMod.Instance.Logger.Error(msg);
+		Debug.Fail(msg);
 		return null;
 	}
 
@@ -86,9 +90,9 @@ public class AffixRegistry : ILoadable
 		var typesByName = AssemblyManager.GetLoadableTypes(ModContent.GetInstance<PoTMod>().Code)
 			.Where(x => typeof(Affix).IsAssignableFrom(x) && !x.IsAbstract)
 			.ToDictionary(x => x.Name);
-		
+
 		ByAffixAndItemType.EnsureCapacity(typesByName.Count);
-		ByItemType.EnsureCapacity(32);
+		ByItemType.EnsureCapacity((int)ItemType.TypeCount);
 
 		foreach (Stream jsonStream in jsonFiles
 			.Where(path => path.StartsWith("Common/Data/Affixes") && path.EndsWith(".json"))
@@ -109,7 +113,7 @@ public class AffixRegistry : ILoadable
 					PoTMod.Instance.Logger.Warn($"Affix of type {data.AffixType} not found.");
 					continue;
 				}
-				
+
 				AddAffixData(affixType, data);
 			}
 		}
@@ -132,7 +136,7 @@ public class AffixRegistry : ILoadable
 		foreach (int bitIndex in bits)
 		{
 			var itemType = (ItemType)(1ul << bitIndex);
-			
+
 			AddToDictList(ByItemType, itemType, data);
 
 			if (!ByAffixAndItemType.TryAdd((affixType, itemType), data))

--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -1,100 +1,147 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text.Json;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+using PathOfTerraria.Core.Items;
+using PathOfTerraria.Utilities;
 using Terraria.ModLoader.Core;
 
 namespace PathOfTerraria.Common.Data;
 
 public class AffixRegistry : ILoadable
 {
-	/// <summary>
-	/// A map of AffixData objects, with the key being the type from NPC.
-	/// </summary>
-	private static Dictionary<Type, ItemAffixData> ItemAffixData = [];
+	/// <summary> All item affix data objects. </summary>
+	private static readonly List<ItemAffixData> AllItemData = [];
+	/// <summary> Lookup by affix type. </summary>
+	private static readonly Dictionary<Type, List<ItemAffixData>> ByAffix = [];
+	/// <summary> Lookup by EXACT item type. </summary>
+	private static readonly Dictionary<ItemType, List<ItemAffixData>> ByItemType = [];
+	/// <summary> Lookup by affix and EXACT item type. </summary>
+	private static readonly Dictionary<(Type AffixType, ItemType ItemType), ItemAffixData> ByAffixAndItemType = [];
 
 	public void Load(Mod mod)
 	{
-		ItemAffixData = LoadJsonFilesToMapAsync();
+		LoadJsonFilesToMap();
 
-		foreach (KeyValuePair<Type, ItemAffixData> entry in ItemAffixData)
+		foreach (string entry in AllItemData.Select(d => $"'{d.EquipTypes}'->'{d.AffixType}'").OrderBy(x => x))
 		{
-			Console.WriteLine($"Affix with type key: \"{entry.Key}\" registered.");
+			Console.WriteLine($"Affix data registered: {entry}.");
 		}
 	}
 
 	public virtual void Unload() { }
 
-	/// <summary>
-	/// Provides a safe way of getting ItemAffixData from the ItemAffixData map.
-	/// </summary>
-	/// <param name="type">Type to look for.</param>
-	/// <returns><see cref="Models.ItemAffixData"/> instance of the given type.</returns>
-	public static ItemAffixData TryGetAffixData(Type type)
+#nullable enable
+	public static ItemAffixData? TryGetAffixData(Type affixType, Item item)
 	{
-		if (ItemAffixData.TryGetValue(type, out ItemAffixData value))
+		return TryGetAffixData(affixType, item.GetInstanceData().ItemType);
+	}
+	public static ItemAffixData? TryGetAffixData(Type affixType, ItemType itemType)
+	{
+		Debug.Assert(BitOperations.PopCount((ulong)itemType) == 1);
+		
+		if (ByAffixAndItemType.TryGetValue((affixType, itemType), out ItemAffixData? values))
 		{
-			return value;
+			return values;
 		}
 
-		PoTMod.Instance.Logger.Error($"ItemAffixData with type {type.Name} not found.");
+		PoTMod.Instance.Logger.Error($"ItemAffixData not found for affix-item type pair ({affixType.Name}, {itemType}).");
 		return null;
 	}
 
-	/// <summary>
-	/// Provides a safe way of getting ItemAffixData from the ItemAffixData map.
-	/// </summary>
-	/// <typeparam name="T">Type to look for.</typeparam>
-	/// <returns><see cref="Models.ItemAffixData"/> instance of the given type.</returns>
-	public static ItemAffixData TryGetAffixData<T>() where T : Affix
+	/// <summary> Provides a safe way of getting ItemAffixData from the ItemAffixData map. </summary>
+	public static IEnumerable<ItemAffixData> TryGetAffixDatas<T>() where T : Affix
 	{
-		return TryGetAffixData(typeof(T));
+		return TryGetAffixDatas(typeof(T));
 	}
+	/// <summary> Provides a safe way of getting ItemAffixData from the ItemAffixData map. </summary>
+	public static IEnumerable<ItemAffixData> TryGetAffixDatas(Type affixType)
+	{
+		if (ByAffix.TryGetValue(affixType, out List<ItemAffixData>? values))
+		{
+			return values;
+		}
+
+		PoTMod.Instance.Logger.Error($"ItemAffixData not found for affix type {affixType.Name}.");
+		return [];
+	}
+#nullable disable
 
 	/// <summary>
 	/// Loads the JSON files from the paths.txt file and returns a map of the data.
 	/// </summary>
-	/// <returns></returns>
-	private static Dictionary<Type, ItemAffixData> LoadJsonFilesToMapAsync()
+	private static void LoadJsonFilesToMap()
 	{
-		var jsonDataMap = new Dictionary<Type, ItemAffixData>();
+		AllItemData.Clear();
+
 		var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
 		List<string> jsonFiles = PoTMod.Instance.GetFileNames();
-		IEnumerable<Type> types = AssemblyManager.GetLoadableTypes(ModContent.GetInstance<PoTMod>().Code)
-			.Where(x => typeof(Affix).IsAssignableFrom(x) && !x.IsAbstract);
+		var typesByName = AssemblyManager.GetLoadableTypes(ModContent.GetInstance<PoTMod>().Code)
+			.Where(x => typeof(Affix).IsAssignableFrom(x) && !x.IsAbstract)
+			.ToDictionary(x => x.Name);
+		
+		ByAffixAndItemType.EnsureCapacity(typesByName.Count);
+		ByItemType.EnsureCapacity(32);
 
-		foreach (Stream jsonStream in from path in jsonFiles
-		         where path.StartsWith("Common/Data/Affixes") && path.EndsWith(".json")
-		         select PoTMod.Instance.GetFileStream(path))
+		foreach (Stream jsonStream in jsonFiles
+			.Where(path => path.StartsWith("Common/Data/Affixes") && path.EndsWith(".json"))
+			.Select(path => PoTMod.Instance.GetFileStream(path)))
 		{
 			using var jsonReader = new StreamReader(jsonStream);
 			string json = jsonReader.ReadToEnd();
-			List<ItemAffixData> datas = JsonSerializer.Deserialize<List<ItemAffixData>>(json, options);
+			ItemAffixData[] datas = JsonSerializer.Deserialize<ItemAffixData[]>(json, options);
 
-			if (datas == null)
-			{
-				continue;
-			}
+			if (datas is not { Length: > 0 }) { continue; }
+
+			AllItemData.EnsureCapacity(AllItemData.Count + datas.Length);
 
 			foreach (ItemAffixData data in datas)
 			{
-				Type type = types.FirstOrDefault(x => x.Name == data.AffixType);
-
-				if (type is null || !jsonDataMap.TryAdd(type, data))
+				if (!typesByName.TryGetValue(data.AffixType, out Type affixType))
 				{
-					Console.WriteLine($"Affix of type {data.AffixType} not found.");
+					PoTMod.Instance.Logger.Warn($"Affix of type {data.AffixType} not found.");
+					continue;
 				}
+				
+				AddAffixData(affixType, data);
 			}
 		}
-
-		return jsonDataMap;
 	}
-	
+
+	private static void AddAffixData(Type affixType, ItemAffixData data)
+	{
+		static void AddToDictList<K, V>(Dictionary<K, List<V>> dict, K key, V value)
+		{
+			if (!dict.TryGetValue(key, out List<V> list)) { dict[key] = [value]; }
+			else { list.Add(value); }
+		}
+
+		AllItemData.Add(data);
+		AddToDictList(ByAffix, affixType, data);
+
+		ItemType types = data.GetEquipTypes();
+		BitMask<ulong> bits = new((ulong)types);
+
+		foreach (int bitIndex in bits)
+		{
+			var itemType = (ItemType)(1ul << bitIndex);
+			
+			AddToDictList(ByItemType, itemType, data);
+
+			if (!ByAffixAndItemType.TryAdd((affixType, itemType), data))
+			{
+				throw new InvalidDataException($"Duplicate item affix data found for key ({affixType.Name}, {itemType})!");
+			}
+		}
+	}
+
 	/// <summary>
 	/// Convert ItemAffixData to ItemAffix instance based on affix type.
 	/// </summary>
@@ -115,7 +162,6 @@ public class AffixRegistry : ILoadable
 		return affixInstance;
 	}
 
-	
 	/// <summary>
 	/// Filters ItemAffixData dictionary by ItemType and selects a random affix.
 	/// </summary>
@@ -123,10 +169,12 @@ public class AffixRegistry : ILoadable
 	/// <returns>Random ItemAffixData entry matching the ItemType.</returns>
 	public static ItemAffixData GetRandomAffixDataByItemType(ItemType itemType, IEnumerable<ItemAffixData> excludedAffixes = null)
 	{
-		IEnumerable<ItemAffixData> enumerable = ItemAffixData.Values
+		if (itemType == 0) { throw new ArgumentNullException(nameof(itemType)); }
+
+		IEnumerable<ItemAffixData> enumerable = AllItemData
 			.Where(affixData => (itemType & affixData.GetEquipTypes()) != ItemType.None);
 
-		if (enumerable != null)
+		if (excludedAffixes != null)
 		{
 			enumerable = enumerable.Except(excludedAffixes);
 		}
@@ -143,18 +191,17 @@ public class AffixRegistry : ILoadable
 		return filteredAffixData[randomIndex];
 	}
 
-	
 	/// <summary>
 	/// Retrieves a random affix value for the given ItemAffix.
 	/// </summary>
 	/// <param name="affix">The ItemAffix instance.</param>
 	/// <param name="itemLevel">The level of the item for determining appropriate tier.</param>
 	/// <returns>Random affix value.</returns>
-	internal static float GetRandomAffixValue(ItemAffix affix, int itemLevel)
+	internal static float GetRandomAffixValue(ItemAffix affix, Item item, int itemLevel)
 	{
 		// Get the corresponding ItemAffixData for the affix's type
 		Type affixType = affix.GetType();
-		if (!ItemAffixData.TryGetValue(affixType, out ItemAffixData affixData))
+		if (TryGetAffixData(affixType, item) is not ItemAffixData affixData)
 		{
 			throw new ArgumentException($"ItemAffixData not found for affix type: {affixType.Name}");
 		}
@@ -163,7 +210,7 @@ public class AffixRegistry : ILoadable
 		{
 			itemLevel = 1;
 		}
-		
+
 		// Get the appropriate TierData based on itemLevel
 		ItemAffixData.TierData tierData = affixData.GetAppropriateTierData(itemLevel, out int tier);
 		affix.Tier = tier;

--- a/Common/Data/Affixes/GrimoireAffixes.json
+++ b/Common/Data/Affixes/GrimoireAffixes.json
@@ -1,7 +1,7 @@
 ﻿[
 	{
 		"affixType": "ChanceToApplyPoisonItemAffix",
-		"equipTypes": "Weapon Grimoire",
+		"equipTypes": "Grimoire",
 		"influences": "None",
 		"tiers": [
 			{
@@ -32,7 +32,7 @@
 	},
 	{
 		"affixType": "HealOnKillingBurningEnemiesAffix",
-		"equipTypes": "Weapon Grimoire",
+		"equipTypes": "Grimoire",
 		"tiers": [
 			{
 				"minValue": 1,
@@ -92,7 +92,7 @@
 	},
 	{
 		"affixType": "IncreasedDamageAffix",
-		"equipTypes": "Weapon Grimoire",
+		"equipTypes": "Grimoire",
 		"tiers": [
 			{
 				"minValue": 1,

--- a/Common/Data/Models/AffixData.cs
+++ b/Common/Data/Models/AffixData.cs
@@ -70,20 +70,22 @@ public class ItemAffixData
 
 	public ItemType GetEquipTypes()
 	{
-		return GetSeparateEquipTypes().Aggregate((a, b) => a | b);
-	}
-	private IEnumerable<ItemType> GetSeparateEquipTypes()
-	{
+		ItemType result = 0;
+		
 		foreach (string item in EquipTypes.Split(' '))
 		{
-			if (Enum.TryParse(item, out ItemType type))
+			bool? negate = item.StartsWith('-') ? true : (item.StartsWith('+') ? false : null);
+			ReadOnlySpan<char> chars = item.AsSpan(negate.HasValue ? 1 : 0);
+			if (Enum.TryParse(chars, out ItemType type))
 			{
-				yield return type;
+				result = negate != true ? (result | type) : (result &= ~type);
 				continue;
 			}
 			
-			PoTMod.Instance.Logger.Error($"Affix attempted to load non-existing {item} ItemType enumeration. Types: {EquipTypes}\n{Environment.StackTrace}");
+			PoTMod.Instance.Logger.Error($"Affix attempted to load non-existing '{item}' ItemType enumeration. Types: {EquipTypes}\n{Environment.StackTrace}");
 		}
+
+		return result;
 	}
 
 	public Influence GetInfluences()

--- a/Common/Data/Models/AffixData.cs
+++ b/Common/Data/Models/AffixData.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using PathOfTerraria.Common.Enums;
 
@@ -33,45 +35,45 @@ public class ItemAffixData
 	public (int MinInclusive, int MaxInclusive) GetPossibleTierRange(int level)
 	{
 		var eligibleTiers = Tiers.Where(t => t.MinimumLevel <= level).ToList();
-		
+
 		return (0, eligibleTiers.Count - 1);
 	}
 
 	public TierData GetAppropriateTierData(int level, out int tierIndex)
-    {
-        var eligibleTiers = Tiers.Where(t => t.MinimumLevel <= level).ToList();
+	{
+		var eligibleTiers = Tiers.Where(t => t.MinimumLevel <= level).ToList();
 
 		tierIndex = 0;
 
-        if (eligibleTiers.Count == 0)
-        {
-            return null;
-        }
+		if (eligibleTiers.Count == 0)
+		{
+			return null;
+		}
 
-        float totalWeight = eligibleTiers.Sum(t => t.Weight);
+		float totalWeight = eligibleTiers.Sum(t => t.Weight);
 
-        float randomWeight = (float) Main.rand.NextDouble() * totalWeight;
-        float cumulativeWeight = 0;
+		float randomWeight = (float)Main.rand.NextDouble() * totalWeight;
+		float cumulativeWeight = 0;
 
-        foreach (TierData tier in eligibleTiers)
-        {
-            cumulativeWeight += tier.Weight;
+		foreach (TierData tier in eligibleTiers)
+		{
+			cumulativeWeight += tier.Weight;
 
-            if (randomWeight <= cumulativeWeight)
-            {
+			if (randomWeight <= cumulativeWeight)
+			{
 				tierIndex = eligibleTiers.IndexOf(tier);
-                return tier;
-            }
-        }
+				return tier;
+			}
+		}
 
 		tierIndex = eligibleTiers.Count - 1;
-        return eligibleTiers.Last(); //Just in case we don't return a tier?
-    }
+		return eligibleTiers.Last(); //Just in case we don't return a tier?
+	}
 
 	public ItemType GetEquipTypes()
 	{
 		ItemType result = 0;
-		
+
 		foreach (string item in EquipTypes.Split(' '))
 		{
 			bool? negate = item.StartsWith('-') ? true : (item.StartsWith('+') ? false : null);
@@ -81,8 +83,10 @@ public class ItemAffixData
 				result = negate != true ? (result | type) : (result &= ~type);
 				continue;
 			}
-			
-			PoTMod.Instance.Logger.Error($"Affix attempted to load non-existing '{item}' ItemType enumeration. Types: {EquipTypes}\n{Environment.StackTrace}");
+
+			string msg = $"Affix attempted to load non-existing '{item}' ItemType enumeration. Types: {EquipTypes}\n{Environment.StackTrace}";
+			PoTMod.Instance.Logger.Error(msg);
+			Debug.Fail(msg);
 		}
 
 		return result;

--- a/Common/Data/Models/AffixData.cs
+++ b/Common/Data/Models/AffixData.cs
@@ -70,23 +70,20 @@ public class ItemAffixData
 
 	public ItemType GetEquipTypes()
 	{
-		string[] split = EquipTypes.Split(' ');
-		ItemType types = ItemType.None;
-
-		foreach (string item in split)
+		return GetSeparateEquipTypes().Aggregate((a, b) => a | b);
+	}
+	private IEnumerable<ItemType> GetSeparateEquipTypes()
+	{
+		foreach (string item in EquipTypes.Split(' '))
 		{
 			if (Enum.TryParse(item, out ItemType type))
 			{
-				types |= type;
+				yield return type;
+				continue;
 			}
-			else
-			{
-				Console.WriteLine($"Affix attempted to load nonexisting {item} ItemType enumeration. Types: " + EquipTypes);
-				Console.WriteLine(Environment.StackTrace);
-			}
+			
+			PoTMod.Instance.Logger.Error($"Affix attempted to load non-existing {item} ItemType enumeration. Types: {EquipTypes}\n{Environment.StackTrace}");
 		}
-
-		return types;
 	}
 
 	public Influence GetInfluences()

--- a/Common/Enums/ItemType.cs
+++ b/Common/Enums/ItemType.cs
@@ -34,6 +34,7 @@ public enum ItemType : long
 	Quiver = 1 << 25,
 	Talisman = 1 << 26,
 	Focus = 1 << 27,
+	TypeCount = 28,
 
 	Armor = Helmet | Chestplate | Leggings,
 	Accessories = Ring | Charm | Amulet,

--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -302,9 +302,9 @@ internal class AffixHandler : ILoadable
 	public static List<ItemAffix> GetAffixes(Item item)
 	{
 		return _itemAffixes
-			.Where(proto => proto.RequiredInfluence == Influence.None ||
-			                proto.RequiredInfluence == item.GetInstanceData().Influence)
-			.Where(proto => (item.GetInstanceData().ItemType & proto.PossibleTypes) == item.GetInstanceData().ItemType)
+			.Where(proto => proto.GetRequiredInfluence(item) == Influence.None ||
+			                proto.GetRequiredInfluence(item) == item.GetInstanceData().Influence)
+			.Where(proto => (item.GetInstanceData().ItemType & proto.GetPossibleTypes()) == item.GetInstanceData().ItemType)
 			.ToList();
 	}
 

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -1,4 +1,6 @@
-﻿using PathOfTerraria.Common.Data;
+﻿using System.Collections.Generic;
+using System.Linq;
+using PathOfTerraria.Common.Data;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Core.Items;
@@ -10,9 +12,6 @@ namespace PathOfTerraria.Common.Systems.Affixes;
 
 public abstract class ItemAffix : Affix
 {
-	public Influence RequiredInfluence => GetData()?.GetInfluences() ?? Influence.None;
-	public ItemType PossibleTypes => GetData()?.GetEquipTypes() ?? ItemType.None;
-
 	public virtual void ApplyAffix(Player player, EntityModifier modifier, Item item) { }
 
 	/// <summary>
@@ -21,17 +20,18 @@ public abstract class ItemAffix : Affix
 	/// </summary>
 	public virtual void ApplyTooltips(Player player, Item item, AffixTooltips handler)
 	{
-		handler.AddOrModify(GetType(), CreateDefaultTooltip(player, item));
+		var instanceData = item.GetInstanceData();
+		handler.AddOrModify(GetType(), CreateDefaultTooltip(player, instanceData.ItemType, instanceData.RealLevel));
+	}
+	/// <inheritdoc cref="ApplyTooltips(Player, Item, AffixTooltips)"/>
+	public virtual void ApplyTooltips(Player player, ItemType itemType, int itemLevel, AffixTooltips handler)
+	{
+		handler.AddOrModify(GetType(), CreateDefaultTooltip(player, itemType, itemLevel));
 	}
 
-	public virtual void ApplyTooltips(Player player, int itemLevel, AffixTooltips handler)
+	protected virtual AffixTooltipLine CreateDefaultTooltip(Player player, ItemType itemType, int itemLevel)
 	{
-		handler.AddOrModify(GetType(), CreateDefaultTooltip(player, itemLevel));
-	}
-
-	protected virtual AffixTooltipLine CreateDefaultTooltip(Player player, int itemLevel)
-	{
-		ItemAffixData? data = GetData();
+		ItemAffixData? data = GetData(itemType);
 
 		if (data is null) // Data can be null if the affix doesn't exist in the json data. This skips the checks below.
 		{
@@ -46,6 +46,7 @@ public abstract class ItemAffix : Affix
 			};
 		}
 
+		// PoTInstanceItemData itemData = item.GetInstanceData();
 		ItemAffixData.TierData tierData = data.Tiers[Tier];
 		
 		(int tierMin, int tierMax) = data.GetPossibleTierRange(itemLevel);
@@ -64,16 +65,32 @@ public abstract class ItemAffix : Affix
 	protected virtual AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
 	{
 		int level = GetItemLevel.Invoke(item);
-		return CreateDefaultTooltip(player, level);
+		return CreateDefaultTooltip(player, item);
 	}
 
-	/// <summary>
-	/// Retrieves the affix data for the current <see cref="ItemAffix"/> instance.
-	/// </summary>
-	/// <returns></returns>
-	public ItemAffixData? GetData()
+	/// <summary> Retrieves the item affix data for the current <see cref="ItemAffix"/> instance and the provided exact item type. </summary>
+	public ItemAffixData? GetData(ItemType exactItemType)
 	{
-		return AffixRegistry.TryGetAffixData(GetType());
+		return AffixRegistry.TryGetAffixData(GetType(), exactItemType);
+	}
+	/// <summary> Retrieves the item affix data for the current <see cref="ItemAffix"/> instance and the provided item. </summary>
+	public ItemAffixData? GetData(Item item)
+	{
+		return AffixRegistry.TryGetAffixData(GetType(), item);
+	}
+	/// <summary> Retrieves all the item affix data for the current <see cref="ItemAffix"/> instance. </summary>
+	public IEnumerable<ItemAffixData> GetDatas()
+	{
+		return AffixRegistry.TryGetAffixDatas(GetType());
+	}
+
+	public Influence GetRequiredInfluence(Item item)
+	{
+		return GetData(item)?.GetInfluences() ?? Influence.None;
+	}
+	public ItemType GetPossibleTypes()
+	{
+		return GetDatas().Aggregate<ItemAffixData, ItemType>(default, (current, data) => current | data.GetEquipTypes());
 	}
 
 	internal override void CreateLocalization()

--- a/Common/Systems/Affixes/ItemTypes/MapAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/MapAffixes.cs
@@ -112,7 +112,7 @@ public class MapIncreasedBehaviourAffix : MapAffix
 
 public class EoLDaylightAffix : MapAffix
 {
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, int itemLevel)
+	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
 	{
 		return new AffixTooltipLine
 		{

--- a/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
+++ b/Common/UI/GrimoireSelection/GrimoireSelectionUIState.cs
@@ -381,7 +381,7 @@ internal class GrimoireSelectionUIState : CloseableSmartUi, IMutuallyExclusiveUI
 			{
 				foreach (ItemAffix affix in affixes)
 				{
-					affix.ApplyTooltips(Main.LocalPlayer, material.GetInstanceData().RealLevel, handler);
+					affix.ApplyTooltips(Main.LocalPlayer, material, handler);
 					affix.ApplyAffix(_modificationsPlayer, _modificationsPlayer.GetModPlayer<UniversalBuffingPlayer>().UniversalModifier, material);
 				}
 			}

--- a/Common/UI/SubworldHelp/SubworldHelpInvButton.cs
+++ b/Common/UI/SubworldHelp/SubworldHelpInvButton.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
@@ -78,7 +79,7 @@ public class SubworldHelpInvButton : SmartUiState
 
 			foreach (MapAffix affix in MappingWorld.Affixes)
 			{
-				affix.ApplyTooltips(Main.LocalPlayer, MappingWorld.AreaLevel, tooltips);
+				affix.ApplyTooltips(Main.LocalPlayer, ItemType.Map, MappingWorld.AreaLevel, tooltips);
 				totalStrength += affix.Strength;
 			}
 

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -106,7 +106,7 @@ public static class PoTItemHelper
 	    PoTInstanceItemData data = item.GetInstanceData();
 	    foreach (ItemAffix affix in data.Affixes)
 	    {
-	        affix.Value = AffixRegistry.GetRandomAffixValue(affix, GetItemLevel.Invoke(item));
+	        affix.Value = AffixRegistry.GetRandomAffixValue(affix, item, GetItemLevel.Invoke(item));
 	    }
 	}
 
@@ -123,7 +123,7 @@ public static class PoTItemHelper
 			return;
 		}
 
-		ItemAffixData chosenAffix = AffixRegistry.GetRandomAffixDataByItemType(data.ItemType, excludedAffixes: data.Affixes.Select(a => a.GetData()));
+		ItemAffixData chosenAffix = AffixRegistry.GetRandomAffixDataByItemType(data.ItemType, excludedAffixes: data.Affixes.Select(a => a.GetData(item)));
 		if (chosenAffix is null)
 		{
 			return;
@@ -135,7 +135,7 @@ public static class PoTItemHelper
 			return;
 		}
 
-		affix.Value = AffixRegistry.GetRandomAffixValue(affix, GetItemLevel.Invoke(item));
+		affix.Value = AffixRegistry.GetRandomAffixValue(affix, item, GetItemLevel.Invoke(item));
 		if (affix.Value == 0)
 		{
 			return; //If the affix has no value, don't add it. This usually happens when there's no TierData associated with the given item


### PR DESCRIPTION
### Description of Work
Current affix JSON data files are formed in a way implying ability to bind different stat ranges to multiple item types per a given affix type. However, the C# code handling all this is written in a way that binds one affix type to exactly one ItemAffixData (set of stat ranges). This PR does its worst to fix that issue, assisting #1722 and helping it not duplicate affix types as a workaround.

Additionally it allows `equipTypes` syntax alike `Weapon +Quiver -Staff` to be used to resolve conflicts, which will now be detected and cause a crash during mod loading. `Weapon` and `+Weapon` are of course the same thing, `|= x`, while `-Weapon` means `&= ~x`.