### PR TITLE
Optimization and il detours

### DIFF
--- a/Common/Projectiles/CustomProjectileSets.cs
+++ b/Common/Projectiles/CustomProjectileSets.cs
@@ -1,0 +1,15 @@
+﻿using Terraria.ID;
+
+namespace PathOfTerraria.Common.Projectiles;
+
+[ReinitializeDuringResizeArrays]
+internal class CustomProjectileSets
+{
+	/// <summary>
+	/// Defines which minion projectiles are multisegment, such as the body/tail of the Stardust Dragon projectile.<br/>
+	/// This is useful when doing actions per-minion that should avoid also occuring for each segment of a segmented minion.
+	/// </summary>
+	public static bool[] MultisegmentMinionProjectiles = ProjectileID.Sets.Factory.CreateNamedSet(PoTMod.Instance, "MultisegmentMinionProjectiles")
+		.Description("Defines which minion projectiles are multisegment, such as the body/tail of the Stardust Dragon projectile.")
+		.RegisterBoolSet(false, [ProjectileID.StardustDragon2, ProjectileID.StardustDragon3, ProjectileID.StardustDragon4]);
+}

--- a/Common/Projectiles/SpeedUpProjectile.cs
+++ b/Common/Projectiles/SpeedUpProjectile.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Utilities;
 using System.Runtime.CompilerServices;
 using Terraria.ID;
 
@@ -31,17 +32,14 @@ public class SpeedUpProjectile : GlobalProjectile
 
 	public override void Load()
 	{
-		On_Projectile.Update += ResetProjectileValues;
-	}
-
-	private void ResetProjectileValues(On_Projectile.orig_Update orig, Projectile self, int i)
-	{
-		if (self.TryGetGlobalProjectile(out SpeedUpProjectile speed))
+		// Used to reset all projectile's speed modifier early enough for it to not impact the next frame
+		ILUtils.EmitILDetour(typeof(Projectile).GetMethod("Update"), (Projectile self, int i) =>
 		{
-			speed.VelocityModifier = 0;
-		}
-
-		orig(self, i);
+			if (self.TryGetGlobalProjectile(out SpeedUpProjectile speed))
+			{
+				speed.VelocityModifier = 0;
+			}
+		}, null);
 	}
 
 	public override bool AppliesToEntity(Projectile entity, bool lateInstantiation)

--- a/Common/Subworlds/BossDomains/Prehardmode/BrainDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/BrainDomain.cs
@@ -1,22 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode.BoCDomain;
+using PathOfTerraria.Common.Systems.BossTrackingSystems;
+using PathOfTerraria.Common.UI.SubworldHelp;
+using PathOfTerraria.Common.World.Generation;
+using PathOfTerraria.Content.NPCs.Town;
+using PathOfTerraria.Content.Projectiles.Utility;
+using PathOfTerraria.Content.Tiles.BossDomain;
+using SubworldLibrary;
+using System.Collections.Generic;
+using System.Linq;
 using Terraria.DataStructures;
+using Terraria.Enums;
 using Terraria.GameContent.Generation;
 using Terraria.ID;
 using Terraria.IO;
+using Terraria.Localization;
 using Terraria.Utilities;
 using Terraria.WorldBuilding;
-using PathOfTerraria.Common.World.Generation;
-using SubworldLibrary;
-using Terraria.Enums;
-using Terraria.Localization;
-using PathOfTerraria.Common.World;
-using System.Linq;
-using PathOfTerraria.Content.Tiles.BossDomain;
-using PathOfTerraria.Content.Projectiles.Utility;
-using PathOfTerraria.Content.NPCs.Town;
-using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode.BoCDomain;
-using PathOfTerraria.Common.Systems.BossTrackingSystems;
-using System.Diagnostics;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
 
@@ -52,6 +51,14 @@ public class BrainDomain : BossDomainSubworld
 		base.ReadCopiedMainWorldData();
 
 		ModContent.GetInstance<BoCDomainSystem>().HasLloyd = SubworldSystem.ReadCopiedWorldData<bool>("hasLloyd");
+	}
+
+	public override void ModifyHelpTooltips(List<DrawableTooltipLine> lines, Vector2 scale)
+	{
+		if (lines.FindIndex(x => x.Name == "Desc") is { } index and not -1)
+		{
+			SubworldHelpInvButton.AddLine(lines, "Extra", Language.GetTextValue("Mods.PathOfTerraria.Subworlds.BrainDomain.Extra"), scale, null, index + 1);
+		}
 	}
 
 	private void SpawnDecor(GenerationProgress progress, GameConfiguration configuration)

--- a/Common/Subworlds/BossDomains/Prehardmode/DeerDomain/DeerclopsDomainLightEdits.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/DeerDomain/DeerclopsDomainLightEdits.cs
@@ -1,4 +1,6 @@
-﻿using SubworldLibrary;
+﻿using PathOfTerraria.Utilities;
+using SubworldLibrary;
+using System.Reflection;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode.DeerDomain;
 
