### PR TITLE
fix(#1744): Add in equipability for offhand/mainhands to allow for on…

### DIFF
--- a/Common/AccessorySlots/AccessorySlotRemapping.cs
+++ b/Common/AccessorySlots/AccessorySlotRemapping.cs
@@ -3,6 +3,9 @@ using PathOfTerraria.Content.Items.Gear.Offhands;
 using PathOfTerraria.Content.Items.Gear.Offhands.Quivers;
 using PathOfTerraria.Content.Items.Gear.Rings;
 using PathOfTerraria.Content.Items.Gear.Weapons.Bow;
+using Terraria.Audio;
+using Terraria.ID;
+using Terraria.UI;
 
 namespace PathOfTerraria.Common.AccessorySlots;
 
@@ -65,6 +68,27 @@ public sealed class AccessorySlotRemapping : ModSystem
 	public override void Load()
 	{
 		On_Player.IsItemSlotUnlockedAndUsable += Player_IsItemSlotUnlockedAndUsable_Hook;
+		On_ItemSlot.RightClick_ItemArray_int_int += (orig, inv, context, slot) =>
+		{
+			Player player = Main.LocalPlayer;
+			Item item = inv[slot];
+			bool clicked = Main.mouseRight && Main.mouseRightRelease;
+
+			if (clicked
+				&& context == ItemSlot.Context.InventoryItem
+				&& slot != 0
+				&& !item.IsAir
+				&& item.damage > 0
+				&& !item.accessory
+				&& IsWeaponCompatible(player, item))
+			{
+				(player.inventory[0], inv[slot]) = (inv[slot], player.inventory[0]);
+				SoundEngine.PlaySound(SoundID.Grab);
+				return;
+			}
+
+			orig(inv, context, slot);
+		};
 	}
 
 	public static bool IsNormalAccessory(Item item)

--- a/Common/AccessorySlots/AccessorySlotRemapping.cs
+++ b/Common/AccessorySlots/AccessorySlotRemapping.cs
@@ -1,6 +1,8 @@
 ﻿using PathOfTerraria.Content.Items.Gear.Amulets;
 using PathOfTerraria.Content.Items.Gear.Offhands;
+using PathOfTerraria.Content.Items.Gear.Offhands.Quivers;
 using PathOfTerraria.Content.Items.Gear.Rings;
+using PathOfTerraria.Content.Items.Gear.Weapons.Bow;
 
 namespace PathOfTerraria.Common.AccessorySlots;
 
@@ -78,6 +80,32 @@ public sealed class AccessorySlotRemapping : ModSystem
 		return result;
 	}
 
