### PR TITLE
feat(#1719): Add in monster difficulty scaling for monster affix syst…

### DIFF
--- a/Common/Systems/Affixes/MobTypes/DamageAffix.cs
+++ b/Common/Systems/Affixes/MobTypes/DamageAffix.cs
@@ -1,9 +1,11 @@
-﻿namespace PathOfTerraria.Common.Systems.Affixes.MobTypes;
+using PathOfTerraria.Common.Systems.MobSystem;
+
+namespace PathOfTerraria.Common.Systems.Affixes.MobTypes;
 
 internal class DamageAffix : MobAffix
 {
 	public override void PostRarity(NPC npc)
 	{
-		npc.damage = (int)(npc.damage * 1.5f);
+		npc.damage = (int)(npc.damage * MathHelper.Lerp(1.15f, 1.5f, PoTMobHelper.GetStatScaling()));
 	}
 }

--- a/Common/Systems/Affixes/MobTypes/LifeAffixes.cs
+++ b/Common/Systems/Affixes/MobTypes/LifeAffixes.cs
@@ -1,10 +1,12 @@
-﻿namespace PathOfTerraria.Common.Systems.Affixes.MobTypes;
+using PathOfTerraria.Common.Systems.MobSystem;
+
+namespace PathOfTerraria.Common.Systems.Affixes.MobTypes;
 
 internal class DoubleLife : MobAffix
 {
 	public override void PostRarity(NPC npc)
 	{
-		npc.lifeMax *= 2;
+		npc.lifeMax = (int)(npc.lifeMax * MathHelper.Lerp(1.25f, 2f, PoTMobHelper.GetStatScaling()));
 		npc.life = npc.lifeMax;
 	}
 }

--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -303,10 +303,11 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		if (!fromNet)
 		{
 			List<MobAffix> possible = AffixHandler.GetMobAffixes(npc, Rarity);
+			int areaLevel = PoTMobHelper.GetAreaLevel();
 
 			Affixes = Rarity switch
 			{
-				ItemRarity.Magic or ItemRarity.Rare => Affix.GenerateAffixes(possible, PoTItemHelper.GetMaxMobAffixCounts(Rarity)),
+				ItemRarity.Magic or ItemRarity.Rare => Affix.GenerateAffixes(possible, PoTMobHelper.GetAffixCount(Rarity, areaLevel)),
 				_ => []
 			};
 		}
@@ -314,6 +315,7 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		Affixes.ForEach(a => a.PreRarity(npc));
 
 		bool alwaysDisplayHealthbar = false;
+		float statScaling = PoTMobHelper.GetStatScaling();
 
 		switch (Rarity)
 		{
@@ -321,16 +323,16 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 				break;
 			case ItemRarity.Magic:
 				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(125, 125, 255), 0.5f);
-				npc.lifeMax *= 2; // Magic mobs get 100% increased life
+				npc.lifeMax = (int)(npc.lifeMax * MathHelper.Lerp(1.35f, 2f, statScaling));
 				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
-				npc.damage = (int)(npc.damage * 1.1f); // Magic mobs get 10% increase damage
+				npc.damage = (int)(npc.damage * MathHelper.Lerp(1.04f, 1.1f, statScaling));
 				alwaysDisplayHealthbar = true;
 				break;
 			case ItemRarity.Rare:
 				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(255, 255, 0), 0.5f);
-				npc.lifeMax *= 3; // Rare mobs get 200% Increased Life
+				npc.lifeMax = (int)(npc.lifeMax * MathHelper.Lerp(1.75f, 3f, statScaling));
 				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
-				npc.damage = (int)(npc.damage * 1.2f); // Magic mobs get 20% increase damage
+				npc.damage = (int)(npc.damage * MathHelper.Lerp(1.08f, 1.2f, statScaling));
 				alwaysDisplayHealthbar = true;
 				break;
 			case ItemRarity.Unique:

--- a/Common/Systems/MobSystem/PoTMobHelper.cs
+++ b/Common/Systems/MobSystem/PoTMobHelper.cs
@@ -1,0 +1,45 @@
+using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Core.Items;
+using SubworldLibrary;
+
+namespace PathOfTerraria.Common.Systems.MobSystem;
+
+public static class PoTMobHelper
+{
+	public static int GetAffixCount(ItemRarity rarity, int areaLevel)
+	{
+		(int min, int max) = rarity switch
+		{
+			ItemRarity.Magic when areaLevel <= 20 => (1, 1),
+			ItemRarity.Magic => (1, 2),
+			ItemRarity.Rare when areaLevel <= 20 => (2, 2),
+			ItemRarity.Rare when areaLevel <= 40 => (2, 3),
+			ItemRarity.Rare => (3, 4),
+			_ => (0, 0)
+		};
+
+		if (max == 0)
+		{
+			return 0;
+		}
+
+		return Main.rand.Next(min, max + 1);
+	}
+
+	public static int GetAreaLevel()
+	{
+		if (SubworldSystem.Current is MappingWorld && MappingWorld.AreaLevel > 0)
+		{
+			return MappingWorld.AreaLevel;
+		}
+
+		return PoTItemHelper.PickItemLevel(clampHardmode: false);
+	}
+
+	public static float GetStatScaling()
+	{
+		float progress = MathHelper.Clamp((GetAreaLevel() - 1f) / 84f, 0f, 1f);
+		return progress * progress * (3f - 2f * progress);
+	}
+}

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -190,21 +190,6 @@ public static class PoTItemHelper
 		};
 	}
 
-	/// <summary>
-	/// Gets the max amount of affixes a mob can have based on the rarity.
-	/// </summary>
-	/// <param name="rarity">Rarity of the mob.</param>
-	/// <returns>How many affixes the mob can have.</returns>
-	public static int GetMaxMobAffixCounts(ItemRarity rarity)
-	{
-		return rarity switch
-		{
-			ItemRarity.Magic => 2,
-			ItemRarity.Rare => 4,
-			_ => 0
-		};
-	}
-
 	public static bool HasMaxAffixesForRarity(Item item)
 	{
 		PoTInstanceItemData data = item.GetInstanceData();


### PR DESCRIPTION
…em based on area level

﻿### Link Issues
Resolves: #1719 

### Description of Work
* This changes monster modifiers system from being forced at 2/4 for magic/rare into a system that is random, but also scales with the difficult of the game. 
* A full breakdown of the changes and scaling can be found here https://wiki.pathofterraria.com/en/Mechanics/Modifiers/EnemyModifiers


### Comments
* This also adjusts the damage and life scaling of the monsters to make things a bit easier at the start, scaling into endgame
* Also broke out mob-related helper functions into it's own dedicated file to separate context away from items