@@ -8,10 +10,15 @@ internal class DeerclopsDomainLightEdits : ModSystem
 
 	public override void Load()
 	{
+		ILUtils.EmitILDetour(typeof(Main).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance), (Main self, GameTime gameTime) =>
+		{
+			// Reset light multiplier before anything else updates so it doesn't mess up drawing later
+			LightMultiplier = 0;
+		}, null);
+
 		On_Lighting.AddLight_int_int_float_float_float += HijackAddLight;
 		On_Lighting.AddLight_int_int_int_float += HideTorchLight;
 		On_Player.ItemCheck += SoftenPlayerLight;
-		On_Main.Update += ResetLightMul;
 		On_Projectile.ProjLight += HideProjLight;
 		On_Dust.UpdateDust += HideDustLight;
 	}
@@ -38,12 +45,6 @@ internal class DeerclopsDomainLightEdits : ModSystem
 		LightMultiplier = 0f;
 		orig(self);
 		LightMultiplier = 0f;
-	}
-
-	private void ResetLightMul(On_Main.orig_Update orig, Main self, GameTime gameTime)
-	{
-		LightMultiplier = 0;
-		orig(self, gameTime);
 	}
 
 	private void SoftenPlayerLight(On_Player.orig_ItemCheck orig, Player self)

--- a/Common/Subworlds/MappingWorld.cs
+++ b/Common/Subworlds/MappingWorld.cs
@@ -6,6 +6,7 @@ using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.DisableBuilding;
 using PathOfTerraria.Common.UI;
+using PathOfTerraria.Common.UI.SubworldHelp;
 using ReLogic.Content;
 using SubworldLibrary;
 using Terraria.ID;
@@ -242,6 +243,31 @@ public abstract class MappingWorld : Subworld
 	public override void DrawMenu(GameTime gameTime)
 	{
 		SubworldLoadingScreen.DrawLoading(this);
+	}
+
+	public virtual void ModifyLoadScreenDescripton(ref string input)
+	{
+	}
+
+	/// <summary>
+	/// Allows dynamic modification of the tooltips displayed in the Subworld Help UI element under the inventory.<br/>
+	/// Valid names for finding indexes are:<br/>
+	/// <b>Info</b> - "Info" header<br/>
+	/// <b>Name</b> - Name of the domain<br/>
+	/// <b>Desc</b> - Description of the domain<br/>
+	/// <b>Mining</b> - Mining blocklist<br/>
+	/// <b>Placing</b> - Placing blocklist<br/>
+	/// <b>Tier</b> - Only appears if this is a high enough level to have a tier (level 45+). Displays the map's current tier<br/><br/>
+	/// The following only appear when the map have affixes<br/>
+	/// <b>AffixHeading</b> - Affix header<br/>
+	/// <b>MapAffix0..N</b> - Affix information for the given slot<br/>
+	/// <b>ModifierStrength</b> - "Map Strength" modifier, which is the value used for calculating benefits<br/>
+	/// <b>ExpMod</b> - Experience modifier<br/>
+	/// <b>RateMod</b> - Drop rate modifier<br/>
+	/// <b>RarityMod</b> - Drop rarity modifier<br/>
+	/// </summary>
+	public virtual void ModifyHelpTooltips(List<DrawableTooltipLine> lines, Vector2 scale)
+	{
 	}
 
 	internal static int ModifyExperience(int experience)

--- a/Common/Systems/PassiveTreeSystem/Passive.cs
+++ b/Common/Systems/PassiveTreeSystem/Passive.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Mechanics;
@@ -18,9 +17,13 @@ internal class PassiveLoader : ILoadable
 	public void Unload() { }
 }
 
+[Autoload(false)] // Loading is handled in LoadPassives a bit below
 public abstract class Passive : Allocatable, ILoadable
 {
 	public static Dictionary<string, Type> Passives = [];
+
+	internal static Dictionary<string, int> PassiveNameToId = [];
+	internal static int MaxId { get; private set; }
 
 	/// <summary> If true, this passive will be given a special UI element that allows players to choose only one of its children. </summary>
 	public bool IsChoiceNode { get; set; }
@@ -29,9 +32,16 @@ public abstract class Passive : Allocatable, ILoadable
 	/// This is used to map the JSON data to the correct passive. This is also what's used to grab the texture of this passive.
 	/// </summary>
 	public override string Name => GetType().Name;
-	
-	// This is used to create a reference to the created passive for connections
+
+	/// <summary>
+	/// This is used to create a reference to the created passive for connections in JSON.
+	/// </summary>
 	public int ReferenceId;
+
+	/// <summary>
+	/// Runtime ID assigned for lookup tables.
+	/// </summary>
+	public int ID;
 
 	public override string TexturePath => $"{PoTMod.ModName}/Assets/Passives/" + Name;
 	/// <summary>
@@ -60,8 +70,10 @@ public abstract class Passive : Allocatable, ILoadable
 	public static void LoadPassives()
 	{
 		Mod mod = PoTMod.Instance;
+		int id = 0;
 
 		Passives.Clear();
+		PassiveNameToId.Clear();
 
 		foreach (Type type in AssemblyManager.GetLoadableTypes(mod.Code))
 		{
@@ -71,6 +83,7 @@ public abstract class Passive : Allocatable, ILoadable
 			}
 
 			var instance = (Passive)Activator.CreateInstance(type);
+			instance.ID = id++;
 			mod.AddContent(instance);
 
 			// Automatically registers the given keys for each instance loaded, and sets Name to the class's name and Description to empty if they do not exist.
@@ -78,7 +91,10 @@ public abstract class Passive : Allocatable, ILoadable
 			Language.GetOrRegister("Mods.PathOfTerraria.Passives." + instance.Name + ".Tooltip", () => "");
 
 			Passives.Add(instance.Name, type);
+			PassiveNameToId.Add(instance.Name, instance.ID);
 		}
+
+		MaxId = id - 1;
 	}
 
 	public static Passive GetPassiveFromData(PassiveData data)
