### PR TITLE
Multiplayer conflux & rift fixups

### DIFF
--- a/Common/Conflux/ConfluxRifts.cs
+++ b/Common/Conflux/ConfluxRifts.cs
@@ -135,7 +135,7 @@ internal sealed class ConfluxRifts : ModSystem
 				numSpawnsToAnnounce = Math.Max(0, numSpawnsToAnnounce + 1);
 
 #if DEBUG_LOG
-				DebugUtils.DebugLog("New conflux rift spawn pending.");
+				DebugUtils.DebugLog($"{GetType().Name}: New conflux rift spawn pending.");
 #endif
 			}
 		}
@@ -409,6 +409,8 @@ internal sealed class ConfluxRifts : ModSystem
 			{
 				break;
 			}
+
+			numSpawned++;
 			
 			if (maxSpawns > 0 && numSpawned >= maxSpawns)
 			{

--- a/Common/Encounters/EnemySpawning.cs
+++ b/Common/Encounters/EnemySpawning.cs
@@ -179,7 +179,7 @@ internal static class EnemySpawning
 			
 			if (Main.netMode == NetmodeID.Server)
 			{
-				NetMessage.SendData(MessageID.SyncNPC, npc.whoAmI);
+				NetMessage.SendData(MessageID.SyncNPC, number: npc.whoAmI);
 			}
 		}
 

--- a/Common/Mapping/MapResources.cs
+++ b/Common/Mapping/MapResources.cs
@@ -57,7 +57,10 @@ internal sealed class MapResources : ModSystem, ISubworldSync
 			ModContent.GetInstance<MapResources>().NetSend(packet);
 			packet.Send();
 
-			if (sendToSubworlds) { SubworldSystem.SendToAllSubservers(PoTMod.Instance, Networking.GetFinalPacketBuffer(packet)); }
+			if (sendToSubworlds)
+			{
+				SubworldSystem.SendToAllSubservers(PoTMod.Instance, Networking.GetFinalPacketBuffer(packet));
+			}
 		}
 
 		internal override void Receive(BinaryReader reader, byte sender)
@@ -213,11 +216,11 @@ internal sealed class MapResources : ModSystem, ISubworldSync
 		// Short-circuit if unrecognized.
 		if (!resourcesByItem.TryGetValue(itemType, out int index)) { return; }
 
-		// Redirect to main server.
+		// Direct copy to main server.
 		if (Main.netMode == NetmodeID.Server && SubworldSystem.Current != null)
 		{
-			SubworldSystem.SendToMainServer(PoTMod.Instance, Networking.GetFinalPacketBuffer(ModifyValueMessage.Write(itemType, delta, discovery)));
-			return;
+			Networking.SendPacketToMainServer(ModifyValueMessage.Write(itemType, delta, discovery));
+			// return;
 		}
 
 		// Perform function.
@@ -232,7 +235,7 @@ internal sealed class MapResources : ModSystem, ISubworldSync
 		};
 
 		// Enqueue a full sync.
-		needsSync |= Main.netMode == NetmodeID.Server;
+		needsSync |= Main.netMode == NetmodeID.Server && SubworldSystem.Current == null;
 	}
 
 	public static bool AnyResourceDiscovered()

--- a/Content/Conflux/ConfluxRift.cs
+++ b/Content/Conflux/ConfluxRift.cs
@@ -188,6 +188,7 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 		Projectile.Size = new Vector2(120, 120);
 		Projectile.Opacity = 0f;
 		Projectile.hide = true;
+		Projectile.netImportant = true;
 	}
 
 	public override bool? CanDamage()

--- a/Content/Conflux/ConfluxRift.cs
+++ b/Content/Conflux/ConfluxRift.cs
@@ -141,6 +141,7 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 	private (SlotId Handle, float Volume) soundAwoken;
 	private ProjectileAudioTracker? audioTracker;
 	private bool approached;
+	private Flags lastFlags;
 
 	public uint EndTime { get; set; }
 	public Encounter Encounter { get; private set; }