+	public static bool IsOffhandCompatible(Player player, Item offhand)
+	{
+		if (offhand?.ModItem is not Offhand)
+		{
+			return false;
+		}
+
+		return player.inventory[0].ModItem switch
+		{
+			Bow => offhand.ModItem is Quiver,
+			_ => true
+		};
+	}
+
+	public static bool IsWeaponCompatible(Player player, Item weapon)
+	{
+		Item offhand = player.armor[(int)RemappedEquipSlots.Offhand];
+
+		if (weapon?.ModItem is Bow)
+		{
+			return offhand.IsAir || offhand.ModItem is Quiver;
+		}
+
+		return true;
+	}
+
 	private static bool Player_IsItemSlotUnlockedAndUsable_Hook(On_Player.orig_IsItemSlotUnlockedAndUsable orig, Player self, int slot)
 	{
 		return true;
@@ -96,7 +124,7 @@ file sealed class ItemAccessorySlotRemapping : GlobalItem
 			(int)RemappedEquipSlots.Accessory2 => AccessorySlotRemapping.IsNormalAccessory(item),
 			(int)RemappedEquipSlots.Wings => item.wingSlot > 0,
 			(int)RemappedEquipSlots.Necklace => item.ModItem is Amulet,
-			(int)RemappedEquipSlots.Offhand => item.ModItem is Offhand,
+			(int)RemappedEquipSlots.Offhand => item.ModItem is Offhand && AccessorySlotRemapping.IsOffhandCompatible(player, item),
 			(int)RemappedEquipSlots.RingOn => item.ModItem is Ring,
 			(int)RemappedEquipSlots.RingOff => item.ModItem is Ring,
 			// For some reason, TML does a weird last-moment "can go into slot zero" check, so we have to account for that.

--- a/Common/Data/Affixes/MapAffixes.json
+++ b/Common/Data/Affixes/MapAffixes.json
@@ -114,6 +114,66 @@
 		]
 	},
 	{
+		"affixType": "MapStealAegisChargeAffix",
+		"equipTypes": "Map",
+		"tiers": [
+			{
+				"minValue": 1,
+				"maxValue": 1,
+				"minimumLevel": 45,
+				"weight": 1,
+				"strength": 8
+			},
+			{
+				"minValue": 1,
+				"maxValue": 1,
+				"minimumLevel": 65,
+				"weight": 1,
+				"strength": 10
+			}
+		]
+	},
+	{
+		"affixType": "MapStealFocusChargeAffix",
+		"equipTypes": "Map",
+		"tiers": [
+			{
+				"minValue": 1,
+				"maxValue": 1,
+				"minimumLevel": 45,
+				"weight": 1,
+				"strength": 8
+			},
+			{
+				"minValue": 1,
+				"maxValue": 1,
+				"minimumLevel": 65,
+				"weight": 1,
+				"strength": 10
+			}
+		]
+	},
+	{
+		"affixType": "MapStealHasteChargeAffix",
+		"equipTypes": "Map",
+		"tiers": [
+			{
+				"minValue": 1,
+				"maxValue": 1,
+				"minimumLevel": 45,
+				"weight": 1,
+				"strength": 8
+			},
+			{
+				"minValue": 1,
+				"maxValue": 1,
+				"minimumLevel": 65,
+				"weight": 1,
+				"strength": 10
+			}
+		]
+	},
+	{
 		"affixType": "MapFireConversionAffix",
 		"equipTypes": "Map",
 		"tiers": [

--- a/Common/Looting/CurrencyPouch/CurrencyPouchIcon.cs
+++ b/Common/Looting/CurrencyPouch/CurrencyPouchIcon.cs
@@ -66,13 +66,7 @@ public class CurrencyPouchIcon : SmartUiState
 
 	public override void SafeClick(UIMouseEvent evt)
 	{
-		Texture2D texture = Texture.Value;
-		Vector2 pos = new(UIHelper.GetTextureXPosition(), 150);
-
-		//Uses just a 64/64 texture size
-		var bounding = new Rectangle((int)(pos.X - texture.Width / 1.125f) - 64, (int)pos.Y, 64, 64);
-
-		if (!bounding.Contains(Main.MouseScreen.ToPoint()))
+		if (!UIHelper.GetInvButtonInfo(150, out _, null, NewXPosition))
 		{
 			return;
 		}

--- a/Common/Looting/VirtualBagUI/VirtualBagIcon.cs
+++ b/Common/Looting/VirtualBagUI/VirtualBagIcon.cs
@@ -68,13 +68,7 @@ public class VirtualBagIcon : SmartUiState
 
 	public override void SafeClick(UIMouseEvent evt)
 	{
-		Texture2D texture = Texture.Value;
-		Vector2 pos = new(UIHelper.GetTextureXPosition(), 80);
-
-		//Uses just a 64/64 texture size
-		var bounding = new Rectangle((int)(pos.X - texture.Width / 1.125f) - 64, (int)pos.Y, 64, 64);
-
-		if (!bounding.Contains(Main.MouseScreen.ToPoint()))
+		if (!UIHelper.GetInvButtonInfo(80, out _, null, NewXPosition))
 		{
 			return;
 		}

--- a/Common/Systems/Affixes/ItemTypes/MapAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/MapAffixes.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Systems.ElementalDamage;
+using PathOfTerraria.Common.Systems.Charges;
+using PathOfTerraria.Common.Systems.ElementalDamage;
 using PathOfTerraria.Common.Systems.NPCCritFunctionality;
 using System.IO;
 using Terraria.ID;
@@ -107,6 +108,30 @@ public class MapIncreasedBehaviourAffix : MapAffix
 	public override void PreAI(NPC npc)
 	{
 		npc.GetGlobalNPC<SpeedUpNPC>().ExtraAISpeed += Value / 100f;
+	}
+}
+
+public class MapStealAegisChargeAffix : MapAffix
+{
+	public override void OnHitPlayer(NPC npc, Player player, Player.HurtInfo info)
+	{
+		player.GetModPlayer<AegisChargePlayer>().RemoveCharge();
+	}
+}
+
+public class MapStealFocusChargeAffix : MapAffix
+{
+	public override void OnHitPlayer(NPC npc, Player player, Player.HurtInfo info)
+	{
+		player.GetModPlayer<FocusChargePlayer>().RemoveCharge();
+	}
+}
+
+public class MapStealHasteChargeAffix : MapAffix
+{
+	public override void OnHitPlayer(NPC npc, Player player, Player.HurtInfo info)
+	{
+		player.GetModPlayer<HasteChargePlayer>().RemoveCharge();
 	}
 }
 

--- a/Common/Systems/Charges/ModChargePlayer.cs
+++ b/Common/Systems/Charges/ModChargePlayer.cs
@@ -82,7 +82,6 @@ public abstract class ModChargePlayer : ModPlayer
 
     public void AddCharge(int amount = 1)
     {
-	    bool hadCharges = Charges > 0;
 	    Charges = Math.Min(Charges + amount, MaxCharges);
 	    RefreshChargeDuration();
 	    //ShowChargeGainText();
@@ -94,6 +93,27 @@ public abstract class ModChargePlayer : ModPlayer
 	    }
 
     }
+
+	public void RemoveCharge(int amount = 1)
+	{
+		if (Charges <= 0 || amount <= 0)
+		{
+			return;
+		}
+
+		Charges = Math.Max(Charges - amount, 0);
+
+		if (Charges == 0)
+		{
+			RemoveAllCharges();
+			return;
+		}
+
+		if (BuffType != -1 && Player.HasBuff(BuffType))
+		{
+			Player.buffTime[Player.FindBuffIndex(BuffType)] = chargeDuration;
+		}
+	}
 
     protected void RefreshChargeDuration()
     {

--- a/Common/UI/Armor/Elements/UIDefaultArmor.cs
+++ b/Common/UI/Armor/Elements/UIDefaultArmor.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Common.AccessorySlots;
 using PathOfTerraria.Common.UI.Elements;
+using PathOfTerraria.Content.Items.Gear.Offhands;
 using ReLogic.Content;
 using Terraria.UI;
 
@@ -17,14 +18,24 @@ public sealed class UIDefaultArmor : UIArmorPage
 	{
 		numAccessorySlots += 2;
 
+		var offhandSlot = new UIHoverImageItemSlot(DefaultFrameTexture, OffhandIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Offhand)), (LocPrefix + "Offhand", null)!, ItemSlot.Context.EquipAccessory, armorHideSlot: ((int)RemappedEquipSlots.Offhand, true))
+		{
+			Predicate = (_, _) => Main.mouseItem.ModItem is Offhand && AccessorySlotRemapping.IsOffhandCompatible(Player, Main.mouseItem)
+		};
+
+		var weaponSlot = new UIHoverImageItemSlot(DefaultFrameTexture, WeaponIconTexture, new(() => (Player.inventory, 0)), (LocPrefix + "Weapon", null)!, 0)
+		{
+			Predicate = (_, _) => AccessorySlotRemapping.IsWeaponCompatible(Player, Main.mouseItem)
+		};
+
 		return [
 			new(DefaultFrameTexture, WingsIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Wings)), (LocPrefix + "Wings", null)!, ItemSlot.Context.EquipAccessory, armorHideSlot: ((int)RemappedEquipSlots.Wings, true)),
 			new(DefaultFrameTexture, HelmetIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Head)), (LocPrefix + "Head", null)!, ItemSlot.Context.EquipArmor),
 			new(DefaultFrameTexture, NecklaceIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Necklace)), (LocPrefix + "Necklace", null)!, ItemSlot.Context.EquipAccessory, armorHideSlot: ((int)RemappedEquipSlots.Necklace, true)),
 			//