@@ -88,7 +104,7 @@ public abstract class Passive : Allocatable, ILoadable
 			return null;
 		}
 
-		var p = (Passive) Activator.CreateInstance(value);
+		var p = (Passive)Activator.CreateInstance(value);
 
 		if (p is null)
 		{

--- a/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
@@ -313,7 +313,7 @@ internal class PassiveTreePlayer : ModPlayer
 #if DEBUG
 		else
 		{
-			Main.NewText($"Deallocation ran on a passive with no allocation to begin with? {passive.Name}");
+			System.Diagnostics.Debug.Fail($"Deallocation ran on a passive with no allocation to begin with? {passive.Name}");
 		}
 #endif
 

--- a/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
@@ -1,13 +1,14 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using PathOfTerraria.Common.Data;
+﻿using PathOfTerraria.Common.Data;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.UI;
+using PathOfTerraria.Common.UI.Guide;
 using PathOfTerraria.Content.Passives;
 using PathOfTerraria.Content.Passives.Misc;
 using PathOfTerraria.Core.UI.SmartUI;
+using System.Collections.Generic;
+using System.Linq;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Systems.PassiveTreeSystem;
@@ -25,6 +26,7 @@ internal class PassiveTreePlayer : ModPlayer
 	/// </summary>
 	public int ExtraPoints;
 
+	public float[] StrengthByPassive = new float[Passive.MaxId];
 	public List<Passive> ActiveNodes = [];
 	public List<Edge<Allocatable>> Edges = [];
 
@@ -42,14 +44,30 @@ internal class PassiveTreePlayer : ModPlayer
 		ExpModPlayer expPlayer = Main.LocalPlayer.GetModPlayer<ExpModPlayer>();
 		Points = expPlayer.EffectiveLevel + ExtraPoints;
 
-		SetTree();
+		SetTree(false);
 	}
 
-	private void SetTree()
+	/// <summary>
+	/// Sets or updates the tree according to the player's information.
+	/// </summary>
+	private void SetTree(bool setStrengths)
 	{
 		foreach (Passive passive in ActiveNodes.Where(passive => passive != null))
 		{
+			int oldLevel = passive.Level;
 			passive.Level = _saveData.TryGet(passive.ReferenceId.ToString(), out int level) ? level : passive.Name == "AnchorPassive" ? 1 : 0;
+
+			if (setStrengths)
+			{
+				if (oldLevel < passive.Level)
+				{
+					AllocatePassive(passive, passive.Level - oldLevel, false);
+				}
+				else if (oldLevel > passive.Level)
+				{
+					DeallocatePassive(passive, oldLevel - passive.Level);
+				}
+			}
 
 			if (passive is JewelSocket jsPassive)
 			{
@@ -76,7 +94,9 @@ internal class PassiveTreePlayer : ModPlayer
 
 		data.ForEach(n =>
 		{
-			passives.Add(n.ReferenceId, Passive.GetPassiveFromData(n));
+			var passive = Passive.GetPassiveFromData(n);
+			passives.Add(n.ReferenceId, passive);
+
 			if (passives[n.ReferenceId] != null)
 			{
 				ActiveNodes.Add(passives[n.ReferenceId]);
@@ -131,14 +151,10 @@ internal class PassiveTreePlayer : ModPlayer
 				continue;
 			}
 
-			while (node.Level > 0)
+			if (node.Level > 0)
 			{
-				node.OnDeallocate(Player);
-
-				if (node is not MasteryPassive)
-				{
-					Points++;
-				}
+				Player.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(node, node.Level, false);
+				node.Level = 0;
 			}
 		}
 
@@ -151,31 +167,21 @@ internal class PassiveTreePlayer : ModPlayer
 		ExtraPoints = tag.GetInt("extraPoints");
 
 		ResetNodes();
-		SetTree();
+		SetTree(true);
 	}
 
 	/// <summary>
-	/// Gets the total value of every node of a given type on the passive tree. This includes multiplying a node's value by its level, though level is almost always 1.
+	/// Gets the total value of every node of a given type on the passive tree.
 	/// </summary>
-	internal float GetCumulativeValue<T>()
+	internal float GetCumulativeValue<T>() where T : Passive
 	{
-		float value = 0f;
-
-		foreach (Passive passive in ActiveNodes)
-		{
-			if (passive is T && passive.Level > 0)
-			{
-				value += passive.Value * passive.Level;
-			}
-		}
-
-		return value;
+		return StrengthByPassive[ModContent.GetInstance<T>().ID];
 	}
 
 	/// <summary>
 	/// Same as <see cref="GetCumulativeValue{T}"/>, but returns false if <paramref name="value"/> is 0.
 	/// </summary>
-	internal bool TryGetCumulativeValue<T>(out float value)
+	internal bool TryGetCumulativeValue<T>(out float value) where T : Passive
 	{
 		value = GetCumulativeValue<T>();
 		return value > 0;
@@ -265,5 +271,55 @@ internal class PassiveTreePlayer : ModPlayer
 		}
 
 		return new(false, []);
+	}
+
+	internal void AllocatePassive(Passive passive, int strength = 1, bool save = true)
+	{
+		if (passive is MasteryPassive) // Hardcode for this, which doesn't work the same as any other passive
+		{
+			return;
+		}
+
+		Points--;
+		Player.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.AllocatedPassive);
+		int id = Passive.PassiveNameToId[passive.Name];
+		StrengthByPassive[id] += strength;
+
+		if (save)
+		{
+			SaveData([]); // Instantly save the result because _saveData is needed whenever the element reloads - same in DeallocatePassive
+		}
+	}
+
+	internal void DeallocatePassive(Passive passive, int usedCost, bool save = true)
+	{
+		if (passive is MasteryPassive)
+		{
+			passive.Level--;
+			return;
+		}
+
+		int id = Passive.PassiveNameToId[passive.Name];
+
+		Points += usedCost;
+		Player.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.DeallocatedPassive);
+
+		ref float str = ref StrengthByPassive[id];
+
+		if (str > 0)
+		{
+			str = Math.Max(0, str - usedCost);
+		}
+#if DEBUG
+		else
+		{
+			Main.NewText($"Deallocation ran on a passive with no allocation to begin with? {passive.Name}");
+		}
+#endif
+
+		if (save)
+		{
+			SaveData([]);
+		}
 	}
 }

