### PR TITLE
Fix passives not working

### DIFF
--- a/Common/Data/Passives/Passives-dev.json
+++ b/Common/Data/Passives/Passives-dev.json
@@ -4474,7 +4474,7 @@
 			"y": -600
 		},
 		"isChoiceNode": true,
-		"requiredAllocatedEdges": 2
+		"requiredAllocatedEdges": 3
 	},
 	{
 		"internalIdentifier": "HemorrhageMastery",

--- a/Common/EntityExtensions.cs
+++ b/Common/EntityExtensions.cs
@@ -45,25 +45,25 @@ public static class EntityExtensions
 		return player.GetModPlayer<SkillTreePlayer>().HasSpecialization<TSkill, TSpecialization>();
 	}
 
-	/// <inheritdoc cref="SkillTreePlayer.GetPassiveStrength{TTree, TPassive}"/>
+	/// <inheritdoc cref="SkillTreePlayer.GetSkillPassiveStrength{TTree, TPassive}"/>
 	/// <param name="player">The player being referenced.</param>
 	internal static int GetPassiveStrength<TTree, TPassive>(this Player player) where TTree : SkillTree where TPassive : SkillPassive
 	{
-		return player.GetModPlayer<SkillTreePlayer>().GetPassiveStrength<TTree, TPassive>();
+		return player.GetModPlayer<SkillTreePlayer>().GetSkillPassiveStrength<TTree, TPassive>();
 	}
 
-	/// <inheritdoc cref="SkillTreePlayer.HasPassive{TTree, TPassive}"/>
+	/// <inheritdoc cref="SkillTreePlayer.HasSkillPassive{TTree, TPassive}"/>
 	/// <param name="player">The player being referenced.</param>
 	internal static bool HasTreePassive<TTree, TPassive>(this Player player) where TTree : SkillTree where TPassive : SkillPassive
 	{
-		return player.GetModPlayer<SkillTreePlayer>().HasPassive<TTree, TPassive>(out _);
+		return player.GetModPlayer<SkillTreePlayer>().HasSkillPassive<TTree, TPassive>(out _);
 	}
 
-	/// <inheritdoc cref="SkillTreePlayer.HasPassive{TTree, TPassive}"/>
+	/// <inheritdoc cref="SkillTreePlayer.HasSkillPassive{TTree, TPassive}"/>
 	/// <param name="player">The player being referenced.</param>
 	internal static bool HasTreePassive<TTree, TPassive>(this Player player, out float strength) where TTree : SkillTree where TPassive : SkillPassive
 	{
-		return player.GetModPlayer<SkillTreePlayer>().HasPassive<TTree, TPassive>(out strength);
+		return player.GetModPlayer<SkillTreePlayer>().HasSkillPassive<TTree, TPassive>(out strength);
 	}
 
 	/// <summary>

--- a/Common/Mechanics/SkillPassive.cs
+++ b/Common/Mechanics/SkillPassive.cs
@@ -23,14 +23,14 @@ public abstract class SkillPassive(SkillTree tree) : SkillNode(tree)
 	{
 		base.OnAllocate(player);
 		Tree.Points--;
-		player.GetModPlayer<SkillTreePlayer>().ModifyPassive(Tree, GetType(), Level);
+		player.GetModPlayer<SkillTreePlayer>().ModifySkillPassive(Tree, GetType(), Level);
 	}
 
 	public override void OnDeallocate(Player player)
 	{
 		base.OnDeallocate(player);
 		Tree.Points++;
-		player.GetModPlayer<SkillTreePlayer>().ModifyPassive(Tree, GetType(), Level);
+		player.GetModPlayer<SkillTreePlayer>().ModifySkillPassive(Tree, GetType(), -Level);
 	}
 
 	public override string ToString()

