### PR TITLE
fix: spelunky mastery not giving buffs

### DIFF
--- a/Content/Passives/Utility/Masteries/SpelunkyMastery.cs
+++ b/Content/Passives/Utility/Masteries/SpelunkyMastery.cs
@@ -7,6 +7,12 @@ namespace PathOfTerraria.Content.Passives.Utility.Masteries;
 
 internal class SpelunkyMastery : Passive
 {
+	public override void BuffPlayer(Player player)
+	{
+		player.AddBuff(BuffID.Spelunker, 2);
+		player.AddBuff(BuffID.Mining, 2);
+	}
+
 	internal class SpelunkyPlayer : ModPlayer
 	{
 		public override void Load()


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1842 

### Description of Work
* Fix spelunky mastery not giving buffs

### Comments