--- a/Common/Systems/VanillaModifications/AntiDespawnSystem/ForceNoDespawning.cs
+++ b/Common/Systems/VanillaModifications/AntiDespawnSystem/ForceNoDespawning.cs
@@ -1,5 +1,7 @@
 ﻿using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Utilities;
 using SubworldLibrary;
+using System.Reflection;
 using Terraria.ID;
 
 namespace PathOfTerraria.Common.Systems.VanillaModifications.AntiDespawnSystem;
@@ -7,14 +9,38 @@ namespace PathOfTerraria.Common.Systems.VanillaModifications.AntiDespawnSystem;
 internal class ForceNoDespawning : GlobalNPC
 {
 	public static bool AnyPlayerIsAlive = false;
+	public static int OldLife = 0;
 
 	public override void Load()
 	{
-		On_Main.Update += EarlyUnsetPlayerFlag;
-		On_NPC.UpdateNPC += StopDespawnsByForce;
+		ILUtils.EmitILDetour(typeof(Main).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance), SetPlayersAlive, null);
+		ILUtils.EmitILDetour(typeof(NPC).GetMethod("UpdateNPC"), CacheLife, ForceSetNPCAlive);
+		
+		//On_Main.Update += EarlyUnsetPlayerFlag;
+		//On_NPC.UpdateNPC += StopDespawnsByForce;
 	}
 
-	private void EarlyUnsetPlayerFlag(On_Main.orig_Update orig, Main self, GameTime gameTime)
+	public static void CacheLife(NPC self, int i)
+	{
+		OldLife = self.life;
+	}
+
+	public static void ForceSetNPCAlive(NPC self, int i)
+	{
+		int life = OldLife;
+
+		// Aggressively stop despawning by forcing bosses that have health and were active to continue to be active, if we're in a boss domain and any player is alive
+		// Note - excludes many multi-segment or nonstandard NPCs, which caused a crazy bug that spammed exp and item drops infinitely
+		if ((self.boss || NPCID.Sets.ShouldBeCountedAsBoss[self.type]) && SubworldSystem.Current is BossDomainSubworld && !self.active && life > 0 && AnyPlayerIsAlive
+			&& !(self.type is NPCID.EaterofWorldsHead or NPCID.EaterofWorldsTail or NPCID.MoonLordCore or NPCID.MoonLordFreeEye or NPCID.MoonLordHead or NPCID.MoonLordHand
+			or NPCID.LunarTowerVortex or NPCID.LunarTowerStardust or NPCID.LunarTowerSolar or NPCID.LunarTowerNebula))
+		{
+			self.active = true;
+			self.life = life;
+		}
+	}
+
+	public static void SetPlayersAlive(Main self, GameTime gameTime)
 	{
 		AnyPlayerIsAlive = false;
 
@@ -26,19 +52,32 @@ internal class ForceNoDespawning : GlobalNPC
 				break;
 			}
 		}
-
-		orig(self, gameTime);
 	}
