### PR TITLE
Prevent mass-asserts in affix registry + resolve fishron quest issue.

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -40,40 +41,47 @@ public class AffixRegistry : ILoadable
 	public virtual void Unload() { }
 
 #nullable enable
-	public static ItemAffixData? TryGetAffixData(Type affixType, Item item)
+	/// <summary> Returns one or more affix item distributions entry specific to the provided arguments. Errors if none are found! </summary>
+	public static IEnumerable<ItemAffixData> GetItemData(Type affixType)
 	{
-		return TryGetAffixData(affixType, item.GetInstanceData().ItemType);
+		if (ByAffix.TryGetValue(affixType, out List<ItemAffixData>? values) && values.Count != 0)
+		{
+			return values;
+		}
+
+		throw new KeyNotFoundException($"No item data found for affix type '{affixType.Name}'!");
 	}
-	public static ItemAffixData? TryGetAffixData(Type affixType, ItemType itemType)
+	/// <summary> Unsafely acquires an ItemAffixData entry specific to the provided arguments. Errors if no such data exists! </summary>
+	public static ItemAffixData GetItemData(Type affixType, Item item)
+	{
+		return GetItemData(affixType, item.GetInstanceData().ItemType);
+	}
+	/// <summary> Unsafely acquires an ItemAffixData entry specific to the provided arguments. Errors if no such data exists! </summary>
+	public static ItemAffixData GetItemData(Type affixType, ItemType itemType)
+	{
+		if (TryGetItemData(affixType, itemType) is { } values)
+		{
+			return values;
+		}
+
+		throw new KeyNotFoundException($"No item data found for affix-type pair ('{affixType.Name}', '{itemType}')!");
+	}
+
+	/// <summary> Returns zero or more affix item distributions entry specific to the provided arguments. </summary>
+	public static IEnumerable<ItemAffixData>? TryGetItemData(Type affixType)
+	{
+		return ByAffix.TryGetValue(affixType, out List<ItemAffixData>? values) ? values : null;
+	}
+	/// <summary> Safely tries to acquire an affix item distribution entry specific to the provided arguments. </summary>
+	public static ItemAffixData? TryGetItemData(Type affixType, Item item)
+	{
+		return TryGetItemData(affixType, item.GetInstanceData().ItemType);
+	}
+	/// <summary> Safely tries to acquire an affix item distribution entry specific to the provided arguments. </summary>
+	public static ItemAffixData? TryGetItemData(Type affixType, ItemType itemType)
 	{
 		Debug.Assert(BitOperations.PopCount((ulong)itemType) == 1);
-
-		if (ByAffixAndItemType.TryGetValue((affixType, itemType), out ItemAffixData? values))
-		{
-			return values;
-		}
-
-		string msg = $"ItemAffixData not found for affix-item type pair ({affixType.Name}, {itemType}).";
-		PoTMod.Instance.Logger.Error(msg);
-		Debug.Fail(msg);
-		return null;
-	}
-
-	/// <summary> Provides a safe way of getting ItemAffixData from the ItemAffixData map. </summary>
-	public static IEnumerable<ItemAffixData> TryGetAffixDatas<T>() where T : Affix
-	{
-		return TryGetAffixDatas(typeof(T));
-	}
-	/// <summary> Provides a safe way of getting ItemAffixData from the ItemAffixData map. </summary>
-	public static IEnumerable<ItemAffixData> TryGetAffixDatas(Type affixType)
-	{
-		if (ByAffix.TryGetValue(affixType, out List<ItemAffixData>? values))
-		{
-			return values;
-		}
-
-		PoTMod.Instance.Logger.Error($"ItemAffixData not found for affix type {affixType.Name}.");
-		return [];
+		return ByAffixAndItemType.TryGetValue((affixType, itemType), out ItemAffixData? result) ? result : null;
 	}
 #nullable disable
 
