### PR TITLE
Conflux fixups

### DIFF
--- a/Common/Encounters/EnemySpawning.cs
+++ b/Common/Encounters/EnemySpawning.cs
@@ -49,6 +49,10 @@ internal record struct EnemySpawn()
 	/// <summary> The encounter kill score given for killing this enemy. </summary>
 	[DefaultValue(1f)]
 	public float KillScore { get; set; } = 1f;
+
+	/// <summary> If true, the spawned NPC will not despawn when off-screen. </summary>
+	[DefaultValue(true)]
+	public bool NoDespawning { get; set; } = true;
 }
 
 /// <summary> A description used to calculate a placement for an enemy spawn. </summary>
@@ -167,9 +171,16 @@ internal static class EnemySpawning
 
 		npc = NPC.NewNPCDirect(source, spawnPosition, spawn.NpcType.Type);
 
-		if (npc.whoAmI == Main.maxNPCs)
+		if (npc.whoAmI >= Main.maxNPCs) { return false; }
+
+		if (spawn.NoDespawning)
 		{
-			return false;
+			npc.GetGlobalNPC<NPCDespawning>().NeverDespawn = true;
+			
+			if (Main.netMode == NetmodeID.Server)
+			{
+				NetMessage.SendData(MessageID.SyncNPC, npc.whoAmI);
+			}
 		}
 
 		SpawnEffects(npc, spawn.Effect, spawnPosition);

--- a/Common/Encounters/NPCDespawning.cs
+++ b/Common/Encounters/NPCDespawning.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using System.IO;
+using Terraria.ModLoader.IO;
+
+namespace PathOfTerraria.Common.Encounters;
+
+public sealed class NPCDespawning : GlobalNPC
+{
+    public bool NeverDespawn { get; set; } = false;
+
+	public override bool InstancePerEntity => true;
+
+	public override bool CheckActive(NPC npc)
+	{
+		return !NeverDespawn;
+	}
+
+	public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
+    {
+        bitWriter.WriteBit(NeverDespawn);
+    }
+	public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
+    {
+        NeverDespawn = bitReader.ReadBit();
+    }
+}

--- a/Common/Mapping/MapResources.cs
+++ b/Common/Mapping/MapResources.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using PathOfTerraria.Common.Systems.Synchronization;
+using PathOfTerraria.Core.Subworlds;
 using SubworldLibrary;
 using Terraria.ID;
 using Terraria.ModLoader.IO;
@@ -45,7 +46,7 @@ internal enum ResourceDiscovery : byte
 }
 
 /// <summary> Tracks and synchronizes <see cref="MapResource"/>s across servers and clients. </summary>
-internal sealed class MapResources : ModSystem
+internal sealed class MapResources : ModSystem, ISubworldSync
 {
 	/// <summary> Synchronizes all resource values. Can only be sent by servers. </summary>
 	internal sealed class SynchronizeMessage : Handler
@@ -271,6 +272,22 @@ internal sealed class MapResources : ModSystem
 				}
 			}
 		}
+	}
+
+	// Only used in Singleplayer.
+    void ISubworldSync.ExportSharedData()
+	{
+		if (Main.netMode != NetmodeID.SinglePlayer) { return; }
+		
+		var tag = new TagCompound();
+		SaveWorldData(tag);
+		SubworldSystem.CopyWorldData("mapResources", tag);
+	}
+    void ISubworldSync.ImportSharedData()
+	{
+		if (Main.netMode != NetmodeID.SinglePlayer) { return; }
+		
+		LoadWorldData(SubworldSystem.ReadCopiedWorldData<TagCompound>("mapResources"));
 	}
 
 	public override void NetSend(BinaryWriter writer)

--- a/Common/Subworlds/MappingWorld.cs
+++ b/Common/Subworlds/MappingWorld.cs
@@ -1,4 +1,4 @@
-using PathOfTerraria.Common.Config;
+﻿using PathOfTerraria.Common.Config;
 using PathOfTerraria.Common.Subworlds.Passes;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
@@ -7,6 +7,7 @@ using PathOfTerraria.Common.Systems.DisableBuilding;
 using PathOfTerraria.Common.Systems.Synchronization;
 using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using PathOfTerraria.Common.UI;
+using PathOfTerraria.Core.Subworlds;
 using ReLogic.Content;
 using SubworldLibrary;
 using System.Collections.Generic;
@@ -482,12 +483,14 @@ public abstract class MappingWorld : Subworld
 	public override void CopySubworldData()
 	{
 		base.CopySubworldData();
+		SubworldHooks.ExportSubworldData(this);
 		CopyConsistentInfo();
 	}
 
 	public override void ReadCopiedSubworldData()
 	{
 		base.ReadCopiedSubworldData();
+		SubworldHooks.ImportSubworldData(this);
 		ReadConsistentInfo();
 	}
 

--- a/Content/Conflux/InfernalBoss.cs
+++ b/Content/Conflux/InfernalBoss.cs
@@ -990,6 +990,12 @@ internal sealed class InfernalBoss : ModNPC
 		return true;
 	}
 