-			new(DefaultFrameTexture, WeaponIconTexture, new(() => (Player.inventory, 0)), (LocPrefix + "Weapon", null)!, 0),
+			weaponSlot,
 			new(DefaultFrameTexture, ChestIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Body)), (LocPrefix + "Body", null)!, ItemSlot.Context.EquipArmor),
-			new(DefaultFrameTexture, OffhandIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Offhand)), (LocPrefix + "Offhand", null)!, ItemSlot.Context.EquipAccessory, armorHideSlot: ((int)RemappedEquipSlots.Offhand, true)),
+			offhandSlot,
 			//
 			new(DefaultFrameTexture, RingIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.RingOn)), (LocPrefix + "RingLeft", null)!, ItemSlot.Context.EquipAccessory, armorHideSlot: ((int)RemappedEquipSlots.RingOn, true)),
 			new(DefaultFrameTexture, LegsIconTexture, new(() => (Player.armor, (int)RemappedEquipSlots.Legs)), (LocPrefix + "Legs", null)!, ItemSlot.Context.EquipArmor),

--- a/Common/UI/Armor/Elements/UIDefaultArmor.cs
+++ b/Common/UI/Armor/Elements/UIDefaultArmor.cs
@@ -2,6 +2,8 @@
 using PathOfTerraria.Common.UI.Elements;
 using PathOfTerraria.Content.Items.Gear.Offhands;
 using ReLogic.Content;
