### PR TITLE
feat(#1521): Adds class-specific anchors to the passive tree. Additio…

### DIFF
--- a/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
@@ -1,6 +1,7 @@
 ﻿using PathOfTerraria.Common.Data;
 using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Mechanics;
+using PathOfTerraria.Common.Classing;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.UI;
 using PathOfTerraria.Common.UI.Guide;
@@ -55,7 +56,9 @@ internal class PassiveTreePlayer : ModPlayer
 		foreach (Passive passive in ActiveNodes.Where(passive => passive != null))
 		{
 			int oldLevel = passive.Level;
-			passive.Level = _saveData.TryGet(passive.ReferenceId.ToString(), out int level) ? level : passive.Name == "AnchorPassive" ? 1 : 0;
+			passive.Level = passive is AnchorPassive
+				? (IsAllowedAnchor(passive) ? 1 : 0)
+				: _saveData.TryGet(passive.ReferenceId.ToString(), out int level) ? level : 0;
 
 			if (setStrengths)
 			{
@@ -82,6 +85,8 @@ internal class PassiveTreePlayer : ModPlayer
 				Points -= passive.Level;
 			}
 		}
+
+		PruneDisconnectedNodes(setStrengths);
 	}
 
 	private void ResetNodes()
@@ -124,7 +129,7 @@ internal class PassiveTreePlayer : ModPlayer
 	{
 		foreach (Passive passive in ActiveNodes)
 		{
-			if (passive.Level > 0)
+			if (passive is not AnchorPassive && passive.Level > 0)
 			{
 				tag[passive.ReferenceId.ToString()] = passive.Level;
 			}
@@ -320,6 +325,104 @@ internal class PassiveTreePlayer : ModPlayer
 		if (save)
 		{
 			SaveData([]);
+		}
+	}
+
+	public bool IsAllowedAnchor(Passive passive)
+	{
+		if (passive is not AnchorPassive)
+		{
+			return false;
+		}
+
+		List<Passive> anchors = ActiveNodes.Where(n => n is AnchorPassive).ToList();
+
+		if (anchors.Count <= 1)
+		{
+			return true;
+		}
+
+		StarterClass starterClass = Player.GetModPlayer<ClassingPlayer>().Class;
+
+		if (starterClass == StarterClass.None)
+		{
+			return true;
+		}
+
+		int allowedAnchorReferenceId = starterClass switch
+		{
+			StarterClass.Melee => 0,
+			StarterClass.Ranged => -1,
+			StarterClass.Magic => -2,
+			StarterClass.Summon => -3,
+			_ => int.MinValue,
+		};
+
+		return passive.ReferenceId == allowedAnchorReferenceId;
+	}
+
+	private void PruneDisconnectedNodes(bool setStrengths)
+	{
+		HashSet<Passive> connectedNodes = GetConnectedNodesFromAllowedAnchors();
+
+		foreach (Passive passive in ActiveNodes)
+		{
+			if (passive is AnchorPassive || passive.Level <= 0 || connectedNodes.Contains(passive))
+			{
+				continue;
+			}
+
+			RemovePassiveLevels(passive, setStrengths);
+		}
+	}
+
+	private HashSet<Passive> GetConnectedNodesFromAllowedAnchors()
+	{
+		HashSet<Passive> visited = [];
+		Queue<Passive> toCheck = new(ActiveNodes.Where(n => n is AnchorPassive && n.Level > 0));
+
+		while (toCheck.Count > 0)
+		{
+			Passive passive = toCheck.Dequeue();
+
+			if (!visited.Add(passive))
+			{
+				continue;
+			}
+
+			foreach (Passive connected in Edges.Where(e => e.Contains(passive) && e.Other(passive) is Passive { Level: > 0 })
+				.Select(e => (Passive)e.Other(passive)))
+			{
+				if (!visited.Contains(connected))
+				{
+					toCheck.Enqueue(connected);
+				}
+			}
+		}
+
+		return visited;
+	}
+
+	private void RemovePassiveLevels(Passive passive, bool setStrengths)
+	{
+		int removedLevels = passive.Level;
+
+		if (removedLevels <= 0)
+		{
+			return;
+		}
+
+		passive.Level = 0;
+
+		if (passive is not MasteryPassive)
+		{
+			Points += removedLevels;
+		}
+
+		if (setStrengths && passive is not MasteryPassive)
+		{
+			int id = Passive.PassiveNameToId[passive.Name];
+			StrengthByPassive[id] = Math.Max(0, StrengthByPassive[id] - removedLevels);
 		}
 	}
 }

--- a/Common/UI/PassiveTree/PassiveElement.cs
+++ b/Common/UI/PassiveTree/PassiveElement.cs
@@ -24,10 +24,9 @@ internal class PassiveElement : AllocatableElement
 		Width.Set(passive.Size.X, 0);
 		Height.Set(passive.Size.Y, 0);
 
-		// Anchor passive should always be "unlocked", thus this hardcoding
 		if (Passive is AnchorPassive)
 		{
-			Passive.Level = 1;
+			Passive.Level = Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().IsAllowedAnchor(Passive) ? 1 : 0;
 		}
 	}
 

--- a/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Common.Systems;
 using PathOfTerraria.Common.Systems.BlockSystem;
+using PathOfTerraria.Common.Classing;
 using PathOfTerraria.Common.Systems.Charges;
 using PathOfTerraria.Common.Systems.ElementalDamage;
 using PathOfTerraria.Common.Systems.ModPlayers;
@@ -129,6 +130,11 @@ internal class PlayerStatInnerPanel : SmartUiElement
 
 		list.Add(new UIElement() { Height = StyleDimension.FromPixels(4) }); // Stops the name text from being cut off
 		list.Add(new PlayerStatUI(LocalizedText.Empty, player => player.name, 0.8f, true, true));
+		list.Add(new PlayerStatUI(Language.GetOrRegister($"Mods.{PoTMod.ModName}.UI.StatUI.Class", () => "Class"), player =>
+		{
+			StarterClass starterClass = player.GetModPlayer<ClassingPlayer>().Class;
+			return starterClass == StarterClass.None ? Language.GetTextValue("LegacyInterface.23") : starterClass.Localize().Value;
+		}, 0.7f));
 		
 		list.Add(new PlayerStatUI(Localize("CharacterHeader"), player => "", isHeader: true));
 		list.Add(new PlayerStatUI(Localize("Level"), player => player.GetModPlayer<ExpModPlayer>().Level.ToString()));


### PR DESCRIPTION
…nally adds your selected class to the character stats menu

﻿### Link Issues
Resolves: #1521 

### Description of Work
* Adds selected class to the character stat dropdown
* Adds class-specific anchors to the passive tree so classes start from different sides

### Comments
* Maybe we rename the anchors to "Mage Starting Slot" or something in the future?