### PR TITLE
More d1 qa

### DIFF
--- a/Common/Classing/StarterClasses.cs
+++ b/Common/Classing/StarterClasses.cs
@@ -44,7 +44,7 @@ internal sealed class StarterClasses : ModSystem
 {
 	private static readonly StarterClassInfo[] infoByClass = new StarterClassInfo[(int)StarterClass.Count];
 
-	static StarterClasses()
+	public override void PostSetupContent()
 	{
 		infoByClass[(int)StarterClass.Melee] = new()
 		{

--- a/Common/Subworlds/BossDomains/Hardmode/EmpressDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/EmpressDomain.cs
@@ -1,4 +1,5 @@
-﻿using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+﻿using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Common.World.Generation;
 using PathOfTerraria.Content.NPCs.BossDomain.EoLDomain;
 using PathOfTerraria.Content.Projectiles.Utility;
@@ -57,6 +58,7 @@ internal class EmpressDomain : BossDomainSubworld, IOverrideBiome
 
 	public override void Update()
 	{
+		GetData().CheckDowned<EmpressDomain>(NPCID.HallowBoss); // HallowBoss is EoL
 		DoWaveFunctionality();
 
 		FightState state = FightTracker.UpdateState();
@@ -79,8 +81,13 @@ internal class EmpressDomain : BossDomainSubworld, IOverrideBiome
 		}
 	}
 
-	private static void DoWaveFunctionality()
+	private void DoWaveFunctionality()
 	{
+		if (GetData().BossDowned) // Stop spawning things when EoL is dead
+		{
+			return;
+		}
+
 		int count = 0;
 
 		foreach (NPC npc in Main.ActiveNPCs)

--- a/Common/Subworlds/BossDomains/Hardmode/FishronDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/FishronDomain.cs
@@ -375,8 +375,9 @@ internal class FishronDomain : BossDomainSubworld, IOverrideBiome
 		TileEntity.UpdateEnd();
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<FishronDomain>(NPCID.DukeFishron);
 
-		if (state == FightState.NotStarted && MushroomsBroken >= 7)
+		if (state == FightState.NotStarted && MushroomsBroken >= 7 && !GetData().BossDowned)
 		{
 			BossSpawnTimer++;
 

--- a/Common/Subworlds/BossDomains/Hardmode/GolemDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/GolemDomain.cs
@@ -360,8 +360,9 @@ internal class GolemDomain : BossDomainSubworld
 		TileEntity.UpdateEnd();
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<GolemDomain>(NPCID.Golem);
 
-		if (state == FightState.NotStarted)
+		if (state == FightState.NotStarted && !GetData().BossDowned)
 		{
 			bool canSpawn = Main.CurrentFrameFlags.ActivePlayersCount > 0;
 			HashSet<int> who = [];

--- a/Common/Subworlds/BossDomains/Hardmode/MoonDomain/MoonDomainSystem.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/MoonDomain/MoonDomainSystem.cs
@@ -41,7 +41,7 @@ internal class MoonDomainSystem : ModSystem
 
 	public override void PreUpdateDusts()
 	{
-		if (SubworldSystem.Current is not MoonLordDomain)
+		if (SubworldSystem.Current is not MoonLordDomain moonDomain)
 		{
 			if (FightTracker.Started)
 			{
@@ -71,7 +71,9 @@ internal class MoonDomainSystem : ModSystem
 			}
 		}
 
-		if (state == FightState.NotStarted && allPlayersAtop && Main.CurrentFrameFlags.ActivePlayersCount > 0)
+		moonDomain.GetData().CheckDowned<MoonLordDomain>(NPCID.MoonLordCore);
+
+		if (state == FightState.NotStarted && allPlayersAtop && Main.CurrentFrameFlags.ActivePlayersCount > 0 && !moonDomain.GetData().BossDowned)
 		{
 			if (Main.netMode != NetmodeID.MultiplayerClient)
 			{

--- a/Common/Subworlds/BossDomains/Hardmode/PrimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/PrimeDomain.cs
@@ -450,8 +450,9 @@ internal class PrimeDomain : BossDomainSubworld
 		TileEntity.UpdateEnd();
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<PrimeDomain>(NPCID.SkeletronPrime);
 
-		if (state == FightState.NotStarted)
+		if (state == FightState.NotStarted && !GetData().BossDowned)
 		{
 			bool canSpawn = Main.CurrentFrameFlags.ActivePlayersCount > 0;
 			HashSet<int> who = [];

--- a/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
@@ -6,9 +6,6 @@ using PathOfTerraria.Content.Tiles.BossDomain;
 using PathOfTerraria.Core.Items;
 using System.Collections.Generic;
 using System.Linq;
-using PathOfTerraria.Common.Systems.Questing;
-using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
-using PathOfTerraria.Content.Items.Quest;
 using Terraria.DataStructures;
 using Terraria.GameContent.Generation;
 using Terraria.ID;
@@ -440,8 +437,9 @@ internal class QueenSlimeDomain : BossDomainSubworld
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<QueenSlimeDomain>(NPCID.QueenSlimeBoss);
 
-		if (state == FightState.NotStarted)
+		if (state == FightState.NotStarted && !GetData().BossDowned)
 		{
 			bool canSpawnBoss = Main.CurrentFrameFlags.ActivePlayersCount > 0;
 

--- a/Common/Subworlds/BossDomains/Hardmode/TwinsDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/TwinsDomain.cs
@@ -5,7 +5,6 @@ using PathOfTerraria.Content.Tiles.BossDomain;
 using PathOfTerraria.Content.Tiles.BossDomain.Mech;
 using System.Collections.Generic;
 using System.Linq;
-using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using Terraria.DataStructures;
 using Terraria.GameContent.Generation;
 using Terraria.ID;
@@ -941,8 +940,9 @@ internal class TwinsDomain : BossDomainSubworld
 		TileEntity.UpdateEnd();
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<TwinsDomain>(NPCID.Retinazer, NPCID.Spazmatism);
 
-		if (state == FightState.NotStarted)
+		if (state == FightState.NotStarted && !GetData().BossDowned)
 		{
 			if (Main.netMode == NetmodeID.SinglePlayer)
 			{

--- a/Common/Subworlds/BossDomains/Prehardmode/BrainDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/BrainDomain.cs
@@ -408,8 +408,9 @@ public class BrainDomain : BossDomainSubworld
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<BrainDomain>(NPCID.BrainofCthulhu);
 
-		if (state == FightState.NotStarted && allInArena)
+		if (state == FightState.NotStarted && allInArena && !GetData().BossDowned)
 		{
 			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X, Arena.Center.Y - 400, NPCID.BrainofCthulhu);
 

--- a/Common/Subworlds/BossDomains/Prehardmode/DeerclopsDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/DeerclopsDomain.cs
@@ -511,8 +511,9 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<DeerclopsDomain>(NPCID.Deerclops);
 
-		if (state == FightState.NotStarted && playersOnSurface)
+		if (state == FightState.NotStarted && playersOnSurface && !GetData().BossDowned)
 		{
 			NPC.SpawnOnPlayer(0, NPCID.Deerclops);
 

--- a/Common/Subworlds/BossDomains/Prehardmode/EaterDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/EaterDomain.cs
@@ -575,8 +575,9 @@ public class EaterDomain : BossDomainSubworld
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<EaterDomain>(NPCID.EaterofWorldsHead);
 
-		if (state == FightState.NotStarted && allInArena)
+		if (state == FightState.NotStarted && allInArena && !GetData().BossDowned)
 		{
 			for (int i = 0; i < 20; ++i)
 			{

--- a/Common/Subworlds/BossDomains/Prehardmode/EyeDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/EyeDomain.cs
@@ -300,8 +300,9 @@ public class EyeDomain : BossDomainSubworld
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<EyeDomain>(NPCID.EyeofCthulhu);
 
-		if (state == FightState.NotStarted && allInArena)
+		if (state == FightState.NotStarted && allInArena && !GetData().BossDowned)
 		{
 			for (int i = 0; i < 20; ++i)
 			{

--- a/Common/Subworlds/BossDomains/Prehardmode/KingSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/KingSlimeDomain.cs
@@ -11,7 +11,6 @@ using PathOfTerraria.Common.World.Generation;
 using Terraria.Localization;
 using PathOfTerraria.Content.Projectiles.Utility;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
-using PathOfTerraria.Common.World.Generation.Tools;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
 
@@ -260,8 +259,9 @@ public class KingSlimeDomain : BossDomainSubworld
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<KingSlimeDomain>(NPCID.KingSlime);
 
-		if (state == FightState.NotStarted && allInArena)
+		if (state == FightState.NotStarted && allInArena && !GetData().BossDowned)
 		{
 			for (int i = -6; i < 11; ++i)
 			{

--- a/Common/Subworlds/BossDomains/Prehardmode/SkeletronDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/SkeletronDomain.cs
@@ -14,7 +14,6 @@ using PathOfTerraria.Common.Subworlds.Tools;
 using PathOfTerraria.Content.Tiles.BossDomain;
 using PathOfTerraria.Common.World.Generation.Tools;
 using PathOfTerraria.Common.Systems.DisableBuilding;
-using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Utilities.Extensions;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
@@ -755,8 +754,9 @@ public class SkeletronDomain : BossDomainSubworld
 		}
 
 		FightState state = FightTracker.UpdateState();
+		GetData().CheckDowned<SkeletronDomain>(NPCID.SkeletronHead);
 
-		if (state == FightState.NotStarted && allInArena)
+		if (state == FightState.NotStarted && allInArena && !GetData().BossDowned)
 		{
 			NPC.NewNPC(Entity.GetSource_NaturalSpawn(), Arena.Center.X, Arena.Center.Y, NPCID.SkeletronHead, 1);
 

--- a/Common/Subworlds/MappingWorld.cs
+++ b/Common/Subworlds/MappingWorld.cs
@@ -25,6 +25,24 @@ namespace PathOfTerraria.Common.Subworlds;
 /// </summary>
 public abstract class MappingWorld : Subworld
 {
+	public class MappingWorldInfo : ModSystem
+	{
+		public override void SaveWorldData(TagCompound tag)
+		{
+			tag.Add("lastPath", LastSubworldSavePath);
+		}
+
+		public override void LoadWorldData(TagCompound tag)
+		{
+			LastSubworldSavePath = null;
+
+			if (tag.TryGet("lastPath", out string value))
+			{
+				LastSubworldSavePath = value;
+			}
+		}
+	}
+
 	/// <summary> How many times this subworld type has been started on this client or server. </summary>
 	public uint TimesEntered { get; private set; }
 

--- a/Common/Subworlds/MappingWorld.cs
+++ b/Common/Subworlds/MappingWorld.cs
@@ -1,15 +1,17 @@
-using System.Collections.Generic;
-using System.Linq;
 using PathOfTerraria.Common.Config;
 using PathOfTerraria.Common.Subworlds.Passes;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.DisableBuilding;
+using PathOfTerraria.Common.Systems.Synchronization;
 using PathOfTerraria.Common.UI;
-using PathOfTerraria.Common.UI.SubworldHelp;
 using ReLogic.Content;
 using SubworldLibrary;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Terraria.ID;
 using Terraria.IO;
 using Terraria.Localization;
@@ -18,8 +20,36 @@ using Terraria.WorldBuilding;
 
 namespace PathOfTerraria.Common.Subworlds;
 
+#nullable enable
+
 /// <summary>
-/// This is the base class for all mapping worlds. It sets the width and height of the world to 1000x1000 and disables world saving.<br/>
+/// Contains persistent data for subworlds to use. This, by default, contains only a <see cref="BossDowned"/> bool, used by most domains,<br/>
+/// but it is a class so it can be inherited to add arbitrary additional data.<br/><b>Most</b> of the code relating to this will not run on multiplayer clients,
+/// so be careful.
+/// </summary>
+public class PersistentData
+{
+	public bool BossDowned = false;
+
+	/// <summary>
+	/// Automatically checks if the corresponding boss(es) have been downed, and sets <see cref="BossDowned"/> to true if so.
+	/// </summary>
+	public void CheckDowned<T>(params int[] id) where T : BossDomainSubworld
+	{
+		if (id.Length == 0)
+		{
+			throw new ArgumentException("There must be at least 1 IDs passed to CheckDowned.");
+		}
+
+		if (BossTracker.DownedInDomain<T>(id))
+		{
+			BossDowned = true;
+		}
+	}
+}
+
+/// <summary>
+/// This is the base class for all mapping worlds. It sets the width and height of the world to 1000x1000 and enables world saving (or uses the configurable option in Debug).<br/>
 /// Additionally, it also makes <see cref="StopBuildingPlayer"/> disable world modification,
 /// and enables <see cref="Systems.ModPlayers.LivesSystem.BossDomainLivesPlayer"/>'s life system.
 /// </summary>
@@ -30,6 +60,8 @@ public abstract class MappingWorld : Subworld
 		public override void SaveWorldData(TagCompound tag)
 		{
 			tag.Add("lastPath", LastSubworldSavePath);
+			tag.Add("timesKeys", (string[])[.. TimesEnteredByDomain.Keys]);
+			tag.Add("timesValues", (int[])[.. TimesEnteredByDomain.Values]);
 		}
 
 		public override void LoadWorldData(TagCompound tag)
@@ -40,11 +72,50 @@ public abstract class MappingWorld : Subworld
 			{
 				LastSubworldSavePath = value;
 			}
+
+			if (SubworldSystem.Current is null && tag.TryGet("timesKeys", out string[] times))
+			{
+				TimesEnteredByDomain = [];
+				int[] values = tag.GetIntArray("timesValues");
+
+				for (int i = 0; i < times.Length; ++i)
+				{
+					TimesEnteredByDomain.Add(times[i], values[i]);
+				}
+			}
 		}
 	}
 
-	/// <summary> How many times this subworld type has been started on this client or server. </summary>
-	public uint TimesEntered { get; private set; }
+	internal class DeleteOnServerHandler : Handler
+	{
+		public static void Send()
+		{
+			ModPacket packet = Networking.GetPacket<DeleteOnServerHandler>();
+			packet.Send();
+		}
+
+		internal override void Receive(BinaryReader reader, byte sender)
+		{
+			DeleteSavedSubworld();
+		}
+	}
+
+	internal class SetLastSubworldPathHandler : Handler
+	{
+		public static void Send(string value)
+		{
+			ModPacket packet = Networking.GetPacket<SetLastSubworldPathHandler>();
+			packet.Write(value);
+			packet.Send();
+		}
+
+		internal override void Receive(BinaryReader reader, byte sender)
+		{
+			string value = reader.ReadString();
+
+			LastSubworldSavePath = value;
+		}
+	}
 
 	public override int Width => 1000;
 	public override int Height => 1000;
@@ -90,7 +161,7 @@ public abstract class MappingWorld : Subworld
 	/// </summary>
 	public virtual (int time, bool isDay) ForceTime => (-1, true);
 
-	public static List<MapAffix> Affixes = null;
+	public static List<MapAffix> Affixes = null!;
 
 	/// <summary>
 	/// The level of the world. This modifies a lot of things:<br/>
@@ -105,12 +176,20 @@ public abstract class MappingWorld : Subworld
 	/// This is kept as the map tier is used for a couple of things, namely <see cref="MappingDomainSystem.Tracker"/>.
 	/// </summary>
 	public static int MapTier = 0;
-	internal static string LastSubworldSavePath { get; private set; }
 
-	public LocalizedText SubworldName { get; private set; }
-	public LocalizedText SubworldDescription { get; private set; }
-	public LocalizedText SubworldMining { get; private set; }
-	public LocalizedText SubworldPlacing { get; private set; }
+	internal static string? LastSubworldSavePath { get; private set; }
+
+	/// <summary>
+	/// How many times a given subworld has been entered, indexed by <see cref="Mod.Name"/>/<see cref="Subworld"/>.GetType().Name.
+	/// </summary>
+	internal static Dictionary<string, int> TimesEnteredByDomain = [];
+
+	internal static Dictionary<string, PersistentData> PersistentDomainInfo = [];
+
+	public LocalizedText? SubworldName { get; private set; }
+	public LocalizedText? SubworldDescription { get; private set; }
+	public LocalizedText? SubworldMining { get; private set; }
+	public LocalizedText? SubworldPlacing { get; private set; }
 
 	/// <summary>
 	/// The loading backgrounds for this <see cref="MappingWorld"/>. Used by <see cref="SubworldLoadingScreen"/>.
@@ -118,6 +197,58 @@ public abstract class MappingWorld : Subworld
 	public Asset<Texture2D>[] LoadingBackgrounds = [];
 
 	private bool needsNetSync;
+
+	public static int GetTimesEntered<T>() where T : Subworld
+	{
+		return GetTimesEntered(ModContent.GetInstance<T>());
+	}
+
+	public static int GetTimesEntered(Subworld subworld)
+	{
+		if (TimesEnteredByDomain.TryGetValue(subworld.FullName, out int value))
+		{
+			return value;
+		}
+
+		return 0;
+	}
+
+	/// <summary>
+	/// Gets the amount of times this subworld has been entered.
+	/// </summary>
+	public int GetTimesEntered()
+	{
+		return GetTimesEntered(this);
+	}
+
+	public static PersistentData? GetData<T>() where T : Subworld
+	{
+		return GetData(ModContent.GetInstance<T>());
+	}
+
+	public static PersistentData? GetData(Subworld subworld)
+	{
+		if (PersistentDomainInfo.TryGetValue(subworld.FullName, out PersistentData? value))
+		{
+			return value;
+		}
+
+		if (SubworldSystem.IsActive(subworld.FullName))
+		{
+			PersistentDomainInfo.Add(subworld.FullName, new());
+			return PersistentDomainInfo[subworld.FullName];
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Gets the persistent data saved with this domain, if any. While a domain is active, this value should not be null.
+	/// </summary>
+	public PersistentData? GetData()
+	{
+		return GetData(this);
+	}
 
 	public override void Load()
 	{
@@ -134,14 +265,47 @@ public abstract class MappingWorld : Subworld
 
 	public override void OnEnter()
 	{
-		TimesEntered++;
-		LastSubworldSavePath = TryGetCurrentPath();
+
 	}
 
-	private static string TryGetCurrentPath()
+	public override void OnLoad()
+	{
+		if (SubworldSystem.Current is not null)
+		{
+			LastSubworldSavePath = TryGetCurrentPath();
+
+			if (!TimesEnteredByDomain.TryAdd(FullName, 1))
+			{
+				TimesEnteredByDomain[FullName]++;
+			}
+
+			if (Main.netMode == NetmodeID.Server && SubworldSystem.Current is not null)
+			{
+				ModPacket packet = Networking.GetPacket<SetLastSubworldPathHandler>();
+				packet.Write(LastSubworldSavePath!);
+				Networking.SendPacketToMainServer(packet);
+			}
+		}
+
+		Mod.Logger.Debug("Running" + " " + TimesEnteredByDomain[FullName]);
+	}
+
+	private static string? TryGetCurrentPath()
 	{
 		try
 		{
+			if (SubworldSystem.Current is null || SubworldSystem.Current.FileName is null)
+			{
+				return null;
+			}
+
+			WorldFileData main = GetMain(ModContent.GetInstance<SubworldSystem>());
+
+			if (main is null)
+			{
+				return null;
+			}
+
 			return SubworldSystem.CurrentPath;
 		}
 		catch (NullReferenceException)
@@ -149,6 +313,9 @@ public abstract class MappingWorld : Subworld
 			return null;
 		}
 	}
+
+	[UnsafeAccessor(UnsafeAccessorKind.StaticField, Name = "main")]
+	public static extern ref WorldFileData GetMain(SubworldSystem sys);
 
 	private void LoadLoadingScreens()
 	{
@@ -285,16 +452,23 @@ public abstract class MappingWorld : Subworld
 
 	internal static void DeleteSavedSubworld()
 	{
-		if (LastSubworldSavePath is { Length: > 0 } path && System.IO.File.Exists(path))
+		if (Main.netMode != NetmodeID.MultiplayerClient)
 		{
-			try
+			if (LastSubworldSavePath is { Length: > 0 } path && File.Exists(path))
 			{
-				System.IO.File.Delete(path);
+				try
+				{
+					File.Delete(path);
+				}
+				catch
+				{
+					PoTMod.Instance.Logger.Error("[DeleteSavedSubworld] Failed to delete saved subworld.");
+				}
 			}
-			catch
-			{
-				PoTMod.Instance.Logger.Error("[DeleteSavedSubworld] Failed to delete saved subworld.");
-			}
+		}
+		else if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			DeleteOnServerHandler.Send();
 		}
 
 		LastSubworldSavePath = null;

--- a/Common/Systems/Affixes/ItemTypes/NearbyEnemiesScorchedAffix.cs
+++ b/Common/Systems/Affixes/ItemTypes/NearbyEnemiesScorchedAffix.cs
@@ -18,6 +18,12 @@ internal class NearbyEnemiesScorchedAffix : ItemAffix
 		public override void PostUpdateBuffs()
 		{
 			const double timeInSeconds = 1.0;
+
+			if (!Active)
+			{
+				return;
+			}
+
 			Vector2 playerCenter = Player.Center;
 			Rectangle playerRect = Player.getRect();
 			int debuffType = ModContent.BuffType<ScorchingFlamesDebuff>();

--- a/Common/Systems/Questing/QuestStepTypes/KillCount.cs
+++ b/Common/Systems/Questing/QuestStepTypes/KillCount.cs
@@ -23,7 +23,7 @@ internal class KillCount(string id, Func<NPC, bool> includes, int count, Localiz
 
 	public override string DisplayString()
 	{
-		return Display.WithFormatArgs(MaxRemaining - _remaining, MaxRemaining).Value;	
+		return Display.WithFormatArgs(_remaining, MaxRemaining).Value;	
 	}
 
 	public override void DrawQuestStep(Vector2 topLeft, out int uiHeight, StepCompletion currentStep)

--- a/Common/Systems/Questing/QuestStepTypes/KillCount.cs
+++ b/Common/Systems/Questing/QuestStepTypes/KillCount.cs
@@ -23,7 +23,8 @@ internal class KillCount(string id, Func<NPC, bool> includes, int count, Localiz
 
 	public override string DisplayString()
 	{
-		return Display.WithFormatArgs(_remaining, MaxRemaining).Value;	
+		int firstArg = Display.Value.Contains("{1}") ? MaxRemaining - _remaining : _remaining;
+		return Display.WithFormatArgs(firstArg, MaxRemaining).Value;	
 	}
 
 	public override void DrawQuestStep(Vector2 topLeft, out int uiHeight, StepCompletion currentStep)

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/DestroyerQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/DestroyerQuest.cs
@@ -25,7 +25,7 @@ internal class DestroyerQuest() : Quest
 		new ActionRewards((p, v) =>
 		{
 			p.GetModPlayer<ExpModPlayer>().Exp += 30000;
-			CompletionVisit = ModContent.GetInstance<RavencrestSubworld>().TimesEntered;
+			CompletionVisit = (uint)MappingWorld.GetTimesEntered<RavencrestSubworld>();
 		},
 			"30000 experience"),
 	];
@@ -69,6 +69,6 @@ internal class DestroyerQuest() : Quest
 	{
 		Quest twinsQuest = GetLocalPlayerInstance<TwinsQuest>();
 		RavencrestSubworld subworld = ModContent.GetInstance<RavencrestSubworld>();
-		return twinsQuest.Completed && NPC.downedMechBoss2 && subworld.TimesEntered != TwinsQuest.CompletionVisit;
+		return twinsQuest.Completed && NPC.downedMechBoss2 && MappingWorld.GetTimesEntered<RavencrestSubworld>() != TwinsQuest.CompletionVisit;
 	}
 }

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/SkelePrimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/SkelePrimeQuest.cs
@@ -64,6 +64,6 @@ internal class SkelePrimeQuest() : Quest
 	{
 		Quest destroyerQuest = GetLocalPlayerInstance<DestroyerQuest>();
 		RavencrestSubworld subworld = ModContent.GetInstance<RavencrestSubworld>();
-		return destroyerQuest.Completed && NPC.downedMechBoss1 && subworld.TimesEntered != DestroyerQuest.CompletionVisit;
+		return destroyerQuest.Completed && NPC.downedMechBoss1 && MappingWorld.GetTimesEntered<RavencrestSubworld>() != DestroyerQuest.CompletionVisit;
 	}
 }

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/TinkerIntroQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/TinkerIntroQuest.cs
@@ -22,7 +22,7 @@ internal class TinkerIntroQuest() : Quest
 		new ActionRewards((p, v) =>
 		{
 			p.GetModPlayer<ExpModPlayer>().Exp += 30000;
-			CompletionVisit = ModContent.GetInstance<RavencrestSubworld>().TimesEntered;
+			CompletionVisit = (uint)MappingWorld.GetTimesEntered<RavencrestSubworld>();
 		}, "30000 experience"),
 	];
 

--- a/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/TwinsQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/HardmodeQuesting/TwinsQuest.cs
@@ -27,7 +27,7 @@ internal class TwinsQuest() : Quest
 		new ActionRewards((p, v) =>
 		{
 			p.GetModPlayer<ExpModPlayer>().Exp += 30000;
-			CompletionVisit = ModContent.GetInstance<RavencrestSubworld>().TimesEntered;
+			CompletionVisit = (uint)MappingWorld.GetTimesEntered<RavencrestSubworld>();
 		}, "30000 experience"),
 	];
 
@@ -84,6 +84,6 @@ internal class TwinsQuest() : Quest
 	{
 		Quest tinkerIntroQuest = GetLocalPlayerInstance<TinkerIntroQuest>();
 		RavencrestSubworld subworld = ModContent.GetInstance<RavencrestSubworld>();
-		return tinkerIntroQuest.Completed && NPC.downedQueenSlime && subworld.TimesEntered != TinkerIntroQuest.CompletionVisit;
+		return tinkerIntroQuest.Completed && NPC.downedQueenSlime && MappingWorld.GetTimesEntered<RavencrestSubworld>() != TinkerIntroQuest.CompletionVisit;
 	}
 }

--- a/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/KingSlimeQuest.cs
@@ -7,10 +7,8 @@ using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.Questing.QuestStepTypes;
 using PathOfTerraria.Common.Systems.Questing.RewardTypes;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
-using PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 using PathOfTerraria.Content.NPCs.Town;
 using SubworldLibrary;
-using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
 

--- a/Common/Systems/Questing/Quests/MainPath/WizardStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/WizardStartQuest.cs
@@ -37,7 +37,9 @@ internal class WizardStartQuest : Quest
 				RavencrestSystem.UpgradeBuilding("Library");
 				return true;
 			}),
+
 			new KillCount("KillScout", ModContent.NPCType<TownScoutNPC>(), 1, this.GetLocalization("KillScout")),
+
 			new InteractWithNPC("Start", ModContent.NPCType<WizardNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.WizardNPC.Dialogue.Quest"),
 				Language.GetText("Mods.PathOfTerraria.NPCs.WizardNPC.Dialogue.Quest2"),
 			[

--- a/Content/Items/Consumables/Maps/BossMaps/BeeMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/BeeMap.cs
@@ -20,9 +20,9 @@ internal class BeeMap() : PreHardmodeBossMap(30, () => NPC.downedQueenBee)
 		Item.Size = new Vector2(36, 36);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<QueenBeeDomain>();
+		return ModContent.GetInstance<QueenBeeDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/BoCMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/BoCMap.cs
@@ -22,9 +22,9 @@ internal class BoCMap() : PreHardmodeBossMap(25, () => NPC.downedBoss2)
 		Item.Size = new Vector2(34, 28);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<BrainDomain>();
+		return ModContent.GetInstance<BrainDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/CultistMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/CultistMap.cs
@@ -20,9 +20,9 @@ internal class CultistMap() : HardmodeBossMap(9, () => NPC.downedAncientCultist)
 		Item.Size = new Vector2(40);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<CultistDomain>();
+		return ModContent.GetInstance<CultistDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/DeerclopsMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/DeerclopsMap.cs
@@ -22,9 +22,9 @@ internal class DeerclopsMap() : PreHardmodeBossMap(35, () => NPC.downedDeerclops
 		Item.Size = new Vector2(30, 30);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<DeerclopsDomain>();
+		return ModContent.GetInstance<DeerclopsDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/DestroyerMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/DestroyerMap.cs
@@ -20,9 +20,9 @@ internal class DestroyerMap() : HardmodeBossMap(3, () => NPC.downedMechBoss1)
 		Item.Size = new Vector2(34, 32);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<DestroyerDomain>();
+		return ModContent.GetInstance<DestroyerDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/EoCMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/EoCMap.cs
@@ -22,9 +22,9 @@ internal class EoCMap() : PreHardmodeBossMap(15, () => NPC.downedBoss1)
 		Item.Size = new Vector2(44, 30);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<EyeDomain>();
+		return ModContent.GetInstance<EyeDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/EoLMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/EoLMap.cs
@@ -24,9 +24,9 @@ internal class EoLMap() : HardmodeBossMap(8, () => NPC.downedEmpressOfLight)
 		Item.Size = new Vector2(34, 38);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<EmpressDomain>();
+		return ModContent.GetInstance<EmpressDomain>();
 	}
 
 	public override void ModifyCorruptionAffixes(WeightedRandom<ItemAffix> affixes)

--- a/Content/Items/Consumables/Maps/BossMaps/EoWMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/EoWMap.cs
@@ -22,9 +22,9 @@ internal class EoWMap() : PreHardmodeBossMap(20, () => NPC.downedBoss2)
 		Item.Size = new Vector2(40, 30);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<EaterDomain>();
+		return ModContent.GetInstance<EaterDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/FishronMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/FishronMap.cs
@@ -20,9 +20,9 @@ internal class FishronMap() : HardmodeBossMap(7, () => NPC.downedFishron)
 		Item.Size = new Vector2(26, 30);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<FishronDomain>();
+		return ModContent.GetInstance<FishronDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/GolemMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/GolemMap.cs
@@ -20,9 +20,9 @@ internal class GolemMap() : HardmodeBossMap(6, () => NPC.downedGolemBoss)
 		Item.Size = new Vector2(40, 26);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<GolemDomain>();
+		return ModContent.GetInstance<GolemDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/KingSlimeMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/KingSlimeMap.cs
@@ -22,9 +22,9 @@ internal class KingSlimeMap() : PreHardmodeBossMap(5, () => NPC.downedSlimeKing)
 		Item.Size = new Vector2(44, 36);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<KingSlimeDomain>();
+		return ModContent.GetInstance<KingSlimeDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/MoonMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/MoonMap.cs
@@ -20,9 +20,9 @@ internal class MoonMap() : HardmodeBossMap(10, () => NPC.downedMoonlord)
 		Item.Size = new Vector2(50, 38);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<MoonLordDomain>();
+		return ModContent.GetInstance<MoonLordDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/PlanteraMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/PlanteraMap.cs
@@ -20,9 +20,9 @@ internal class PlanteraMap() : HardmodeBossMap(5, () => NPC.downedPlantBoss)
 		Item.Size = new Vector2(38, 28);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<PlanteraDomain>();
+		return ModContent.GetInstance<PlanteraDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/PrimeMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/PrimeMap.cs
@@ -20,9 +20,9 @@ internal class PrimeMap() : HardmodeBossMap(4, () => NPC.downedMechBoss3)
 		Item.Size = new Vector2(30, 34);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<PrimeDomain>();
+		return ModContent.GetInstance<PrimeDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/QueenSlimeMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/QueenSlimeMap.cs
@@ -20,9 +20,9 @@ internal class QueenSlimeMap() : HardmodeBossMap(1, () => NPC.downedQueenSlime)
 		Item.Size = new Vector2(34, 38);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<QueenSlimeDomain>();
+		return ModContent.GetInstance<QueenSlimeDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/SkeletronMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/SkeletronMap.cs
@@ -22,9 +22,9 @@ internal class SkeletronMap() : PreHardmodeBossMap(40, () => NPC.downedBoss3)
 		Item.Size = new Vector2(36, 28);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<SkeletronDomain>();
+		return ModContent.GetInstance<SkeletronDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/TwinsMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/TwinsMap.cs
@@ -20,9 +20,9 @@ internal class TwinsMap() : HardmodeBossMap(2, () => NPC.downedMechBoss2)
 		Item.Size = new Vector2(44, 30);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<TwinsDomain>();
+		return ModContent.GetInstance<TwinsDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/BossMaps/WoFMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/WoFMap.cs
@@ -22,9 +22,9 @@ internal class WoFMap() : PreHardmodeBossMap(45, () => Main.hardMode)
 		Item.Size = new Vector2(38, 36);
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<WallOfFleshDomain>();
+		return ModContent.GetInstance<WallOfFleshDomain>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/ExplorableMaps/DesertMap.cs
+++ b/Content/Items/Consumables/Maps/ExplorableMaps/DesertMap.cs
@@ -18,9 +18,9 @@ internal class DesertMap : ExplorableMap
 		staticData.DropChance = 1f;
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<DesertArea>();
+		return ModContent.GetInstance<DesertArea>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/ExplorableMaps/ForestMap.cs
+++ b/Content/Items/Consumables/Maps/ExplorableMaps/ForestMap.cs
@@ -18,9 +18,9 @@ internal class ForestMap : ExplorableMap
 		staticData.DropChance = 1f;
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<ForestArea>();
+		return ModContent.GetInstance<ForestArea>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/ExplorableMaps/SwampMap.cs
+++ b/Content/Items/Consumables/Maps/ExplorableMaps/SwampMap.cs
@@ -18,9 +18,9 @@ internal class SwampMap : ExplorableMap
 		staticData.DropChance = 1f;
 	}
 
-	protected override void OpenMapInternal()
+	internal override Subworld GetDestination()
 	{
-		SubworldSystem.Enter<SwampArea>();
+		return ModContent.GetInstance<SwampArea>();
 	}
 
 	public override string GenerateName(string defaultName)

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -8,6 +8,7 @@ using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using PathOfTerraria.Content.Tiles.Furniture;
 using PathOfTerraria.Core.Items;
 using PathOfTerraria.Core.UI.SmartUI;
+using SubworldLibrary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -98,10 +99,11 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 			SendMappingDomainInfoHandler.Send((short)WorldLevel, (short)Tier, collection);
 		}
 
-		OpenMapInternal();
+		Subworld sub = GetDestination();
+		SubworldSystem.Enter(sub.FullName);
 	}
 
-	protected abstract void OpenMapInternal();
+	internal abstract Subworld GetDestination();
 
 	public virtual int GetMapTier(int itemLevel)
 	{

--- a/Content/Tiles/Furniture/MapDevicePlaceable.cs
+++ b/Content/Tiles/Furniture/MapDevicePlaceable.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using Mono.Cecil;
+﻿using Mono.Cecil;
+using PathOfTerraria.Common.Conflux;
 using PathOfTerraria.Common.Mapping;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.ModPlayers.LivesSystem;
@@ -20,6 +16,11 @@ using PathOfTerraria.Utilities.Xna;
 using ReLogic.Content;
 using ReLogic.Utilities;
 using SubworldLibrary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
 using Terraria.Audio;
 using Terraria.Chat;
 using Terraria.DataStructures;
@@ -327,6 +328,32 @@ public class MapDeviceTile : ModTile
 
 internal class MapDeviceEntity : ModTileEntity
 {
+	internal class ClearInfoHandler : Handler
+	{
+		public static void Send(string subworldName, bool reAdd)
+		{
+			ModPacket packet = Networking.GetPacket<ClearInfoHandler>();
+			BitsByte info = new(reAdd);
+			packet.Write(info);
+			packet.Write(subworldName);
+			packet.Send();
+		}
+
+		internal override void Receive(BinaryReader reader, byte sender)
+		{
+			BitsByte info = reader.ReadBitsByte();
+			string subworldName = reader.ReadString();
+			bool reAdd = info[0];
+
+			ResetPersistentMapInfo(subworldName, reAdd, true);
+
+			if (Main.netMode == NetmodeID.Server)
+			{
+				Send(subworldName, reAdd);
+			}
+		}
+	}
+
 	private static SoundStyle PortalSound = new($"{nameof(PathOfTerraria)}/Assets/Sounds/MapDevice/PortalLoop")
 	{
 		Volume = 0.4f,
@@ -772,6 +799,8 @@ internal class MapDeviceEntity : ModTileEntity
 
 		if (StoredMap is { IsAir: false, ModItem: Map map })
 		{
+			ResetPersistentMapInfo(map.GetDestination().FullName, true);
+
 			PortalUsesLeft = map.MaxUses;
 		}
 		else if (Injection is { } injection)
@@ -802,6 +831,23 @@ internal class MapDeviceEntity : ModTileEntity
 		return true;
 	}
 
+	private static void ResetPersistentMapInfo(string name, bool reAdd = false, bool fromNet = false)
+	{
+		if (!fromNet)
+		{
+			ClearInfoHandler.Send(name, reAdd);
+		}
+
+		MappingWorld.TimesEnteredByDomain.Remove(name);
+		MappingWorld.PersistentDomainInfo.Remove(name);
+
+		if (reAdd)
+		{
+			MappingWorld.TimesEnteredByDomain.Add(name, 0);
+			MappingWorld.PersistentDomainInfo.Add(name, new());
+		}
+	}
+
 	/// <summary>
 	/// Attempts to close the currently open portal.
 	/// <br/> Returns whether an attempt to perform the interaction will be made, not whether it will succeed.
@@ -827,6 +873,11 @@ internal class MapDeviceEntity : ModTileEntity
 		if (Main.netMode == NetmodeID.Server && netSender.HasValue && InteractingPlayer != netSender)
 		{
 			return false;
+		}
+
+		if (StoredMap.ModItem is Map map)
+		{
+			ResetPersistentMapInfo(map.GetDestination().FullName);
 		}
 
 		// The map is destroyed if the portal is ever closed.

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -1141,7 +1141,7 @@ FasterMiningPassive: {
 
 SpelunkyMastery: {
 	// Name: Spelunky
-	// Tooltip: Permanent Spelunker and Mining buffs
+	// Tooltip: Automatically mine out entire veins of ore when mining
 }
 
 CheaperShopsPassive: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -1141,7 +1141,7 @@ FasterMiningPassive: {
 
 SpelunkyMastery: {
 	// Name: Spelunky
-	// Tooltip: Permanent Spelunker and Mining buffs
+	// Tooltip: Automatically mine out entire veins of ore when mining
 }
 
 CheaperShopsPassive: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -1141,7 +1141,7 @@ FasterMiningPassive: {
 
 SpelunkyMastery: {
 	// Name: Spelunky
-	// Tooltip: Permanent Spelunker and Mining buffs
+	// Tooltip: Automatically mine out entire veins of ore when mining
 }
 
 CheaperShopsPassive: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -1141,7 +1141,7 @@ FasterMiningPassive: {
 
 SpelunkyMastery: {
 	// Name: Spelunky
-	// Tooltip: Permanent Spelunker and Mining buffs
+	// Tooltip: Automatically mine out entire veins of ore when mining
 }
 
 CheaperShopsPassive: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -1141,7 +1141,7 @@ FasterMiningPassive: {
 
 SpelunkyMastery: {
 	// Name: Spelunky
-	// Tooltip: Permanent Spelunker and Mining buffs
+	// Tooltip: Automatically mine out entire veins of ore when mining
 }
 
 CheaperShopsPassive: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -1141,7 +1141,7 @@ FasterMiningPassive: {
 
 SpelunkyMastery: {
 	// Name: Spelunky
-	// Tooltip: Permanent Spelunker and Mining buffs
+	// Tooltip: Automatically mine out entire veins of ore when mining
 }
 
 CheaperShopsPassive: {

--- a/build.txt
+++ b/build.txt
@@ -2,4 +2,4 @@ displayName = Path of Terraria (BETA)
 author = ScottieKnowz & GabeHasWon
 modReferences = SubworldLibrary, HousingAPI
 dllReferences = NPCUtils, StructureHelper, Wayfarer
-version = 0.3.0.1
+version = 0.3.1


### PR DESCRIPTION
### Description of Work
- Fixed two of the four starter classes not properly providing their starting item
- Fixed NearbyEnemiesScorchedAffix always applying its visual effect
- Fixed kill count displaying Max - current instead of just current.
- Regenerate localization

#### *Subworld fixes*:
- Added checks to every boss domain to ensure bosses aren't repeatedly farmable with one map
- Made worlds persist properly; closing when closed or failed (by losing all lives), including in multiplayer
- Added safety check to some code that fixed a small innocuous error
- Force-cleared persistent and returning info on subworlds when closing them as well, solving some minor inconsistencies in both singleplayer and multiplayer

Internal:
Rewrote maps to return their destination, such that, given a Map, you can determine where it leads with the GetDestination hook

**This needs testing.** We should have this strongly tested before going live.