+using Terraria.Audio;
+using Terraria.ID;
 using Terraria.UI;
 
 #nullable enable
@@ -52,7 +54,19 @@ public sealed class UIDefaultArmor : UIArmorPage
 		(int, bool)? armorHideSlot = (customModSlot, false);
 		var handler = new UIImageItemSlot.SlotWrapper(() => modSlot.FunctionalItem, value => modSlot.FunctionalItem = value);
 		var uiSlot = new UIHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture, handler, (LocPrefix + "NumberedAccessory", accessoryNumber), ItemSlot.Context.ModdedAccessorySlot, armorHideSlot: armorHideSlot);
+		uiSlot.OnRightClick += (_, _) => SwapFunctionalAndVanity(modSlot);
 
 		return uiSlot;
+	}
+
+	private static void SwapFunctionalAndVanity(ModAccessorySlot modSlot)
+	{
+		if (!Main.mouseItem.IsAir)
+		{
+			return;
+		}
+
+		(modSlot.FunctionalItem, modSlot.VanityItem) = (modSlot.VanityItem, modSlot.FunctionalItem);
+		SoundEngine.PlaySound(SoundID.Grab);
 	}
 }

--- a/Common/UI/Armor/Elements/UIVanityArmor.cs
+++ b/Common/UI/Armor/Elements/UIVanityArmor.cs
@@ -1,6 +1,8 @@
 ﻿using PathOfTerraria.Common.AccessorySlots;
 using PathOfTerraria.Common.UI.Elements;
 using ReLogic.Content;
+using Terraria.Audio;
+using Terraria.ID;
 using Terraria.UI;
 
 #nullable enable
@@ -38,7 +40,19 @@ public sealed class UIVanityArmor : UIArmorPage
 		int accessoryNumber = ++numAccessorySlots;
 		var handler = new UIImageItemSlot.SlotWrapper(() => modSlot.VanityItem, value => modSlot.VanityItem = value);
 		var uiSlot = new UIHoverImageItemSlot(DefaultFrameTexture, MiscellaneousIconTexture, handler, ($"Mods.{PoTMod.ModName}.UI.Slots.NumberedAccessory", accessoryNumber), ItemSlot.Context.ModdedVanityAccessorySlot);
+		uiSlot.OnRightClick += (_, _) => SwapVanityAndFunctional(modSlot);
 
 		return uiSlot;
+	}
+
+	private static void SwapVanityAndFunctional(ModAccessorySlot modSlot)
+	{
+		if (!Main.mouseItem.IsAir)
+		{
+			return;
+		}
+
+		(modSlot.VanityItem, modSlot.FunctionalItem) = (modSlot.FunctionalItem, modSlot.VanityItem);
+		SoundEngine.PlaySound(SoundID.Grab);
 	}
 }