+
+	//private void EarlyUnsetPlayerFlag(On_Main.orig_Update orig, Main self, GameTime gameTime)
+	//{
+	//	AnyPlayerIsAlive = false;
+
+	//	foreach (Player player in Main.ActivePlayers)
+	//	{
+	//		if (!player.dead && !player.ghost)
+	//		{
+	//			AnyPlayerIsAlive = true;
+	//			break;
+	//		}
+	//	}
+
+	//	orig(self, gameTime);
+	//}
 
 	private void StopDespawnsByForce(On_NPC.orig_UpdateNPC orig, NPC self, int i)
 	{
 		int life = self.life;
-		int target = self.target;
 
 		orig(self, i);
 
 		// Aggressively stop despawning by forcing bosses that have health and were active to continue to be active, if we're in a boss domain and any player is alive
-		// Note - excludes EoW's Head and Tail, which caused a crazy bug that spammed exp and item drops infinitely
+		// Note - excludes many multi-segment or nonstandard NPCs, which caused a crazy bug that spammed exp and item drops infinitely
 		if ((self.boss || NPCID.Sets.ShouldBeCountedAsBoss[self.type]) && SubworldSystem.Current is BossDomainSubworld && !self.active && life > 0 && AnyPlayerIsAlive
 			&& !(self.type is NPCID.EaterofWorldsHead or NPCID.EaterofWorldsTail or NPCID.MoonLordCore or NPCID.MoonLordFreeEye or NPCID.MoonLordHead or NPCID.MoonLordHand 
 			or NPCID.LunarTowerVortex or NPCID.LunarTowerStardust or NPCID.LunarTowerSolar or NPCID.LunarTowerNebula))

--- a/Common/Systems/VanillaModifications/AntiDespawnSystem/ForceNoDespawning.cs
+++ b/Common/Systems/VanillaModifications/AntiDespawnSystem/ForceNoDespawning.cs
@@ -15,9 +15,6 @@ internal class ForceNoDespawning : GlobalNPC
 	{
 		ILUtils.EmitILDetour(typeof(Main).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance), SetPlayersAlive, null);
 		ILUtils.EmitILDetour(typeof(NPC).GetMethod("UpdateNPC"), CacheLife, ForceSetNPCAlive);
-		
-		//On_Main.Update += EarlyUnsetPlayerFlag;
-		//On_NPC.UpdateNPC += StopDespawnsByForce;
 	}
 
 	public static void CacheLife(NPC self, int i)
@@ -51,39 +48,6 @@ internal class ForceNoDespawning : GlobalNPC
 				AnyPlayerIsAlive = true;
 				break;
 			}
-		}
-	}
-
-	//private void EarlyUnsetPlayerFlag(On_Main.orig_Update orig, Main self, GameTime gameTime)
-	//{
-	//	AnyPlayerIsAlive = false;
-
-	//	foreach (Player player in Main.ActivePlayers)
-	//	{
-	//		if (!player.dead && !player.ghost)
-	//		{
-	//			AnyPlayerIsAlive = true;
-	//			break;
-	//		}
-	//	}
-
-	//	orig(self, gameTime);
-	//}
-
-	private void StopDespawnsByForce(On_NPC.orig_UpdateNPC orig, NPC self, int i)
-	{
-		int life = self.life;
-
-		orig(self, i);
-
-		// Aggressively stop despawning by forcing bosses that have health and were active to continue to be active, if we're in a boss domain and any player is alive
-		// Note - excludes many multi-segment or nonstandard NPCs, which caused a crazy bug that spammed exp and item drops infinitely
-		if ((self.boss || NPCID.Sets.ShouldBeCountedAsBoss[self.type]) && SubworldSystem.Current is BossDomainSubworld && !self.active && life > 0 && AnyPlayerIsAlive
-			&& !(self.type is NPCID.EaterofWorldsHead or NPCID.EaterofWorldsTail or NPCID.MoonLordCore or NPCID.MoonLordFreeEye or NPCID.MoonLordHead or NPCID.MoonLordHand 
-			or NPCID.LunarTowerVortex or NPCID.LunarTowerStardust or NPCID.LunarTowerSolar or NPCID.LunarTowerNebula))
-		{
-			self.active = true;
-			self.life = life;
 		}
 	}
 

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Content.Passives.Misc;
 using Terraria.UI;
 
 #nullable enable

--- a/Common/UI/PassiveTree/PassiveElement.cs
+++ b/Common/UI/PassiveTree/PassiveElement.cs
@@ -1,7 +1,8 @@
-﻿using PathOfTerraria.Common.Mechanics;
+﻿using PathOfTerraria.Common.Looting.VirtualBagUI;
+using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
-using PathOfTerraria.Common.UI.Guide;
 using PathOfTerraria.Content.Passives;
+using PathOfTerraria.Content.Passives.Misc;
 using Terraria.Audio;
 using Terraria.ID;
 using Terraria.UI;
