### PR TITLE
Qa time for me

### DIFF
--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -159,13 +159,24 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 {
 	public override bool HoverSlot(Item[] inventory, int context, int slot)
 	{
-		if (ItemSlot.ShiftInUse
-		&& context == ItemSlot.Context.InventoryItem
-		&& SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null
-		&& inventory[slot] is { IsAir: false })
+		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
 		{
-			Main.cursorOverride = CursorOverrideID.InventoryToChest;
-			return true;
+			// Move item into storage (cursorOverride functionality only)
+			if (ItemSlot.ShiftInUse
+				&& context == ItemSlot.Context.InventoryItem
+				&& inventory[slot] is { IsAir: false })
+			{
+				Main.cursorOverride = CursorOverrideID.InventoryToChest;
+				return true;
+			}
+
+			// Move item into slot (all functionality)
+			if (Main.mouseRight && Main.mouseRightRelease && context == ItemSlot.Context.BankItem)
+			{
+				// RightClick isn't called for bank items, so we have to run this manually.
+				// This may cause issues but should be fine as long as other mods don't do anything silly here.
+				ItemLoader.RightClick(inventory[slot], Main.LocalPlayer);
+			}
 		}
 		
 		return false;
@@ -173,53 +184,33 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 
 	public override bool ShiftClickSlot(Item[] inventory, int context, int slot)
 	{
-		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
+		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null
+			&& context == ItemSlot.Context.InventoryItem && inventory[slot] is { IsAir: false }) // Move from inventory to storage/slot
 		{
-			if (context == ItemSlot.Context.InventoryItem && inventory[slot] is { IsAir: false }) // Move from inventory to storage/slot
-			{
-				// Move into main slot if there's space & not holding left ctrl
-				if (inventory[slot].ModItem is Map && MapDeviceInterface.Entity.StoredMap is { IsAir: true } && !Main.keyState.IsKeyDown(Keys.LeftControl))
-				{
-					Item invItem = inventory[slot].Clone();
-					inventory[slot].TurnToAir();
-					MapDeviceInterface.Entity.StoredMap = invItem;
-					SoundEngine.PlaySound(SoundID.Grab);
-					return true;
-				}
+			// Move into storage
+			MoveItemIntoStorage(ref inventory[slot]);
 
-				// Otherwise, move into storage
-				Item[] storage = MapDeviceInterface.Entity.Storage;
-
-				for (int i = 0; i < MapDeviceEntity.StorageSize; i++)
-				{
-					ref Item item = ref storage[i];
-					if (!item.IsAir) { continue; }
-
-					Item invItem = inventory[slot].Clone();
-					inventory[slot].TurnToAir();
-					item = invItem;
-					SoundEngine.PlaySound(SoundID.Grab);
-					break;
-				}
-
-				return true;
-			}
-
-			if (context == ItemSlot.Context.BankItem) // Move from storage to slot if needed
-			{
-				// Move into main slot if there's space & not holding left ctrl
-				if (inventory[slot].ModItem is Map && MapDeviceInterface.Entity.StoredMap is { IsAir: true } && !Main.keyState.IsKeyDown(Keys.LeftControl))
-				{
-					Item invItem = inventory[slot].Clone();
-					inventory[slot].TurnToAir();
-					MapDeviceInterface.Entity.StoredMap = invItem;
-					SoundEngine.PlaySound(SoundID.Grab);
-					return true;
-				}
-			}
+			return true;
 		}
 
 		return false;
+	}
+
+	internal static void MoveItemIntoStorage(ref Item originalItem)
+	{
+		Item[] storage = MapDeviceInterface.Entity!.Storage;
+
+		for (int i = 0; i < MapDeviceEntity.StorageSize; i++)
+		{
+			ref Item item = ref storage[i];
+			if (!item.IsAir) { continue; }
+
+			Item invItem = originalItem.Clone();
+			originalItem.TurnToAir();
+			item = invItem;
+			SoundEngine.PlaySound(SoundID.Grab);
+			break;
+		}
 	}
 }
 

--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.UI;
 using PathOfTerraria.Common.UI.Components;