@@ -205,10 +213,7 @@ public class AffixRegistry : ILoadable
 	{
 		// Get the corresponding ItemAffixData for the affix's type
 		Type affixType = affix.GetType();
-		if (TryGetAffixData(affixType, item) is not ItemAffixData affixData)
-		{
-			throw new ArgumentException($"ItemAffixData not found for affix type: {affixType.Name}");
-		}
+		ItemAffixData affixData = GetItemData(affixType, item);
 
 		if (itemLevel == 0)
 		{

--- a/Common/NPCs/Effects/NPCHitEffects.cs
+++ b/Common/NPCs/Effects/NPCHitEffects.cs
@@ -196,7 +196,7 @@ public sealed class NPCHitEffects : NPCComponent
 
 				Vector2 pos = npc.position;
 				// Add hitbox factor.
-				pos += pool.Position.HitboxFactor * Main.rand.NextFloat() * npcSize;
+				pos += pool.Position.HitboxFactor * new Vector2(Main.rand.NextFloat(), Main.rand.NextFloat()) * npcSize;
 				// If hitbox factor is below 1, move towards center.
 				pos += npcSize * 0.5f * (Vector2.One - pool.Position.HitboxFactor);
 				// Add flat.

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -20,7 +20,7 @@ public abstract class ItemAffix : Affix
 	/// </summary>
 	public virtual void ApplyTooltips(Player player, Item item, AffixTooltips handler)
 	{
-		var instanceData = item.GetInstanceData();
+		PoTInstanceItemData instanceData = item.GetInstanceData();
 		handler.AddOrModify(GetType(), CreateDefaultTooltip(player, instanceData.ItemType, instanceData.RealLevel));
 	}
 	/// <inheritdoc cref="ApplyTooltips(Player, Item, AffixTooltips)"/>
@@ -31,7 +31,7 @@ public abstract class ItemAffix : Affix
 
 	protected virtual AffixTooltipLine CreateDefaultTooltip(Player player, ItemType itemType, int itemLevel)
 	{
-		ItemAffixData? data = GetData(itemType);
+		ItemAffixData? data = TryGetData(itemType);
 
 		if (data is null) // Data can be null if the affix doesn't exist in the json data. This skips the checks below.
 		{
@@ -68,29 +68,29 @@ public abstract class ItemAffix : Affix
 		return CreateDefaultTooltip(player, item);
 	}
 
-	/// <summary> Retrieves the item affix data for the current <see cref="ItemAffix"/> instance and the provided exact item type. </summary>
-	public ItemAffixData? GetData(ItemType exactItemType)
-	{
-		return AffixRegistry.TryGetAffixData(GetType(), exactItemType);
-	}
-	/// <summary> Retrieves the item affix data for the current <see cref="ItemAffix"/> instance and the provided item. </summary>
-	public ItemAffixData? GetData(Item item)
-	{
-		return AffixRegistry.TryGetAffixData(GetType(), item);
-	}
-	/// <summary> Retrieves all the item affix data for the current <see cref="ItemAffix"/> instance. </summary>
-	public IEnumerable<ItemAffixData> GetDatas()
-	{
-		return AffixRegistry.TryGetAffixDatas(GetType());
-	}
+	/// <inheritdoc cref="AffixRegistry.GetItemData(Type)"/>
+	public IEnumerable<ItemAffixData> GetData() { return AffixRegistry.GetItemData(GetType()); }
+	/// <inheritdoc cref="AffixRegistry.GetItemData(Type, Item)"/>
+	public ItemAffixData GetData(Item item) { return AffixRegistry.GetItemData(GetType(), item); }
+	/// <inheritdoc cref="AffixRegistry.GetItemData(Type, ItemType)"/>
+	public ItemAffixData GetData(ItemType exactItemType) { return AffixRegistry.GetItemData(GetType(), exactItemType); }
+
+	/// <inheritdoc cref="AffixRegistry.TryGetItemData(Type)"/>
+	public IEnumerable<ItemAffixData>? TryGetData() { return AffixRegistry.TryGetItemData(GetType()); }
+	/// <inheritdoc cref="AffixRegistry.TryGetItemData(Type, Item)"/>
+	public ItemAffixData? TryGetData(Item item) { return AffixRegistry.TryGetItemData(GetType(), item); }
+	/// <inheritdoc cref="AffixRegistry.TryGetItemData(Type, ItemType)"/>
+	public ItemAffixData? TryGetData(ItemType exactItemType) { return AffixRegistry.TryGetItemData(GetType(), exactItemType); }
 
 	public Influence GetRequiredInfluence(Item item)
 	{
-		return GetData(item)?.GetInfluences() ?? Influence.None;
+		const Influence Default = Influence.None;
+		return TryGetData(item)?.GetInfluences() ?? Default;
 	}
 	public ItemType GetPossibleTypes()
 	{
-		return GetDatas().Aggregate<ItemAffixData, ItemType>(default, (current, data) => current | data.GetEquipTypes());
+		const ItemType Default = ItemType.None;
+		return TryGetData()?.Aggregate(Default, (current, data) => current | data.GetEquipTypes()) ?? Default;
 	}
 
 	internal override void CreateLocalization()

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/FishronQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/FishronQuest.cs
@@ -88,6 +88,8 @@ file sealed class FishronQuestSystem : ModSystem
 {
 	public override void PreUpdateWorld()
 	{
+		if (SubworldSystem.Current is not null) { return; }
+		
 		int riftType = ModContent.ProjectileType<UnderwaterRift>();
 		bool riftShouldExist = false;
 		foreach (Player player in Main.ActivePlayers)

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -7,6 +7,7 @@ using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Data;
 using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Utilities;
 using SubworldLibrary;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
@@ -123,7 +124,8 @@ public static class PoTItemHelper
 			return;
 		}
 
-		ItemAffixData chosenAffix = AffixRegistry.GetRandomAffixDataByItemType(data.ItemType, excludedAffixes: data.Affixes.Select(a => a.GetData(item)));
+		IEnumerable<ItemAffixData> exclusions = data.Affixes.SelectExcept(null, a => a.TryGetData(item));
+		ItemAffixData chosenAffix = AffixRegistry.GetRandomAffixDataByItemType(data.ItemType, excludedAffixes: exclusions);
 		if (chosenAffix is null)
 		{
 			return;

--- a/Utilities/LinqUtils.cs
+++ b/Utilities/LinqUtils.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Numerics;
+
+namespace PathOfTerraria.Utilities;
+
+internal static class LinqUtils
+{
+	public static IEnumerable<TResult> SelectExcept<TSource, TResult>(this IEnumerable<TSource> values, TResult exception, Func<TSource, TResult> selector)
+	{
+		foreach (TSource value in values)
+		{
+			TResult result = selector(value);
+			if (!result.Equals(exception)) { yield return result; }
+		}
+	}
+}


### PR DESCRIPTION
### Description of Work
Internal hotfixes:
- Tweaked AffixRegistry API again to make it more fool-proof. Removed recently added asserts, throwing exceptions instead in new non-Try functions.
- Fixed the Fishron quest's underwater rift spawning outside the primary world.
- Fixed HitboxFactor in gore positioning code only shifting gores in a diagonal line.