@@ -41,12 +42,7 @@ internal class PassiveElement : AllocatableElement
 	protected override void Allocate(Allocatable passive, int usedCost)
 	{
 		base.Allocate(passive, usedCost);
-
-		Player p = Main.LocalPlayer;
-
-		p.GetModPlayer<PassiveTreePlayer>().Points -= usedCost;
-		p.GetModPlayer<PassiveTreePlayer>().SaveData([]); // Instantly save the result because _saveData is needed whenever the element reloads
-		p.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.AllocatedPassive);
+		Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().AllocatePassive((Passive)passive);
 	}
 
 	public override void SafeRightClick(UIMouseEvent evt)
@@ -61,12 +57,7 @@ internal class PassiveElement : AllocatableElement
 	{
 		base.Deallocate(passive, usedCost);
 
-		Player p = Main.LocalPlayer;
-
-		p.GetModPlayer<PassiveTreePlayer>().Points += usedCost;
-		p.GetModPlayer<PassiveTreePlayer>().SaveData([]); // Instantly save the result because _saveData is needed whenever the element reloads
-		p.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.DeallocatedPassive);
-		
+		Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(Passive, usedCost);
 		SoundEngine.PlaySound(SoundID.DD2_WitherBeastDeath);
 	}
 }

--- a/Common/UI/SubworldHelp/SubworldHelpInvButton.cs
+++ b/Common/UI/SubworldHelp/SubworldHelpInvButton.cs
@@ -99,12 +99,22 @@ public class SubworldHelpInvButton : SmartUiState
 			AddLine(lines, "RarityMod", Language.GetTextValue("Mods.PathOfTerraria.UI.SubworldHelp.DropRarityBoost") + rarityModifier.ToString("#0.##") + "%", scale);
 		}
 
+		CurrentWorld.ModifyHelpTooltips(lines, scale);
 		return lines;
 	}
 
-	private static void AddLine(List<DrawableTooltipLine> lines, string name, string text, Vector2 scale, Color? color = null)
+	internal static void AddLine(List<DrawableTooltipLine> lines, string name, string text, Vector2 scale, Color? color = null, int index = -1)
 	{
-		lines.Add(new DrawableTooltipLine(new TooltipLine(PoTMod.Instance, name, text), lines.Count, 0, lines.Count * 24, color ?? Color.White) { BaseScale = scale });
+		var line = new DrawableTooltipLine(new TooltipLine(PoTMod.Instance, name, text), lines.Count, 0, lines.Count * 24, color ?? Color.White) { BaseScale = scale };
+
+		if (index == -1)
+		{
+			lines.Add(line);
+		}
+		else
+		{
+			lines.Insert(index, line);
+		}
 	}
 
 	public override void SafeClick(UIMouseEvent evt)

--- a/Common/UI/SubworldLoadingScreen.cs
+++ b/Common/UI/SubworldLoadingScreen.cs
@@ -38,7 +38,10 @@ internal static class SubworldLoadingScreen
 		{
 			DrawStringCentered(Language.GetTextValue("Mods.PathOfTerraria.Subworlds.Entering"), Color.LightGray, new Vector2(0, -360), 0.4f, true);
 			DrawStringCentered(mappingWorld.SubworldName.Value, Color.White, new Vector2(0, -310), 1.1f, true);
-			DrawStringCentered(mappingWorld.SubworldDescription.Value, Color.White, new Vector2(0, -250), 0.5f, true);
+
+			string desc = mappingWorld.SubworldDescription.Value;
+			mappingWorld.ModifyLoadScreenDescripton(ref desc);
+			DrawStringCentered(desc, Color.White, new Vector2(0, -250), 0.5f, true);
 		}
 		else
 		{

--- a/Content/Passives/Summon/SmallPassives/MinionDamageAuraPassive.cs
+++ b/Content/Passives/Summon/SmallPassives/MinionDamageAuraPassive.cs
@@ -24,7 +24,7 @@ internal class MinionDamageAuraPassive : Passive
 
 		public override bool PreAI(Projectile proj)
 		{
-			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value) || !AppliesToEntity(proj, true))
+			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value))
 			{
 				return true;
 			}
@@ -44,7 +44,7 @@ internal class MinionDamageAuraPassive : Passive
 		public override bool PreDraw(Projectile proj, ref Color lightColor)
 		{
 			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value) 
-				|| !ModContent.GetInstance<GameplayConfig>().NearbyAuras || !AppliesToEntity(proj, true))
+				|| !ModContent.GetInstance<GameplayConfig>().NearbyAuras)
 			{
 				return true;
 			}

--- a/Content/Passives/Summon/SmallPassives/MinionDamageAuraPassive.cs
+++ b/Content/Passives/Summon/SmallPassives/MinionDamageAuraPassive.cs
@@ -1,4 +1,5 @@
 using PathOfTerraria.Common.Config;
+using PathOfTerraria.Common.Projectiles;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Content.Buffs;
 using ReLogic.Content;
@@ -16,10 +17,14 @@ internal class MinionDamageAuraPassive : Passive
 			Aura = ModContent.Request<Texture2D>("PathOfTerraria/Assets/Misc/VFX/MinionDamageAura");
 		}
 
