### PR TITLE
fix: pyra related bugs

### DIFF
--- a/Common/Subworlds/BossDomainSubworld.cs
+++ b/Common/Subworlds/BossDomainSubworld.cs
@@ -1,6 +1,9 @@
-﻿using PathOfTerraria.Common.Subworlds.Passes;
+using PathOfTerraria.Common.Subworlds.Passes;
+using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
+using SubworldLibrary;
 using System.Collections.Generic;
+using Terraria.ModLoader.IO;
 using Terraria.WorldBuilding;
 
 namespace PathOfTerraria.Common.Subworlds;
@@ -12,8 +15,44 @@ namespace PathOfTerraria.Common.Subworlds;
 /// </summary>
 public abstract class BossDomainSubworld : MappingWorld
 {
+	private const string RavencrestStructureStateKey = "ravencrestStructureState";
+
 	public override bool NoPlayerSaving => false;
 
 	// We are going to first set the world to be completely flat so we can build on top of that
 	public override List<GenPass> Tasks => [new FlatWorldPass()];
+
+	public override void CopyMainWorldData()
+	{
+		base.CopyMainWorldData();
+		CopyRavencrestStructureState();
+	}
+
+	public override void ReadCopiedMainWorldData()
+	{
+		base.ReadCopiedMainWorldData();
+		ReadRavencrestStructureState();
+	}
+
+	public override void CopySubworldData()
+	{
+		base.CopySubworldData();
+		CopyRavencrestStructureState();
+	}
+
+	public override void ReadCopiedSubworldData()
+	{
+		base.ReadCopiedSubworldData();
+		ReadRavencrestStructureState();
+	}
+
+	private static void CopyRavencrestStructureState()
+	{
+		SubworldSystem.CopyWorldData(RavencrestStructureStateKey, RavencrestSystem.SaveStructureState());
+	}
+
+	private static void ReadRavencrestStructureState()
+	{
+		RavencrestSystem.LoadStructureState(SubworldSystem.ReadCopiedWorldData<TagCompound>(RavencrestStructureStateKey));
+	}
 }

--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -357,6 +357,34 @@ public class RavencrestSystem : ModSystem
 		ImprovableStructure structure = Structures[name];
 		level = level == -1 ? structure.StructureIndex + 1 : level;
 		structure.Change(level);
+
+		if (SubworldSystem.Current is RavencrestSubworld)
+		{
+			structure.Place();
+		}
+	}
+
+	internal static TagCompound SaveStructureState()
+	{
+		TagCompound tag = [];
+
+		foreach (KeyValuePair<string, ImprovableStructure> structure in Structures)
+		{
+			tag.Add(structure.Key, (byte)structure.Value.StructureIndex);
+		}
+
+		return tag;
+	}
+
+	internal static void LoadStructureState(TagCompound tag)
+	{
+		foreach (KeyValuePair<string, ImprovableStructure> structure in Structures)
+		{
+			if (tag.TryGet(structure.Key, out byte index))
+			{
+				structure.Value.Change(index);
+			}
+		}
 	}
 
 	public override void PostUpdateEverything()

--- a/Common/Systems/Synchronization/Handlers/RavencrestBuildingIndexHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/RavencrestBuildingIndexHandler.cs
@@ -12,14 +12,14 @@ internal class RavencrestBuildingIndex : Handler
 	{
 		ModPacket packet = Networking.GetPacket<RavencrestBuildingIndex>();
 		packet.Write(name);
-		packet.Write((byte)index);
+		packet.Write(index);
 		packet.Send();
 	}
 
 	internal override void ServerReceive(BinaryReader reader, byte sender)
 	{
 		string name = reader.ReadString();
-		byte index = reader.ReadByte();
+		int index = reader.ReadInt32();
 
 		RavencrestSystem.UpgradeBuilding(name, index);
 	}

--- a/Content/NPCs/Town/TinkerNPC.cs
+++ b/Content/NPCs/Town/TinkerNPC.cs
@@ -175,30 +175,25 @@ public class TinkerNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpawnIn
 
 	public bool HasQuestMarker(out Quest quest)
 	{
-		Quest tinkerIntroQuest = Quest.GetLocalPlayerInstance<TinkerIntroQuest>();
-		Quest twinsQuest = Quest.GetLocalPlayerInstance<TwinsQuest>();
-		Quest destroyerQuest = Quest.GetLocalPlayerInstance<DestroyerQuest>();
-		Quest skelePrimeQuest = Quest.GetLocalPlayerInstance<SkelePrimeQuest>();
-
-		if (tinkerIntroQuest.QuestNotStarted || (tinkerIntroQuest.Active && !tinkerIntroQuest.Completed))
+		if (ShouldShowMarker<TinkerIntroQuest>(out Quest tinkerIntroQuest))
 		{
 			quest = tinkerIntroQuest;
 			return true;
 		}
 
-		if (twinsQuest.QuestNotStarted || (twinsQuest.Active && !twinsQuest.Completed))
+		if (ShouldShowMarker<TwinsQuest>(out Quest twinsQuest))
 		{
 			quest = twinsQuest;
 			return true;
 		}
 
-		if (destroyerQuest.QuestNotStarted || (destroyerQuest.Active && !destroyerQuest.Completed))
+		if (ShouldShowMarker<DestroyerQuest>(out Quest destroyerQuest))
 		{
 			quest = destroyerQuest;
 			return true;
 		}
 
-		if (skelePrimeQuest.QuestNotStarted || (skelePrimeQuest.Active && !skelePrimeQuest.Completed))
+		if (ShouldShowMarker<SkelePrimeQuest>(out Quest skelePrimeQuest))
 		{
 			quest = skelePrimeQuest;
 			return true;
@@ -206,5 +201,11 @@ public class TinkerNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpawnIn
 	
 		quest = null;
 		return false;
+	}
+
+	private static bool ShouldShowMarker<T>(out Quest quest) where T : Quest
+	{
+		quest = Quest.GetLocalPlayerInstance<T>();
+		return QuestUnlockManager.CanStartQuest<T>() || (quest.Active && !quest.Completed);
 	}
 }


### PR DESCRIPTION
## Tested by Shionne and TheZemor
https://discordapp.com/channels/898562996715012096/1497603940827795534/1497609889445576734

﻿### Link Issues
Resolves:

### Description of Work
* Pyra’s quest marker was too eager: it showed for any not-started Pyra quest, even when QuestUnlockManager.CanStartQuest said the quest was not actually available. 
* The workshop state was also fragile around boss maps. Upgrading a Ravencrest building only changed the structure index; it didn’t immediately place/sync the upgraded building, and boss-domain transitions didn’t carry Ravencrest structure indices through the temporary boss subworld. I added immediate placement/sync on upgrade and copied Ravencrest structure state through boss-domain enter/exit
* *  I also fixed the building sync packet so -1 stays -1 instead of becoming byte 255.

### Comments