--- a/Common/Systems/PassiveTreeSystem/Passive.cs
+++ b/Common/Systems/PassiveTreeSystem/Passive.cs
@@ -144,10 +144,7 @@ public abstract class Passive : Allocatable, ILoadable
 
 		foreach (Edge<Allocatable> edge in edges)
 		{
-			// If the edge contains this, and the other side of the edge is either allocated, or
-			// if this is a hidden node, connected to a mastery - i.e., it's a child node to a mastery - allow allocation.
-			// A bit of a hacky fix, as IsHidden isn't necessarily meant to be used this way, but it'll work for at least release.
-			if (edge.Contains(this) && (edge.Other(this).Level > 0 || (edge.Other(this) is MasteryPassive) && IsHidden))
+			if (edge.Contains(this) && edge.Other(this).Level > 0)
 			{
 				count++;
 

--- a/Common/Systems/PassiveTreeSystem/Passive.cs
+++ b/Common/Systems/PassiveTreeSystem/Passive.cs
@@ -178,7 +178,7 @@ public abstract class Passive : Allocatable, ILoadable
 		{
 			base.OnAllocate(player);
 
-			player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, 1);
+			player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, Value);
 		}
 	}
 
@@ -188,7 +188,7 @@ public abstract class Passive : Allocatable, ILoadable
 		{
 			base.OnDeallocate(player);
 
-			player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, -1);
+			player.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(this, Value, 1);
 		}
 	}
 }

--- a/Common/Systems/PassiveTreeSystem/Passive.cs
+++ b/Common/Systems/PassiveTreeSystem/Passive.cs
@@ -1,7 +1,6 @@
 ﻿using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Mechanics;
-using PathOfTerraria.Common.Systems.Skills;
-using PathOfTerraria.Content.Passives.Magic.Masteries;
+using PathOfTerraria.Content.Passives.Misc;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Terraria.Localization;
@@ -133,12 +132,6 @@ public abstract class Passive : Allocatable, ILoadable
 	{
 		PassiveTreePlayer passivePlayer = player.GetModPlayer<PassiveTreePlayer>();
 
-		if (this is CenterOfTheUniverseMastery)
-		{
-			int i = 0;
-			
-		}
-
 		return
 			Level < MaxLevel &&
 			Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().Points > 0 &&
@@ -151,7 +144,10 @@ public abstract class Passive : Allocatable, ILoadable
 
 		foreach (Edge<Allocatable> edge in edges)
 		{
-			if (edge.Contains(this) && edge.Other(this).Level > 0)
+			// If the edge contains this, and the other side of the edge is either allocated, or
+			// if this is a hidden node, connected to a mastery - i.e., it's a child node to a mastery - allow allocation.
+			// A bit of a hacky fix, as IsHidden isn't necessarily meant to be used this way, but it'll work for at least release.
+			if (edge.Contains(this) && (edge.Other(this).Level > 0 || (edge.Other(this) is MasteryPassive) && IsHidden))
 			{
 				count++;
 
@@ -178,13 +174,21 @@ public abstract class Passive : Allocatable, ILoadable
 
 	public override void OnAllocate(Player player)
 	{
-		base.OnAllocate(player);
-		player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, 1);
+		if (this is not MasteryPassive)
+		{
+			base.OnAllocate(player);
+
+			player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, 1);
+		}
 	}
 
 	public override void OnDeallocate(Player player)
 	{
-		base.OnDeallocate(player);
-		player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, -1);
+		if (this is not MasteryPassive)
+		{
+			base.OnDeallocate(player);
+
+			player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, -1);
+		}
 	}
 }

--- a/Common/Systems/PassiveTreeSystem/Passive.cs
+++ b/Common/Systems/PassiveTreeSystem/Passive.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using PathOfTerraria.Common.Data.Models;
+﻿using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Mechanics;
+using PathOfTerraria.Common.Systems.Skills;
+using PathOfTerraria.Content.Passives.Magic.Masteries;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
 
@@ -131,6 +133,12 @@ public abstract class Passive : Allocatable, ILoadable
 	{
 		PassiveTreePlayer passivePlayer = player.GetModPlayer<PassiveTreePlayer>();
 
+		if (this is CenterOfTheUniverseMastery)
+		{
+			int i = 0;
+			
+		}
+
 		return
 			Level < MaxLevel &&
 			Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().Points > 0 &&
@@ -166,5 +174,17 @@ public abstract class Passive : Allocatable, ILoadable
 		PassiveTreePlayer passiveTreeSystem = player.GetModPlayer<PassiveTreePlayer>();
 
 		return Level > 0 && (Level > 1 || passiveTreeSystem.FullyLinkedWithout(this));
+	}
+
+	public override void OnAllocate(Player player)
+	{
+		base.OnAllocate(player);
+		player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, 1);
+	}
+
+	public override void OnDeallocate(Player player)
+	{
+		base.OnDeallocate(player);
+		player.GetModPlayer<PassiveTreePlayer>().AllocatePassive(this, -1);
 	}
 }

