### PR TITLE
fix(#1904): Fixes a few passives not using the correct values

### DIFF
--- a/Content/Passives/Ranged/SmallPassives/ExplosiveKnockbackPassive.cs
+++ b/Content/Passives/Ranged/SmallPassives/ExplosiveKnockbackPassive.cs
@@ -9,7 +9,7 @@ internal class ExplosiveKnockbackPassive : Passive
 	{
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ExplosiveKnockbackPassive>(out float value))
+			if (ProjectileID.Sets.Explosive[projectile.type] && source is EntitySource_ItemUse itemUse && itemUse.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ExplosiveKnockbackPassive>(out float value))
 			{
 				projectile.knockBack *= 1 + (value / 100f);
 			}

--- a/Content/Passives/Ranged/SmallPassives/ExplosiveKnockbackPassive.cs
+++ b/Content/Passives/Ranged/SmallPassives/ExplosiveKnockbackPassive.cs
@@ -1,5 +1,6 @@
 ﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Content.Passives;
 
@@ -9,7 +10,9 @@ internal class ExplosiveKnockbackPassive : Passive
 	{
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (ProjectileID.Sets.Explosive[projectile.type] && source is EntitySource_ItemUse itemUse && itemUse.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ExplosiveKnockbackPassive>(out float value))
+			if (ProjectileID.Sets.Explosive[projectile.type] 
+			    && source is EntitySource_ItemUse itemUse
+			    && itemUse.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ExplosiveKnockbackPassive>(out float value))
 			{
 				projectile.knockBack *= 1 + (value / 100f);
 			}

--- a/Content/Passives/Ranged/SmallPassives/ExplosiveKnockbackPassive.cs
+++ b/Content/Passives/Ranged/SmallPassives/ExplosiveKnockbackPassive.cs
@@ -9,7 +9,7 @@ internal class ExplosiveKnockbackPassive : Passive
 	{
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<StrongerExplosivesPassive>(out float value))
+			if (source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ExplosiveKnockbackPassive>(out float value))
 			{
 				projectile.knockBack *= 1 + (value / 100f);
 			}

--- a/Content/Passives/Summon/Masteries/DeathrushMastery.cs
+++ b/Content/Passives/Summon/Masteries/DeathrushMastery.cs
@@ -1,6 +1,7 @@
 ﻿using PathOfTerraria.Common.Projectiles;
 using PathOfTerraria.Common.Systems.ModPlayers;
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Content.Passives.Summon.Masteries;
 
@@ -33,4 +34,6 @@ internal class DeathrushMastery : Passive
 		// Player movement speed bonus: (Value / 1000) per minion (capped at 10 minions).
 		player.moveSpeed += MathF.Min(player.slotsMinions, 10) * Value / 1000f;
 	}
+
+	public override string DisplayTooltip => Language.GetText($"Mods.PathOfTerraria.Passives.{Name}.Tooltip").Format(Value / 100f);
 }

--- a/Content/Passives/Utility/SmallPassives/CheaperShopsPassive.cs
+++ b/Content/Passives/Utility/SmallPassives/CheaperShopsPassive.cs
@@ -13,9 +13,9 @@ internal class CheaperShopsPassive : Passive
 	{
 		orig(self, item, out calcForSelling, out calcForBuying);
 
-		if (self.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ValuableSalesPassive>(out float value))
+		if (self.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<CheaperShopsPassive>(out float value))
 		{
-			calcForBuying = (long)(calcForSelling * (1 - value / 100f));
+			calcForBuying = (long)(calcForBuying * (1 - value / 100f));
 		}
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1904

### Description of Work
*  Fixes a few passives not using the correct values
* Fixes deathsrush mastery not using correct tooltip information 

### Comments
