### PR TITLE
fix(#1871): Fixes rage defence not being calced correctly

### DIFF
--- a/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
+++ b/Common/Systems/PassiveTreeSystem/PassiveTreePlayer.cs
@@ -72,7 +72,7 @@ internal class PassiveTreePlayer : ModPlayer
 			{
 				if (oldLevel < passive.Level)
 				{
-					AllocatePassive(passive, passive.Level - oldLevel, false);
+					AllocatePassive(passive, passive.Value * (passive.Level - oldLevel), false);
 				}
 				else if (oldLevel > passive.Level)
 				{
@@ -408,7 +408,7 @@ internal class PassiveTreePlayer : ModPlayer
 
 		if (str > 0)
 		{
-			str = Math.Max(0, str - valueLoss);
+			str = Math.Max(0, str - valueLoss * pointRefund);
 		}
 #if DEBUG
 		else

--- a/Content/Passives/Melee/SmallPassives/RageResistancePassive.cs
+++ b/Content/Passives/Melee/SmallPassives/RageResistancePassive.cs
@@ -11,7 +11,7 @@ internal class RageResistancePassive : Passive
 		{
 			if (Player.HasBuff<RageStacksBuff>())
 			{
-				modifiers.FinalDamage -= Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<RageResistancePassive>();
+				modifiers.FinalDamage -= Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<RageResistancePassive>() / 100f;
 			}
 		}
 	}


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1871 
Confirmed working: https://discordapp.com/channels/898562996715012096/1497657625200951516/1497681888024854549

### Description of Work
* Fixes rage defence not being calced correctly

### Comments