@@ -313,9 +314,30 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 
 	private void UpdateEffects()
 	{
+		Flags newFlags = BitFlags;
+		Flags oldFlags = lastFlags;
+		lastFlags = newFlags;
+		
 		if (Main.dedServ) { return; }
 
 		VisualParams visuals = GetVisualParameters();
+
+		// Activation effects.
+		if (newFlags.HasFlag(Flags.Activated) && !oldFlags.HasFlag(Flags.Activated))
+		{
+			SoundEngine.PlaySound(SoundActivation, Projectile.Center);
+
+			for (int i = 0; i < 100; i++)
+			{
+				Dust.NewDustPerfect(Projectile.Center + Main.rand.NextVector2Circular(8f, 8f), visuals.DustId, Main.rand.NextVector2Circular(8f, 8f));
+			}
+		}
+
+		// Close effects.
+		if (newFlags.HasFlag(Flags.Closing) && !oldFlags.HasFlag(Flags.Closing))
+		{
+			SoundEngine.PlaySound(SoundDeactivation, Projectile.Center);
+		}
 
 		if (Main.rand.NextBool(10) && Activated && OpeningAnimation > 0.34f)
 		{
@@ -454,11 +476,11 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 		return false;
 	}
 
-	public void Activate(bool fromNet = false)
+	public void Activate()
 	{
 		if ((BitFlags & Flags.Activated) != 0) { return; }
 
-		if (Main.netMode == NetmodeID.MultiplayerClient && !fromNet)
+		if (Main.netMode == NetmodeID.MultiplayerClient)
 		{
 			Vector2 compareSpot = Main.LocalPlayer.Center;
 			if (!Main.LocalPlayer.IsProjectileInteractibleAndInInteractionRange(Projectile, ref compareSpot)) { return; }
@@ -471,42 +493,25 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 
 		if (Main.netMode == NetmodeID.Server)
 		{
-			RiftInteractionHandler.Send(Projectile.identity);
+			NetMessage.SendData(MessageID.SyncProjectile, number: Projectile.whoAmI);
 		}
 
 		if (Main.netMode != NetmodeID.MultiplayerClient)
 		{
 			ConfluxRifts.OnRiftActivated(this);
 		}
-
-		// Effects.
-		if (!Main.dedServ)
-		{
-			VisualParams visuals = GetVisualParameters();
-
-			SoundEngine.PlaySound(SoundActivation, Projectile.Center);
-
-			for (int i = 0; i < 100; i++)
-			{
-				Dust.NewDustPerfect(Projectile.Center + Main.rand.NextVector2Circular(8f, 8f), visuals.DustId, Main.rand.NextVector2Circular(8f, 8f));
-			}
-		}
 	}
 
 	public void Close()
 	{
-		if (Closing || Main.netMode == NetmodeID.MultiplayerClient) { return; }
+		if (Closing) { return; }
+		if (Main.netMode == NetmodeID.MultiplayerClient) { return; }
 
 		BitFlags |= Flags.Closing;
 
-		if (!Main.dedServ)
-		{
-			SoundEngine.PlaySound(SoundDeactivation, Projectile.Center);
-		}
-
 		if (Main.netMode == NetmodeID.Server)
 		{
-			NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, Projectile.whoAmI);
+			NetMessage.SendData(MessageID.SyncProjectile, number: Projectile.whoAmI);
 		}
 
 		UpdateProgress();
@@ -833,7 +838,7 @@ internal class RiftInteractionHandler : Handler
 	public static void Send(int riftIdentity)
 	{
 		ModPacket packet = Networking.GetPacket<RiftInteractionHandler>();
-		packet.Write(riftIdentity);
+		packet.Write((int)riftIdentity);
 		packet.Send();
 	}
 
@@ -842,16 +847,13 @@ internal class RiftInteractionHandler : Handler
 		ModPacket packet = Networking.GetPacket(Id);
 		int riftIdentity = reader.ReadInt32();
 
+		if (Main.netMode != NetmodeID.Server) { return; }
 		if (Main.projectile.FirstOrDefault(p => p.identity == riftIdentity) is not { ModProjectile: ConfluxRift rift }) { return; }
+		if (Main.player[sender] is not { active: true } player) { return; }
 
-		if (Main.netMode == NetmodeID.Server)
-		{
-			if (Main.player[sender] is not { active: true } player) { return; }
-
-			// Increased reach distance for synchronization grace.
-			Point tileTarget = rift.Projectile.Hitbox.ClosestPointInRect(player.Center).ToTileCoordinates();
-			if (!player.IsInTileInteractionRange(tileTarget.X, tileTarget.Y, TileReachCheckSettings.Simple with { TileRangeMultiplier = 2 })) { return; }
-		}
+		// Increased reach distance for synchronization grace.
+		Point tileTarget = rift.Projectile.Hitbox.ClosestPointInRect(player.Center).ToTileCoordinates();
+		if (!player.IsInTileInteractionRange(tileTarget.X, tileTarget.Y, TileReachCheckSettings.Simple with { TileRangeMultiplier = 2 })) { return; }
 
 		rift.Activate();
 	}

--- a/Content/Conflux/FallenSoul.cs
+++ b/Content/Conflux/FallenSoul.cs
@@ -27,6 +27,7 @@ internal sealed class FallenSoul : ModProjectile
 		Projectile.Size = new(16);
 		Projectile.aiStyle = -1;
 		Projectile.timeLeft = 60 * 30;
+		Projectile.netImportant = true;
 	}
 
 	public override void AI()


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1876 (now in multiplayer)

### Description of Work
- Fixed rifts often not being synchronized to clients in exploration realms.
- Fixed rifts' opening and closing animations sometimes failing to play in multiplayer.
- Fixed conflux resource acquisition on exploration maps not properly transferring back to the main world, causing overworld rifts to be the only valid source of conflux.
  - Internal: Amended, thought to be SP-only prior, but had different SP and MP aspects.
- Fixed The Fallen's souls not synchronizing to joining players.
- Internal: Footgun fixup to prior PR.

### Comments