+	// Prevent despawn in idle state.
+	public override bool CheckActive()
+	{
+		return false;
+	}
+
 	private void BodyMovement(in Context ctx)
 	{
 		NPC.GravityMultiplier = MultipliableFloat.One * 2.5f;

--- a/Core/Subworlds/SubworldHooks.cs
+++ b/Core/Subworlds/SubworldHooks.cs
@@ -1,0 +1,59 @@
+using SubworldLibrary;
+
+#nullable enable
+
+namespace PathOfTerraria.Core.Subworlds;
+
+/// <summary> Unified interface used for synchronizing data between subworlds. </summary>
+internal interface ISubworldSync : ICopyWorldData
+{
+    void ICopyWorldData.CopyMainWorldData()
+    {
+        ExportMainWorldData();
+    }
+    void ICopyWorldData.ReadCopiedMainWorldData()
+    {
+        ImportMainWorldData();
+    }
+    
+    /// <summary> Called by default implementations of <see cref="ExportMainWorldData"/> and <see cref="ExportSubworldData"/>. </summary>
+    void ExportSharedData() { }
+    /// <summary> Called by default implementations of <see cref="ImportMainWorldData"/> and <see cref="ImportSubworldData"/>. </summary>
+    void ImportSharedData() { }
+
+    /// <inheritdoc cref="ICopyWorldData.CopyMainWorldData"/>
+    void ExportMainWorldData() { ExportSharedData(); }
+    /// <inheritdoc cref="ICopyWorldData.ReadCopiedMainWorldData"/>
+    void ImportMainWorldData() { ImportSharedData(); }
+
+    /// <inheritdoc cref="Subworld.CopySubworldData"/>
+    void ExportSubworldData(Subworld subworld) { ExportSharedData(); }
+    /// <inheritdoc cref="Subworld.ReadCopiedSubworldData"/>
+    void ImportSubworldData(Subworld subworld) { ImportSharedData(); }
+}
+
+internal sealed class SubworldHooks : ModSystem
+{
+    private static Action<Subworld>? exportSubworldData;
+    private static Action<Subworld>? importSubworldData;
+
+    public static void ExportSubworldData(Subworld subworld) { exportSubworldData?.Invoke(subworld); }
+    public static void ImportSubworldData(Subworld subworld) { importSubworldData?.Invoke(subworld); }
+    
+	public override void PostSetupContent()
+	{
+        exportSubworldData = null;
+        importSubworldData = null;
+    
+		foreach (ISubworldSync impl in ModContent.GetContent<ISubworldSync>())
+        {
+            exportSubworldData += impl.ExportSubworldData;
+            importSubworldData += impl.ImportSubworldData;
+        }
+	}
+	public override void Unload()
+	{
+		exportSubworldData = null;
+		importSubworldData = null;
+	}
+}

--- a/Localization/de-DE/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Quests.hjson
@@ -174,7 +174,7 @@ Quest: {
 		// Description: ""
 		// EnterDomain: Enter Plantera's domain
 		// Boss: Defeat Plantera
-		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters TODO: Change this name to the actual mob we make.
+		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters //TODO: Change this name to the actual mob we make.
 	}
 
 	GolemQuest: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Quests.hjson
@@ -174,7 +174,7 @@ Quest: {
 		// Description: ""
 		// EnterDomain: Enter Plantera's domain
 		// Boss: Defeat Plantera
-		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters TODO: Change this name to the actual mob we make.
+		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters //TODO: Change this name to the actual mob we make.
 	}
 
 	GolemQuest: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Quests.hjson
@@ -174,7 +174,7 @@ Quest: {
 		// Description: ""
 		// EnterDomain: Enter Plantera's domain
 		// Boss: Defeat Plantera
-		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters TODO: Change this name to the actual mob we make.
+		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters //TODO: Change this name to the actual mob we make.
 	}
 
 	GolemQuest: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Quests.hjson
@@ -174,7 +174,7 @@ Quest: {
 		// Description: ""
 		// EnterDomain: Enter Plantera's domain
 		// Boss: Defeat Plantera
-		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters TODO: Change this name to the actual mob we make.
+		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters //TODO: Change this name to the actual mob we make.
 	}
 
 	GolemQuest: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Quests.hjson
@@ -174,7 +174,7 @@ Quest: {
 		// Description: ""
 		// EnterDomain: Enter Plantera's domain
 		// Boss: Defeat Plantera
-		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters TODO: Change this name to the actual mob we make.
+		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters //TODO: Change this name to the actual mob we make.
 	}
 
 	GolemQuest: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Quests.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Quests.hjson
@@ -174,7 +174,7 @@ Quest: {
 		// Description: ""
 		// EnterDomain: Enter Plantera's domain
 		// Boss: Defeat Plantera
-		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters TODO: Change this name to the actual mob we make.
+		// Plantera: Defeat ({0}/{1}) Strange Growth Monsters //TODO: Change this name to the actual mob we make.
 	}
 
 	GolemQuest: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1876

### Description of Work
- ~~Fixed a singleplayer-only issue of conflux resource acquisition on exploration maps not properly transferring back to the main world, causing overworld rifts to be the only valid source of conflux in singleplayer.~~
- Fixed enemies spawned in rifts and encounters being able to despawn off-screen, with the despawns also registering towards rift progression. Too late to abuse this!
- Internal: `ISubworldSync` interface.

### Comments