--- a/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
@@ -68,7 +68,7 @@ internal class PassiveTreePlayer : ModPlayer
 				}
 				else if (oldLevel > passive.Level)
 				{
-					DeallocatePassive(passive, oldLevel - passive.Level);
+					DeallocatePassive(passive, passive.Value, oldLevel - passive.Level);
 				}
 			}
 
@@ -158,7 +158,7 @@ internal class PassiveTreePlayer : ModPlayer
 
 			if (node.Level > 0)
 			{
-				Player.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(node, node.Level, false);
+				Player.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(node, node.Value, node.Level, false);
 				node.Level = 0;
 			}
 		}
@@ -296,7 +296,7 @@ internal class PassiveTreePlayer : ModPlayer
 		}
 	}
 
-	internal void DeallocatePassive(Passive passive, int usedCost, bool save = true)
+	internal void DeallocatePassive(Passive passive, int valueLoss, int pointRefund, bool save = true)
 	{
 		if (passive is MasteryPassive)
 		{
@@ -306,14 +306,14 @@ internal class PassiveTreePlayer : ModPlayer
 
 		int id = Passive.PassiveNameToId[passive.Name];
 
-		Points += usedCost;
+		Points += pointRefund;
 		Player.GetModPlayer<TutorialPlayer>().TutorialChecks.Add(TutorialCheck.DeallocatedPassive);
 
 		ref float str = ref StrengthByPassive[id];
 
 		if (str > 0)
 		{
-			str = Math.Max(0, str - usedCost);
+			str = Math.Max(0, str - valueLoss);
 		}
 #if DEBUG
 		else

--- a/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
@@ -11,6 +11,7 @@ using PathOfTerraria.Core.UI.SmartUI;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.ModLoader.IO;
+using System.Runtime.InteropServices;
 
 namespace PathOfTerraria.Common.Systems.PassiveTreeSystem;
 
@@ -42,7 +43,7 @@ internal class PassiveTreePlayer : ModPlayer
 	{
 		ResetNodes();
 
-		ExpModPlayer expPlayer = Main.LocalPlayer.GetModPlayer<ExpModPlayer>();
+		ExpModPlayer expPlayer = Player.GetModPlayer<ExpModPlayer>();
 		Points = expPlayer.EffectiveLevel + ExtraPoints;
 
 		SetTree(false);
@@ -53,8 +54,15 @@ internal class PassiveTreePlayer : ModPlayer
 	/// </summary>
 	private void SetTree(bool setStrengths)
 	{
-		foreach (Passive passive in ActiveNodes.Where(passive => passive != null))
+		Span<Passive> span = CollectionsMarshal.AsSpan(ActiveNodes);
+
+		foreach (ref Passive passive in span)
 		{
+			if (passive is null)
+			{
+				continue;
+			}
+
 			int oldLevel = passive.Level;
 			passive.Level = passive is AnchorPassive
 				? (IsAllowedAnchor(passive) ? 1 : 0)
@@ -86,7 +94,7 @@ internal class PassiveTreePlayer : ModPlayer
 			}
 		}
 
-		PruneDisconnectedNodes(setStrengths);
+		// PruneDisconnectedNodes(setStrengths);
 	}
 
 	private void ResetNodes()
@@ -361,20 +369,22 @@ internal class PassiveTreePlayer : ModPlayer
 		return passive.ReferenceId == allowedAnchorReferenceId;
 	}
 
-	private void PruneDisconnectedNodes(bool setStrengths)
-	{
-		HashSet<Passive> connectedNodes = GetConnectedNodesFromAllowedAnchors();
+	// This method caused mastery nodes to work improperly, and I didn't see any additional functionality.
+	// Why was this here? - Gabe
+	//private void PruneDisconnectedNodes(bool setStrengths)
+	//{
+	//	HashSet<Passive> connectedNodes = GetConnectedNodesFromAllowedAnchors();
 
-		foreach (Passive passive in ActiveNodes)
-		{
-			if (passive is AnchorPassive || passive.Level <= 0 || connectedNodes.Contains(passive))
-			{
-				continue;
-			}
-
-			RemovePassiveLevels(passive, setStrengths);
-		}
-	}
+	//	foreach (Passive passive in ActiveNodes)
+	//	{
+	//		if (passive is AnchorPassive || passive.Level <= 0 || connectedNodes.Contains(passive))
+	//		{
+	//			continue;
+	//		}
+	//
+	//		RemovePassiveLevels(passive, setStrengths);
+	//	}
+	//}
 
 	private HashSet<Passive> GetConnectedNodesFromAllowedAnchors()
 	{

--- a/Common/Systems/Skills/SkillTreePlayer.cs
+++ b/Common/Systems/Skills/SkillTreePlayer.cs
@@ -22,7 +22,6 @@ internal class SkillTreePlayer : ModPlayer
 
 	private readonly List<CachedSkillTreeData> cachedData = [];
 	private readonly Dictionary<SkillTree, Dictionary<Type, int>> TotalLevelByTypeByTree = [];
-	private readonly Dictionary<int, float> PassiveStrengthByID = [];
 
 	public void AddCache(CachedSkillTreeData cache)
 	{
@@ -77,19 +76,6 @@ internal class SkillTreePlayer : ModPlayer
 		}
 	}
 
-	public void ModifyPassive(Passive passive, float modifier)
-	{
-		ModifyPassive(passive.ID, modifier);
-	}
-
-	public void ModifyPassive(int id, float modifier)
-	{
-		if (!PassiveStrengthByID.TryAdd(id, modifier))
-		{
-			PassiveStrengthByID[id] += modifier;
-		}
-	}
-
 	/// <summary>
 	/// Sets the specialization for the given skill type. Used for syncing.
 	/// </summary>
@@ -114,7 +100,7 @@ internal class SkillTreePlayer : ModPlayer
 	}
 
 	/// <summary>