--- a/Common/UI/CloseableSmartUi.cs
+++ b/Common/UI/CloseableSmartUi.cs
@@ -27,6 +27,11 @@ public abstract class CloseableSmartUi : SmartUiState
         return layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
     }
 
+    public override bool ShouldBlockClickThrough(Vector2 mousePosition)
+    {
+        return Panel?.ContainsPoint(mousePosition) == true;
+    }
+
     protected override void DrawSelf(SpriteBatch spriteBatch)
     {
         base.DrawSelf(spriteBatch);

--- a/Common/UI/DraggableSmartUi.cs
+++ b/Common/UI/DraggableSmartUi.cs
@@ -31,6 +31,11 @@ public abstract class DraggableSmartUi : SmartUiState
 		return layers.FindIndex(layer => layer.Name.Equals("Vanilla: Mouse Text"));
 	}
 
+	public override bool ShouldBlockClickThrough(Vector2 mousePosition)
+	{
+		return Panel?.ContainsPoint(mousePosition) == true;
+	}
+
 	protected virtual void CreateMainPanel((string key, LocalizedText text)[] tabs, bool showCloseButton = true, Point? panelSize = null, bool canResize = true)
 	{
 		panelSize ??= new Point(PanelWidth, PanelHeight);

--- a/Common/UI/UIHelper.cs
+++ b/Common/UI/UIHelper.cs
@@ -1,5 +1,7 @@
 ﻿using Terraria.DataStructures;
 
+using PathOfTerraria.Core.UI.SmartUI;
+
 namespace PathOfTerraria.Common.UI;
 
 internal static class UIHelper
@@ -15,7 +17,7 @@ internal static class UIHelper
 		size ??= new(64, 64);
 		pos = new(x ?? GetTextureXPosition(), y);
 		var bounds = new Rectangle((int)(pos.X - size.Value.X / 1.125f), (int)pos.Y, size.Value.X, size.Value.Y);
-		return bounds.Contains(Main.MouseScreen.ToPoint());
+		return bounds.Contains(Main.MouseScreen.ToPoint()) && !SmartUiLoader.IsCoveredByHigherPriorityBlockingUi(Main.MouseScreen, 0);
 	}
 
 	/// <summary>

--- a/Core/Items/GearGlobalItem.cs
+++ b/Core/Items/GearGlobalItem.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.AccessorySlots;
 using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Content.Items.Gear;
 using PathOfTerraria.Content.Socketables;
@@ -258,6 +259,11 @@ internal sealed partial class GearGlobalItem : GlobalItem, InsertAdditionalToolt
 		base.UpdateEquip(item, player);
 
 		if (!IsGearItem(item))
+		{
+			return;
+		}
+
+		if (ReferenceEquals(player.armor[(int)RemappedEquipSlots.Offhand], item) && !AccessorySlotRemapping.IsOffhandCompatible(player, item))
 		{
 			return;
 		}

--- a/Core/Items/PoTGlobalItem.cs
+++ b/Core/Items/PoTGlobalItem.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.AccessorySlots;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using Terraria.DataStructures;
 using Terraria.UI;
@@ -35,6 +36,11 @@ public sealed partial class PoTGlobalItem : GlobalItem
 	public override void UpdateEquip(Item item, Player player)
 	{
 		base.UpdateEquip(item, player);
+
+		if (ReferenceEquals(player.armor[(int)RemappedEquipSlots.Offhand], item) && !AccessorySlotRemapping.IsOffhandCompatible(player, item))
+		{
+			return;
+		}
 
 		PoTItemHelper.ApplyAffixes(item, player.GetModPlayer<UniversalBuffingPlayer>().UniversalModifier, player);
 	}

--- a/Core/UI/SmartUI/SmartUiLoader.Helpers.cs
+++ b/Core/UI/SmartUI/SmartUiLoader.Helpers.cs
@@ -40,6 +40,24 @@ internal sealed partial class SmartUiLoader
 		return state;
 	}
 