+		public override bool AppliesToEntity(Projectile entity, bool lateInstantiation)
+		{
+			return entity.minion && !CustomProjectileSets.MultisegmentMinionProjectiles[entity.type];
+		}
+
 		public override bool PreAI(Projectile proj)
 		{
-			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value)
-				|| !proj.minion)
+			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value) || !AppliesToEntity(proj, true))
 			{
 				return true;
 			}
@@ -38,8 +43,8 @@ internal class MinionDamageAuraPassive : Passive
 
 		public override bool PreDraw(Projectile proj, ref Color lightColor)
 		{
-			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value) || !proj.minion
-				|| !ModContent.GetInstance<GameplayConfig>().NearbyAuras)
+			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionDamageAuraPassive>(out float value) 
+				|| !ModContent.GetInstance<GameplayConfig>().NearbyAuras || !AppliesToEntity(proj, true))
 			{
 				return true;
 			}

--- a/Content/Passives/Summon/SmallPassives/MinionManaRegenAuraPassive.cs
+++ b/Content/Passives/Summon/SmallPassives/MinionManaRegenAuraPassive.cs
@@ -1,4 +1,5 @@
 using PathOfTerraria.Common.Config;
+using PathOfTerraria.Common.Projectiles;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Content.Buffs;
 using ReLogic.Content;
@@ -16,10 +17,14 @@ internal class MinionManaRegenAuraPassive : Passive
 			Aura = ModContent.Request<Texture2D>("PathOfTerraria/Assets/Misc/VFX/MinionManaRegenAura");
 		}
 
+		public override bool AppliesToEntity(Projectile entity, bool lateInstantiation)
+		{
+			return entity.minion && !CustomProjectileSets.MultisegmentMinionProjectiles[entity.type];
+		}
+
 		public override bool PreAI(Projectile proj)
 		{
-			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionManaRegenAuraPassive>(out float value)
-				|| !proj.minion)
+			if (!proj.TryGetOwner(out Player plr) || !plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionManaRegenAuraPassive>(out float value) || !AppliesToEntity(proj, true))
 			{
 				return true;
 			}
@@ -38,8 +43,8 @@ internal class MinionManaRegenAuraPassive : Passive
 
 		public override bool PreDraw(Projectile proj, ref Color lightColor)
 		{
-			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionManaRegenAuraPassive>(out float value) || !proj.minion
-				|| !ModContent.GetInstance<GameplayConfig>().NearbyAuras)
+			if (!proj.TryGetOwner(out Player owner) || !owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MinionManaRegenAuraPassive>(out float value)
+				|| !ModContent.GetInstance<GameplayConfig>().NearbyAuras || !AppliesToEntity(proj, true))
 			{
 				return true;
 			}

--- a/Core/Time/TimeSystem.cs
+++ b/Core/Time/TimeSystem.cs
@@ -1,4 +1,7 @@
-﻿namespace PathOfTerraria.Core.Time;
+﻿using PathOfTerraria.Utilities;
+using System.Reflection;
+
+namespace PathOfTerraria.Core.Time;
 
 internal sealed class TimeSystem : ModSystem
 {
@@ -28,34 +31,33 @@ internal sealed class TimeSystem : ModSystem
 		// Hooking of potentially executing draw methods has to be done on the main thread.
 		Main.QueueMainThreadAction(static () =>
 		{
-			On_Main.DoUpdate += OnDoUpdate;
-			On_Main.DoDraw += OnDoDraw;
+			// Cache LogicTime before updating
+			ILUtils.EmitILDetour(typeof(Main).GetMethod("DoUpdate", BindingFlags.Instance | BindingFlags.NonPublic), (Main main, ref GameTime gameTime) =>
+			{
+				LogicTime = (float)gameTime.TotalGameTime.TotalSeconds;
+			}, null);
+
+			// Cache some drawing information before drawing
+			ILUtils.EmitILDetour(typeof(Main).GetMethod("DoDraw", BindingFlags.Instance | BindingFlags.NonPublic), (Main main, GameTime gameTime) => // Set render info
+			{
+				uint updateCount = Main.GameUpdateCount;
+
+				RenderOnlyFrame = updateCount == lastRenderUpdateCount;
+				lastRenderUpdateCount = updateCount;
+
+				RenderTime = (float)gameTime.TotalGameTime.TotalSeconds;
+				RenderDeltaTime = (float)gameTime.ElapsedGameTime.TotalSeconds;
+			}, 
+			(Main main, GameTime gameTime) => // and then unset flag
+			{
+				RenderOnlyFrame = false;
+			});
 		});
 	}