@@ -172,26 +173,50 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 
 	public override bool ShiftClickSlot(Item[] inventory, int context, int slot)
 	{
-		if (ItemSlot.ShiftInUse
-		&& context == ItemSlot.Context.InventoryItem
-		&& inventory[slot] is { IsAir: false }
-		&& SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
+		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null)
 		{
-			Item[] storage = MapDeviceInterface.Entity.Storage;
-
-			for (int i = 0; i < MapDeviceEntity.StorageSize; i++)
+			if (context == ItemSlot.Context.InventoryItem && inventory[slot] is { IsAir: false }) // Move from inventory to storage/slot
 			{
-				ref Item item = ref storage[i];
-				if (!item.IsAir) { continue; }
+				// Move into main slot if there's space & not holding left ctrl
+				if (inventory[slot].ModItem is Map && MapDeviceInterface.Entity.StoredMap is { IsAir: true } && !Main.keyState.IsKeyDown(Keys.LeftControl))
+				{
+					Item invItem = inventory[slot].Clone();
+					inventory[slot].TurnToAir();
+					MapDeviceInterface.Entity.StoredMap = invItem;
+					SoundEngine.PlaySound(SoundID.Grab);
+					return true;
+				}
 
-				Item invItem = inventory[slot].Clone();
-				inventory[slot].TurnToAir();
-				item = invItem;
-				SoundEngine.PlaySound(SoundID.Grab);
-				break;
+				// Otherwise, move into storage
+				Item[] storage = MapDeviceInterface.Entity.Storage;
+
+				for (int i = 0; i < MapDeviceEntity.StorageSize; i++)
+				{
+					ref Item item = ref storage[i];
+					if (!item.IsAir) { continue; }
+
+					Item invItem = inventory[slot].Clone();
+					inventory[slot].TurnToAir();
+					item = invItem;
+					SoundEngine.PlaySound(SoundID.Grab);
+					break;
+				}
+
+				return true;
 			}
 
-			return true;
+			if (context == ItemSlot.Context.BankItem) // Move from storage to slot if needed
+			{
+				// Move into main slot if there's space & not holding left ctrl
+				if (inventory[slot].ModItem is Map && MapDeviceInterface.Entity.StoredMap is { IsAir: true } && !Main.keyState.IsKeyDown(Keys.LeftControl))
+				{
+					Item invItem = inventory[slot].Clone();
+					inventory[slot].TurnToAir();
+					MapDeviceInterface.Entity.StoredMap = invItem;
+					SoundEngine.PlaySound(SoundID.Grab);
+					return true;
+				}
+			}
 		}
 
 		return false;

--- a/Common/Systems/Questing/Quests/MainPath/EoWQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/EoWQuest.cs
@@ -30,7 +30,7 @@ internal class EoWQuest : Quest
 	{
 		return
 		[
-			new InteractWithNPC("Start", ModContent.NPCType<MorvenNPC>(), this.GetLocalization("BlacksmithInput"), this.GetLocalization("MorvenDialogue")),
+			new InteractWithNPC("Start", ModContent.NPCType<MorvenNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.BlacksmithNPC.Dialogue.EoWDialogue"), Language.GetText("MorvenDialogue")),
 			new ConditionCheck("Raven", (_) => SubworldSystem.Current is RavencrestSubworld && NPC.AnyNPCs(ModContent.NPCType<MorvenNPC>()), 1, this.GetLocalization("MorvenRaven")),
 			new InteractWithNPC("MorvenAboveground", ModContent.NPCType<MorvenNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.MorvenNPC.Dialogue.Aboveground"),
 			    Language.GetText("Mods.PathOfTerraria.NPCs.MorvenNPC.Dialogue.InRavencrest")),

--- a/Common/Systems/Questing/Quests/MainPath/FirstQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/FirstQuest.cs
@@ -3,13 +3,8 @@ using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
-using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
-using PathOfTerraria.Content.Items.Placeable;
 using SubworldLibrary;
 using System.Collections.Generic;
-using Terraria;
-using Terraria.DataStructures;
-using Terraria.ID;
 
 namespace PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 
@@ -30,17 +25,6 @@ internal class FirstQuest : Quest
 			new ConditionCheck("Approach", plr => plr.DistanceSQ(ModContent.GetInstance<RavencrestSystem>().EntrancePosition.ToWorldCoordinates()) < 400 * 400,
 				1, this.GetLocalization("ApproachEntrance")),
 			new ConditionCheck("Enter", _ => SubworldSystem.Current is RavencrestSubworld, 1, this.GetLocalization("EnterRavencrest")),
-			new ActionStep((plr, step) =>
-			{
-				int item = Item.NewItem(new EntitySource_Misc("Quest"), plr.Bottom, ModContent.ItemType<ArcaneObeliskItem>());
-
-				if (Main.netMode == NetmodeID.MultiplayerClient)
-				{
-					NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
-				}
-
-				return true;
-			})
 		];
 	}
 

--- a/Common/Systems/Questing/Quests/MainPath/WizardStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/WizardStartQuest.cs
@@ -37,6 +37,7 @@ internal class WizardStartQuest : Quest
 				RavencrestSystem.UpgradeBuilding("Library");
 				return true;
 			}),