+	public static bool IsCoveredByHigherPriorityBlockingUi(Vector2 mousePosition, int depthPriority, SmartUiState? except = null)
+	{
+		foreach (SmartUiState state in ModContent.GetInstance<SmartUiLoader>().uiStates)
+		{
+			if (state == except || !state.Visible || state.DepthPriority <= depthPriority)
+			{
+				continue;
+			}
+
+			if (state.ShouldBlockClickThrough(mousePosition))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/// <summary>
 	///		Derives the most-ancestral <see cref="SmartUiElement"/> from the
 	///		given <paramref name="element"/>.

--- a/Core/UI/SmartUI/SmartUiLoader.cs
+++ b/Core/UI/SmartUI/SmartUiLoader.cs
@@ -45,21 +45,26 @@ internal sealed partial class SmartUiLoader : ModSystem
 				continue;
 			}
 
-			UIElement hoveredElement = userInterface.CurrentState.GetElementAt(Main.MouseScreen);
-			if (hoveredElement is null)
+			SmartUiState state = (SmartUiState)userInterface.CurrentState;
+			UIElement hoveredElement = state.GetElementAt(Main.MouseScreen);
+			bool shouldBlockClickThrough = state.ShouldBlockClickThrough(Main.MouseScreen);
+
+			if (hoveredElement is null && !shouldBlockClickThrough)
 			{
 				continue;
 			}
 
 			SmartUiElement parent = DeriveSmartUiElement(hoveredElement);
-			if (stateToBlockAt != userInterface.CurrentState && hoveredElement is UIState)
+			if (stateToBlockAt != state && hoveredElement is UIState && !shouldBlockClickThrough)
 			{
 				continue;
 			}
 
 			Main.blockMouse = true;
+			Main.isMouseLeftConsumedByUI = true;
+			Main.LocalPlayer.mouseInterface = true;
 			BlockClickItem.Block = true;
-			stateToBlockAt = userInterface.CurrentState;
+			stateToBlockAt = state;
 
 			if (parent is null)
 			{

--- a/Core/UI/SmartUI/SmartUiState.cs
+++ b/Core/UI/SmartUI/SmartUiState.cs
@@ -24,6 +24,11 @@ public abstract class SmartUiState : UIState
 
 	public virtual int DepthPriority => 0;
 
+	public virtual bool ShouldBlockClickThrough(Vector2 mousePosition)
+	{
+		return false;
+	}
+
 	/// <summary>
 	///		Where this UI state should be inserted relative to the vanilla UI
 	///		layers.

--- a/Localization/en-US/Mods.PathOfTerraria.Affixes.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Affixes.hjson
@@ -63,6 +63,9 @@ MapBossHealthAffix.Description: "{1}{0}% increased boss health"
 MapMobCritChanceAffix.Description: "{1}{0}% increased enemy crit chance"
 MapMobChillChanceAffix.Description: "{1}{0}% chance for enemies to inflict chilled"
 MapIncreasedBehaviourAffix.Description: "{1}{0}% increased enemy behavior speed"
+MapStealAegisChargeAffix.Description: "Monsters steal an Aegis Charge on hit"
+MapStealFocusChargeAffix.Description: "Monsters steal a Focus Charge on hit"
+MapStealHasteChargeAffix.Description: "Monsters steal a Haste Charge on hit"
 ColdAffix.Prefix: Freezing
 LightningAffix.Prefix: Shocking
 FlamingAffix.Prefix: Flaming


### PR DESCRIPTION
…ly certain combinations to be available

﻿### Link Issues
Resolves: #1744 
Resolves: #1710 
Resolves: #1709 
Resolves: #1738 

### Description of Work
* Adds in `IsWeaponCompatible` for matching offhand to main hand for certain combinations of weapons being available vs some disabling the offhand, etc.
* Adds support for right clicking something that should go into your main hand, which moves into your inventory 1 slot
* Fixes the 3rd and 4th accessory vanity slot swapping
* Fixes an issue with clicking through the passive tree , unintentionally opening other UIs
* Adds in map modifiers that steal charges from you

### Comments