-	/// Modifies the stored value for a SKILL passive, per tree and per node. This does nothing for standard passives.
+	/// Modifies the stored value for a skill passive, per tree and per node. This does nothing for standard passives.
 	/// </summary>
 	/// <param name="tree">The tree being modified.</param>
 	/// <param name="nodeType">The node value being modified.</param>

--- a/Common/Systems/Skills/SkillTreePlayer.cs
+++ b/Common/Systems/Skills/SkillTreePlayer.cs
@@ -1,6 +1,8 @@
 ﻿using PathOfTerraria.Common.Mechanics;
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Terraria.ID;
@@ -20,6 +22,7 @@ internal class SkillTreePlayer : ModPlayer
 
 	private readonly List<CachedSkillTreeData> cachedData = [];
 	private readonly Dictionary<SkillTree, Dictionary<Type, int>> TotalLevelByTypeByTree = [];
+	private readonly Dictionary<int, float> PassiveStrengthByID = [];
 
 	public void AddCache(CachedSkillTreeData cache)
 	{
@@ -74,6 +77,19 @@ internal class SkillTreePlayer : ModPlayer
 		}
 	}
 
+	public void ModifyPassive(Passive passive, float modifier)
+	{
+		ModifyPassive(passive.ID, modifier);
+	}
+
+	public void ModifyPassive(int id, float modifier)
+	{
+		if (!PassiveStrengthByID.TryAdd(id, modifier))
+		{
+			PassiveStrengthByID[id] += modifier;
+		}
+	}
+
 	/// <summary>
 	/// Sets the specialization for the given skill type. Used for syncing.
 	/// </summary>
@@ -98,15 +114,17 @@ internal class SkillTreePlayer : ModPlayer
 	}
 
 	/// <summary>
-	/// Modifies the stored value for a passive, per tree and per node.
+	/// Modifies the stored value for a SKILL passive, per tree and per node. This does nothing for standard passives.
 	/// </summary>
 	/// <param name="tree">The tree being modified.</param>
 	/// <param name="nodeType">The node value being modified.</param>
 	/// <param name="levelAdjustment">If <paramref name="set"/> is true, the final value to use. Otherwise, the value to add to the stored value.</param>
 	/// <param name="sync">Whether this should run <see cref="SkillPassiveValueHandler.Send(string, string, byte)"/> or not.</param>
 	/// <param name="set">Whether this overrides or adds to the stored value.</param>