+			new KillCount("KillScout", ModContent.NPCType<TownScoutNPC>(), 1, this.GetLocalization("KillScout")),
 			new InteractWithNPC("Start", ModContent.NPCType<WizardNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.WizardNPC.Dialogue.Quest"),
 				Language.GetText("Mods.PathOfTerraria.NPCs.WizardNPC.Dialogue.Quest2"),
 			[

--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -217,7 +217,7 @@ internal class TutorialUIState : UIState
 				}
 			}
 		}
-		else if (Step == 12 && !tutPlr.Restarted)
+		else if (Step == 12 && !tutPlr.Restarted && !plr.HasItem(ModContent.ItemType<ArcaneObeliskItem>()))
 		{
 			plr.QuickSpawnItem(new EntitySource_Misc("Quest"), ModContent.ItemType<ArcaneObeliskItem>());
 		}

--- a/Common/UI/Guide/TutorialUIState.cs
+++ b/Common/UI/Guide/TutorialUIState.cs
@@ -217,7 +217,7 @@ internal class TutorialUIState : UIState
 				}
 			}
 		}
-		else if (Step == 12 && !tutPlr.Restarted && !plr.HasItem(ModContent.ItemType<ArcaneObeliskItem>()))
+		else if (Step == 12 && !tutPlr.Restarted)
 		{
 			plr.QuickSpawnItem(new EntitySource_Misc("Quest"), ModContent.ItemType<ArcaneObeliskItem>());
 		}

--- a/Common/Waypoints/HomeWaypoint.cs
+++ b/Common/Waypoints/HomeWaypoint.cs
@@ -15,8 +15,8 @@ public sealed class HomeWaypoint : ModWaypoint
 
 	public override bool CanGoto()
 	{
-		bool isHomeObeliskMissing = !ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains("Overworld");
-		
-		return SubworldSystem.Current is not null && !isHomeObeliskMissing;
+		//bool isHomeObeliskMissing = !ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains("Overworld");
+
+		return SubworldSystem.Current is not null;// && !isHomeObeliskMissing;
 	}
 }

--- a/Common/Waypoints/HomeWaypoint.cs
+++ b/Common/Waypoints/HomeWaypoint.cs
@@ -1,5 +1,3 @@
-using PathOfTerraria.Common.Systems;
-using PathOfTerraria.Common.UI.Guide;
 using SubworldLibrary;
 
 namespace PathOfTerraria.Common.Waypoints;
@@ -15,8 +13,6 @@ public sealed class HomeWaypoint : ModWaypoint
 
 	public override bool CanGoto()
 	{
-		//bool isHomeObeliskMissing = !ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains("Overworld");
-
-		return SubworldSystem.Current is not null;// && !isHomeObeliskMissing;
+		return SubworldSystem.Current is not null;
 	}
 }