+
 	public override void Unload()
 	{
 		Main.OnTickForInternalCodeOnly -= OnTickForInternalCodeOnly;
-	}
-
-	private static void OnDoUpdate(On_Main.orig_DoUpdate orig, Main main, ref GameTime gameTime)
-	{
-		LogicTime = (float)gameTime.TotalGameTime.TotalSeconds;
-
-		orig(main, ref gameTime);
-	}
-	private static void OnDoDraw(On_Main.orig_DoDraw orig, Main main, GameTime gameTime)
-	{
-		uint updateCount = Main.GameUpdateCount;
-
-		RenderOnlyFrame = updateCount == lastRenderUpdateCount;
-		lastRenderUpdateCount = updateCount;
-
-		RenderTime = (float)gameTime.TotalGameTime.TotalSeconds;
-		RenderDeltaTime = (float)gameTime.ElapsedGameTime.TotalSeconds;
-
-		orig(main, gameTime);
-
-		RenderOnlyFrame = false;
 	}
 
 	private static void OnTickForInternalCodeOnly()

--- a/Localization/de-DE/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	// DisplayName: Rising Steps Above Red
-	/* Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		''' */
+	// Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	// Mining: "{$DefaultMining}"
 	// Placing: "{$DefaultPlacing}"
+	// Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Localization/en-US/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	DisplayName: Rising Steps Above Red
-	Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		'''
+	Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	Mining: "{$DefaultMining}"
 	Placing: "{$DefaultPlacing}"
+	Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	// DisplayName: Rising Steps Above Red
-	/* Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		''' */
+	// Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	// Mining: "{$DefaultMining}"
 	// Placing: "{$DefaultPlacing}"
+	// Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	// DisplayName: Rising Steps Above Red
-	/* Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		''' */
+	// Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	// Mining: "{$DefaultMining}"
 	// Placing: "{$DefaultPlacing}"
+	// Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	// DisplayName: Rising Steps Above Red
-	/* Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		''' */
+	// Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	// Mining: "{$DefaultMining}"
 	// Placing: "{$DefaultPlacing}"
+	// Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	// DisplayName: Rising Steps Above Red
-	/* Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		''' */
+	// Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	// Mining: "{$DefaultMining}"
 	// Placing: "{$DefaultPlacing}"
+	// Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Subworlds.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Subworlds.hjson
@@ -76,13 +76,10 @@ TwinsDomain: {
 
 BrainDomain: {
 	// DisplayName: Rising Steps Above Red
-	/* Description:
-		'''
-		Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
-		[i:53] You have 3 additional double jumps
-		''' */
+	// Description: Take the portal at the top of grand steps to challenge the Brain of Cthulhu.
 	// Mining: "{$DefaultMining}"
 	// Placing: "{$DefaultPlacing}"
+	// Extra: "[i:53] A mysterious power grants you three additional mid-air jumps"
 }
 
 DeerclopsDomain: {

--- a/Utilities/ILUtils.cs
+++ b/Utilities/ILUtils.cs
@@ -46,7 +46,7 @@ internal static class ILUtils
 	}
 
 	/// <summary>
-	/// Creates an IL edit "detour" that, in two parts, works the same as a standard detour but doesn't bloat the call stack. 
+	/// Creates an IL edit "detour" that, in two parts, works almost the same as a standard detour but doesn't bloat the call stack. 
 	/// </summary>
 	public static void EmitILDetour<T>(MethodInfo hook, T? before, T? after) where T : Delegate
 	{

--- a/Utilities/ILUtils.cs
+++ b/Utilities/ILUtils.cs
@@ -1,9 +1,13 @@
-﻿using System.Linq;
-using Mono.Cecil;
+﻿using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace PathOfTerraria.Utilities;
+
+#nullable enable
 
 internal static class ILUtils
 {
@@ -39,5 +43,48 @@ internal static class ILUtils
 		ctx.Body.Variables.Add(new VariableDefinition(importedType));
 
 		return localId;
+	}
+
+	/// <summary>
+	/// Creates an IL edit "detour" that, in two parts, works the same as a standard detour but doesn't bloat the call stack. 
+	/// </summary>
+	public static void EmitILDetour<T>(MethodInfo hook, T? before, T? after) where T : Delegate
+	{
+		MonoModHooks.Modify(hook, (context) =>
+		{
+			ILCursor c = new(context);
+			int paramCount = typeof(T).GenericTypeArguments.Length;
+
+			if (before != null)
+			{
+				EmitAllArguments();
+				c.EmitDelegate(before);
+			}
+
+			if (after != null)
+			{
+				Queue<int> indexes = [];
+
+				while (c.TryGotoNext(x => x.MatchRet()))
+				{
+					indexes.Enqueue(c.Index);
+				}
+
+				while (indexes.Count > 0)
+				{
+					c.Index = indexes.Dequeue();
+					EmitAllArguments();
+					c.EmitDelegate(after);
+				}
+			}
+
+			void EmitAllArguments()
+			{
+				for (int i = 0; i < paramCount; ++i)
+				{
+					c.Emit(OpCodes.Ldarg_S, (byte)i);
+				}
+			}
+		});
 	}
 }


### PR DESCRIPTION
### Description of Work
- Heavily optimized how passive strength is obtained
- Added "IL Detour" functionality, which will simplify the call stack for errors & debugging a lot (not a full implementation - some detours may still need to be ported)
- Added logic for modifying the help tooltips for subworlds
- Fixed issue where passives would be autoloaded twice, which made the singleton instance null for some reason
- Added runtime ID to passives (`passive.ID`)
- Fixed issue where BoC's domain would show an incorrect description when loading