-	internal void ModifyPassive(SkillTree tree, Type nodeType, int levelAdjustment, bool sync = true)
+	internal void ModifySkillPassive(SkillTree tree, Type nodeType, int levelAdjustment, bool sync = true)
 	{
+		Debug.Assert(typeof(SkillPassive).IsAssignableFrom(nodeType), "Type must be a SkillPassive.");
+
 		TotalLevelByTypeByTree.TryAdd(tree, []);
 		Dictionary<Type, int> levelByType = TotalLevelByTypeByTree[tree];
 
@@ -127,7 +145,7 @@ internal class SkillTreePlayer : ModPlayer
 	/// <typeparam name="TTree">The tree to reference.</typeparam>
 	/// <typeparam name="TPassive">The passive to get the level of.</typeparam>
 	/// <returns>The cumulative levels of a given passive on a tree.</returns>
-	internal int GetPassiveStrength<TTree, TPassive>() where TTree : SkillTree where TPassive : SkillPassive
+	internal int GetSkillPassiveStrength<TTree, TPassive>() where TTree : SkillTree where TPassive : SkillPassive
 	{
 		if (!TotalLevelByTypeByTree.TryGetValue(ModContent.GetInstance<TTree>(), out Dictionary<Type, int> lookup) || !lookup.TryGetValue(typeof(TPassive), out int level))
 		{
@@ -143,10 +161,10 @@ internal class SkillTreePlayer : ModPlayer
 	/// <typeparam name="TTree">The tree to reference.</typeparam>
 	/// <typeparam name="TPassive">The passive to check for.</typeparam>
 	/// <returns>If the player has any one or more of the passive enabled.</returns>
-	internal bool HasPassive<TTree, TPassive>(out float strength) where TTree : SkillTree where TPassive : SkillPassive
+	internal bool HasSkillPassive<TTree, TPassive>(out float strength) where TTree : SkillTree where TPassive : SkillPassive
 	{
-		strength = GetPassiveStrength<TTree, TPassive>();
-		return strength > 0;
+		strength = GetSkillPassiveStrength<TTree, TPassive>();
+		return GetSkillPassiveStrength<TTree, TPassive>() > 0;
 	}
 
 	/// <summary>

--- a/Common/Systems/Synchronization/Handlers/SkillPassiveValueHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/SkillPassiveValueHandler.cs
@@ -28,7 +28,7 @@ internal class SkillPassiveValueHandler : Handler
 		Type nodeType = typeof(PoTMod).Assembly.GetType(nodeName);
 		MethodInfo method = typeof(ModContent).GetMethod(nameof(ModContent.GetInstance)).MakeGenericMethod(skillType);
 		var skill = (Skill)method.Invoke(null, null);
-		Main.player[player].GetModPlayer<SkillTreePlayer>().ModifyPassive(skill.Tree, nodeType, level, false);
+		Main.player[player].GetModPlayer<SkillTreePlayer>().ModifySkillPassive(skill.Tree, nodeType, level, false);
 	}
 
 	internal override void ServerReceive(BinaryReader reader, byte sender)

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
-using PathOfTerraria.Content.Passives.Misc;
 using Terraria.UI;
 
 #nullable enable
@@ -12,10 +11,11 @@ namespace PathOfTerraria.Common.UI.PassiveTree;
 /// <summary> Offers a choice of one of multiple passives contained within. Every hidden child node is considered an inner node. </summary>
 internal class MultiPassiveElement : PassiveElement
 {
+	public const int AnimationTimeMax = 60;
+
 	private readonly Edge<IConnectedAllocatableNode>[] _extraEdges;
 
 	public int AnimationTime { get; set; }
-	public int AnimationTimeMax => 60;
 	public Passive[] InnerPassives { get; }
 	public Passive? ActivePassive => InnerPassives.FirstOrDefault(p => p.Level > 0);
 
@@ -156,7 +156,7 @@ internal class PassiveRadialElement : PassiveElement
 
 	public MultiPassiveElement? Handler => Parent is MultiPassiveElement e ? e : null;
 
-	private float Progress => Handler is { } handler ? (float)Handler.AnimationTime / Handler.AnimationTimeMax : 0f;
+	private float Progress => Handler is { } handler ? (float)Handler.AnimationTime / MultiPassiveElement.AnimationTimeMax : 0f;
 
 	public PassiveRadialElement(Passive passive, Vector2 startOffset, Vector2 targetOffset) : base(passive)
 	{

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -156,7 +156,7 @@ internal class PassiveRadialElement : PassiveElement
 
 	public MultiPassiveElement? Handler => Parent is MultiPassiveElement e ? e : null;
 
-	private float Progress => Handler is { } handler ? (float)Handler.AnimationTime / MultiPassiveElement.AnimationTimeMax : 0f;
+	private float Progress => Handler is { } handler ? (float)Handler.AnimationTime / Handler.AnimationTimeMax : 0f;
 
 	public PassiveRadialElement(Passive passive, Vector2 startOffset, Vector2 targetOffset) : base(passive)
 	{

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -11,11 +11,11 @@ namespace PathOfTerraria.Common.UI.PassiveTree;
 /// <summary> Offers a choice of one of multiple passives contained within. Every hidden child node is considered an inner node. </summary>
 internal class MultiPassiveElement : PassiveElement
 {
-	public const int AnimationTimeMax = 60;
 
 	private readonly Edge<IConnectedAllocatableNode>[] _extraEdges;
 
 	public int AnimationTime { get; set; }
+	public int AnimationTimeMax => 60;
 	public Passive[] InnerPassives { get; }
 	public Passive? ActivePassive => InnerPassives.FirstOrDefault(p => p.Level > 0);
 

--- a/Common/UI/PassiveTree/PassiveElement.cs
+++ b/Common/UI/PassiveTree/PassiveElement.cs
@@ -41,7 +41,7 @@ internal class PassiveElement : AllocatableElement
 	protected override void Allocate(Allocatable passive, int usedCost)
 	{
 		base.Allocate(passive, usedCost);
-		Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().AllocatePassive((Passive)passive);
+		//Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().AllocatePassive((Passive)passive);
 	}
 
 	public override void SafeRightClick(UIMouseEvent evt)
@@ -56,7 +56,7 @@ internal class PassiveElement : AllocatableElement
 	{
 		base.Deallocate(passive, usedCost);
 
-		Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(Passive, usedCost);
+		//Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(Passive, Value, usedCost);
 		SoundEngine.PlaySound(SoundID.DD2_WitherBeastDeath);
 	}
 }

--- a/Common/UI/PassiveTree/PassiveElement.cs
+++ b/Common/UI/PassiveTree/PassiveElement.cs
@@ -1,8 +1,6 @@
-﻿using PathOfTerraria.Common.Looting.VirtualBagUI;
-using PathOfTerraria.Common.Mechanics;
+﻿using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Content.Passives;
-using PathOfTerraria.Content.Passives.Misc;
 using Terraria.Audio;
 using Terraria.ID;
 using Terraria.UI;
@@ -38,12 +36,6 @@ internal class PassiveElement : AllocatableElement
 		}
 	}
 
-	protected override void Allocate(Allocatable passive, int usedCost)
-	{
-		base.Allocate(passive, usedCost);
-		//Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().AllocatePassive((Passive)passive);
-	}
-
 	public override void SafeRightClick(UIMouseEvent evt)
 	{
 		if (Passive.CanDeallocate(Main.LocalPlayer) && CheckMouseContained())
@@ -56,7 +48,6 @@ internal class PassiveElement : AllocatableElement
 	{
 		base.Deallocate(passive, usedCost);
 
-		//Main.LocalPlayer.GetModPlayer<PassiveTreePlayer>().DeallocatePassive(Passive, Value, usedCost);
 		SoundEngine.PlaySound(SoundID.DD2_WitherBeastDeath);
 	}
 }

--- a/Common/UI/TreeState.cs
+++ b/Common/UI/TreeState.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using PathOfTerraria.Common.Mechanics;
 using PathOfTerraria.Common.Systems.ModPlayers.SkillPlayers;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
@@ -102,7 +103,7 @@ internal class TreeState : TabsUiState
 
 		// Add nodes
 		var mapping = new Dictionary<int, AllocatableElement>(capacity: LocalPassiveTreePlayer.ActiveNodes.Count);
-		foreach (Passive passive in LocalPassiveTreePlayer.ActiveNodes)
+		foreach (Passive passive in CollectionsMarshal.AsSpan(LocalPassiveTreePlayer.ActiveNodes))
 		{
 			if (passive.IsHidden)
 			{


### PR DESCRIPTION
### Description of Work
- Fixed Bleeding cluster masteries needing only 2 of 3 connections
- Fixed passives not [de]allocating properly
- Fixed mastery passives not be able to be allocated, deallocated, and allocated again
- Optimized an immeasurably small amount

Internal: 
- Clarified some names
- Removed method that seemed to only cause issues?