### PR TITLE
fix: made it so multiple tavern npcs cannot spawn

### DIFF
--- a/Common/Subworlds/RavencrestContent/TavernManager.cs
+++ b/Common/Subworlds/RavencrestContent/TavernManager.cs
@@ -109,6 +109,16 @@ internal class TavernManager : ModSystem
 			int type = types.Dequeue();
 			Point16 pos = seatsToUse.Dequeue();
 
+			if (NPC.AnyNPCs(type))
+			{
+				if (seatsToUse.Count == 0)
+				{
+					return;
+				}
+
+				continue;
+			}
+
 			if (Main.netMode == NetmodeID.SinglePlayer)
 			{
 				NPC.NewNPC(Entity.GetSource_NaturalSpawn(), pos.X * 16, pos.Y * 16, type);

--- a/Common/Systems/Synchronization/Handlers/SpawnNPCOnServerHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/SpawnNPCOnServerHandler.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using PathOfTerraria.Common.NPCs;
 using Terraria.DataStructures;
 using Terraria.ID;
 
@@ -38,6 +39,11 @@ internal class SpawnNPCOnServerHandler : Handler
 		if (paramCount > 2)
 		{
 			velocity = reader.ReadVector2();
+		}
+
+		if (ContentSamples.NpcsByNetId[type].ModNPC is ITavernNPC && NPC.AnyNPCs(type))
+		{
+			return;
 		}
 
 		int who = NPC.NewNPC(new EntitySource_SpawnNPC(), (int)pos.X, (int)pos.Y, type, Start: 1);


### PR DESCRIPTION
﻿### Link Issues
Resolves: N/A

### Description of Work
* Adds a guard around Tavern NPCs to prevent duplicate spawning

### Comments