--- a/Common/Waypoints/UI/UIWaypointListElement.cs
+++ b/Common/Waypoints/UI/UIWaypointListElement.cs
@@ -17,7 +17,7 @@ public sealed class UIWaypointListElement(Asset<Texture2D> icon, LocalizedText n
 	public const float FullHeight = 48f;
 	public const float ElementMargin = 16f;
 
-	public bool CanClick => ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains(Location);
+	public bool CanClick => Location == "Overworld" || ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains(Location);
 
 	public readonly Asset<Texture2D> Icon = icon;
 	public readonly int Index = index;

--- a/Common/Waypoints/UI/UIWaypointMenu.cs
+++ b/Common/Waypoints/UI/UIWaypointMenu.cs
@@ -1,19 +1,14 @@
 using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
 using Microsoft.Xna.Framework.Input;
 using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.UI.Elements;
-using PathOfTerraria.Common.UI.Guide;
 using PathOfTerraria.Core.UI;
 using ReLogic.Content;
 using Terraria.Audio;
-using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
 using Terraria.GameInput;
 using Terraria.ID;
-using Terraria.Localization;
 using Terraria.UI;
 
 namespace PathOfTerraria.Common.Waypoints.UI;
@@ -76,7 +71,6 @@ public sealed class UIWaypointMenu : UIState
 	private UIImage thumbnailImage;
 
 	private UIText waypointText;
-	private UIText tutorialTipText;
 
 	public override void OnInitialize()
 	{
@@ -92,22 +86,6 @@ public sealed class UIWaypointMenu : UIState
 		};
 
 		rootElement.Append(BuildPanel());
-
-		// Add tip to clear up confusion on the return button in tutorial
-		string tutorialTipLocalized = Language.GetTextValue($"Mods.{PoTMod.ModName}.UI.Waypoints.TutorialTip");
-		tutorialTipText = new UIText(tutorialTipLocalized, 0.8f)
-		{
-			HAlign = 0.5f,
-			VAlign = 0.0f,
-			Top = { Pixels = -45f },
-			Width = { Pixels = FullWidth },
-			TextOriginX = 0.5f,
-			WrappedTextBottomPadding = 0f,
-			IsWrapped = true
-		};
-		
-		rootElement.Append(tutorialTipText);
-
 		Append(rootElement);
 
 		listRootElement = new UIElement
@@ -145,7 +123,10 @@ public sealed class UIWaypointMenu : UIState
 
 		buttonElement.OnLeftClick += (_, _) =>
 		{
-			if (ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains(SelectedListWaypoint.LocationEnum) && SelectedListWaypoint.CanGoto())
+			string location = SelectedListWaypoint.LocationEnum;
+			bool hasLocation = ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains(location);
+
+			if ((location == "Overworld" || hasLocation) && SelectedListWaypoint.CanGoto())
 			{
 				SelectedListWaypoint.Teleport(Main.LocalPlayer);
 				Enabled = false;
@@ -257,16 +238,6 @@ public sealed class UIWaypointMenu : UIState
 			Main.LocalPlayer.mouseInterface = true;
 		}
 		
-		bool hasArcaneObelisk = ModContent.GetInstance<PersistentDataSystem>().ObelisksByLocation.Contains("Overworld");
-		bool tutorialTipCurrentlyShowing = rootElement.Children.Contains(tutorialTipText);
-
-		// Check if player has placed an obelisk in the main world, and if the tutorialtiptext currently exists
-		if (hasArcaneObelisk && tutorialTipCurrentlyShowing)
-		{
-			// Remove the tip if obelisk is placed and tip is showing
-			tutorialTipText.Remove();
-		}
-
 		UpdateInput();
 
 		float target = Enabled ? 0f : Main.screenHeight;

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -1,18 +1,23 @@
 ﻿using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.Mapping;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Common.Systems.ModPlayers.LivesSystem;
 using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using PathOfTerraria.Core.Items;
+using PathOfTerraria.Core.UI.SmartUI;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
 
 namespace PathOfTerraria.Content.Items.Consumables.Maps;
+
+#nullable enable
 
 public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.IItem, GenerateImplicits.IItem, IPoTGlobalItem, GetItemLevel.IItem, SetItemLevel.IItem
 {
@@ -28,7 +33,7 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 	public override ModItem Clone(Item newEntity)
 	{
 		var map = base.Clone(newEntity) as Map;
-		map.Tier = Tier;
+		map!.Tier = Tier;
 		map.ItemLevel = ItemLevel;
 		return map;
 	}
@@ -46,6 +51,27 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 		PoTInstanceItemData data = this.GetInstanceData();
 		data.ItemType = ItemType.Map;
+	}
+
+	public override bool CanRightClick()
+	{
+		return SmartUiLoader.TryGetUiState(out MapDeviceState? map) && map is { Visible: true } && MapDeviceInterface.Entity is not null;
+	}
+
+	public override void RightClick(Player player)
+	{
+		if (SmartUiLoader.TryGetUiState(out MapDeviceState? map) && MapDeviceInterface.Entity is not null && MapDeviceInterface.Entity.StoredMap is null or { IsAir: true })
+		{
+			Item invItem = Item.Clone();
+			Item.TurnToAir();
+			MapDeviceInterface.Entity.StoredMap = invItem;
+			SoundEngine.PlaySound(SoundID.Grab);
+		}
+	}
+
+	public override bool ConsumeItem(Player player)
+	{
+		return false;
 	}
 
 	public virtual ushort GetTileAt(int x, int y) { return TileID.Stone; }
@@ -80,7 +106,7 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 	{
 		var item = new Item();
 		item.SetDefaults(ModContent.ItemType<T>());
-		(item.ModItem as Map).Tier = 1;
+		(item.ModItem as Map)!.Tier = 1;
 
 		Item.NewItem(null, pos, Vector2.Zero, item);
 	}

--- a/Content/Passives/Melee/Masteries/WideSwingsMastery.cs
+++ b/Content/Passives/Melee/Masteries/WideSwingsMastery.cs
@@ -12,8 +12,6 @@ internal class WideSwingsMastery : Passive
 {
 	internal class WideSwingsPlayer : ModPlayer
 	{
-		public static Asset<Texture2D> PoisonIcon = null!;
-
 		internal int StacksCount => _stacks.Count;
 
 		private readonly List<int> _stacks = [];
@@ -24,11 +22,6 @@ internal class WideSwingsMastery : Passive
 		public void AddStack(int stack)
 		{
 			_stacks.Add(stack);
-		}
-
-		public override void Load()
-		{
-			PoisonIcon = ModContent.Request<Texture2D>("PathOfTerraria/Assets/Misc/VFX/PoisonIcon");
 		}
 
 		public override void PostUpdateEquips()
@@ -43,7 +36,10 @@ internal class WideSwingsMastery : Passive
 
 		public override void ModifyItemScale(Item item, ref float scale)
 		{
-			scale += _stacks.Count / 10f;
+			if (item.noMelee)
+			{
+				scale += _stacks.Count / 10f;
+			}
 		}
 
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)

--- a/Content/Passives/Melee/Masteries/WideSwingsMastery.cs
+++ b/Content/Passives/Melee/Masteries/WideSwingsMastery.cs
@@ -36,7 +36,7 @@ internal class WideSwingsMastery : Passive
 
 		public override void ModifyItemScale(Item item, ref float scale)
 		{
-			if (item.noMelee)
+			if (!item.noMelee)
 			{
 				scale += _stacks.Count / 10f;
 			}

--- a/Localization/de-DE/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		// Name: Magical Returnal
 		// Description: ""
+		// KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		// ReturnToOverworld: Return to the Overworld
 		// MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		// EnterEvilBiome: Find the Scientist in the Underground Corruption
-		// BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {

--- a/Localization/en-US/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		Name: Magical Returnal
 		Description: ""
+		KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		ReturnToOverworld: Return to the Overworld
 		MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		EnterEvilBiome: Find the Scientist in the Underground Corruption
-		BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		// Name: Magical Returnal
 		// Description: ""
+		// KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		// ReturnToOverworld: Return to the Overworld
 		// MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		// EnterEvilBiome: Find the Scientist in the Underground Corruption
-		// BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		Name: Retour Magique
 		// Description: ""
+		// KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		// ReturnToOverworld: Return to the Overworld
 		// MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		// EnterEvilBiome: Find the Scientist in the Underground Corruption
-		// BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		Name: Magiczny Powrót
 		// Description: ""
+		// KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		// ReturnToOverworld: Return to the Overworld
 		// MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		// EnterEvilBiome: Find the Scientist in the Underground Corruption
-		// BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		// Name: Magical Returnal
 		// Description: ""
+		// KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		// ReturnToOverworld: Return to the Overworld
 		// MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		// EnterEvilBiome: Find the Scientist in the Underground Corruption
-		// BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Quests.hjson
@@ -57,6 +57,7 @@ Quest: {
 	WizardStartQuest: {
 		Name: Волшебное возвращение
 		Description: ""
+		// KillScout: Kill a Goblin Surveyor in Ravencrest's outskirts
 	}
 
 	EoCQuest: {
@@ -74,7 +75,6 @@ Quest: {
 		// ReturnToOverworld: Return to the Overworld
 		// MorvenDialogue: Hm...oh. Hello, stranger. Thank you for getting me out of that bind. I'm afraid I went down here to track some Devourers I tagged...no matter. My trusty tools failed me, and somehow I'd become encased in this fetid stone. For a grueling few hours I've been here. Would you be so kind as to escort me out and bring me to the Raven Statue? I'll reward you greatly...or something.
 		// EnterEvilBiome: Find the Scientist in the Underground Corruption
-		// BlacksmithInput: Mods.PathOfTerraria.Quests.Quest.EoWQuest.BlacksmithInput
 	}
 
 	BoCQuest: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1693
Resolves: #1567
Resolves: #1556

### Description of Work
- Allowed control-shift click to move maps to storage in Map Device; shift click to move to map slot, if open
- Fixed missing reminder text in EoW quest
- Fixed duplicate Arcane Obelisks granted by quest
- Added step to kill a Goblin Surveyor in Ravencrest's outskirts in Wizard's first quest
- Made Home waypoint work at all times when in a subworld, removed now-irrelevant tutorialization

### Comments
Control-shift-left click functionality will need a tooltip somewhere for clarity.