### PR TITLE
misc tree fixes

### DIFF
--- a/Common/Data/Passives/Passives.json
+++ b/Common/Data/Passives/Passives.json
@@ -6257,7 +6257,7 @@
 		"internalIdentifier": "ExplosiveSlugsMastery",
 		"referenceId": 1091,
 		"maxLevel": 1,
-		"value": 50,
+		"value": 30,
 		"position": {
 			"x": 450,
 			"y": 1210

--- a/Content/Passives/Magic/Masteries/StarcallerMastery.cs
+++ b/Content/Passives/Magic/Masteries/StarcallerMastery.cs
@@ -59,7 +59,7 @@ internal class StarcallerMastery : Passive
 			{
 				IEntitySource src = Player.GetSource_OnHit(target);
 				Vector2 pos = target.Center - new Vector2(0, 800);
-				Projectile.NewProjectile(src, pos, new Vector2(0, 8), type, (int)(damageDone * value / 100f), 2, Player.whoAmI, target.whoAmI);
+				Projectile.NewProjectile(src, pos, new Vector2(0, 8), type, (int)(damageDone), 2, Player.whoAmI, target.whoAmI);
 			}
 		}
 

--- a/Content/Passives/Ranged/Masteries/DemolitionsExpertMastery.cs
+++ b/Content/Passives/Ranged/Masteries/DemolitionsExpertMastery.cs
@@ -12,7 +12,7 @@ internal class DemolitionsExpertMastery : Passive
 	{
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().HasNode<DemolitionsExpertMastery>())
+			if (ProjectileID.Sets.Explosive[projectile.type] && source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().HasNode<DemolitionsExpertMastery>())
 			{
 				projectile.damage = (int)(projectile.damage * (1 + DamageBoost / 100f));
 			}

--- a/Content/Passives/Ranged/Masteries/DemolitionsExpertMastery.cs
+++ b/Content/Passives/Ranged/Masteries/DemolitionsExpertMastery.cs
@@ -12,7 +12,7 @@ internal class DemolitionsExpertMastery : Passive
 	{
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (ProjectileID.Sets.Explosive[projectile.type] && source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().HasNode<DemolitionsExpertMastery>())
+			if (ProjectileID.Sets.Explosive[projectile.type] && source is EntitySource_ItemUse itemUse && itemUse.Player.GetModPlayer<PassiveTreePlayer>().HasNode<DemolitionsExpertMastery>())
 			{
 				projectile.damage = (int)(projectile.damage * (1 + DamageBoost / 100f));
 			}

--- a/Content/Passives/Ranged/Masteries/ExplosiveSlugsMastery.cs
+++ b/Content/Passives/Ranged/Masteries/ExplosiveSlugsMastery.cs
@@ -25,7 +25,14 @@ internal class ExplosiveSlugsMastery : Passive
 		{
 			if (_bullet && hit.Crit && proj.TryGetOwner(out Player plr) && plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ExplosiveSlugsMastery>(out float value))
 			{
-				ExplosionHitbox.QuickSpawn(proj.GetSource_OnHit(target), proj, (int)(damageDone * value / 100f), proj.owner, new Vector2(60, 60), ExplosionSpawnInfo.PlayerOwned(proj.owner));
+				var explosionInfo = new ExplosionSpawnInfo(
+					Friendly: true,
+					Knockback: 3f,
+					Velocity: Vector2.Zero, 
+					CanSpawnProjectile: proj.owner == Main.myPlayer
+				);
+		
+				ExplosionHitbox.QuickSpawn(proj.GetSource_OnHit(target), proj, (int)(damageDone * 30f / 100f), proj.owner, new Vector2(60, 60), explosionInfo);
 			}
 		}
 	}


### PR DESCRIPTION

﻿### Link Issues
Resolves:
#1885 
#
### Description of Work

- Nerfed explosive slugs knockback
- Fixed explosive slugs damage being low and changed it to a 30% of base damage hit, not 50.
- Fixed demolitions expert damage bonus being global
- Fixed starcaller mastery damage scaling (was previously ~1% scaling...now its back to 100%.)

### Comments
