### PR TITLE
feat: add in aquiring a new map if lost

### DIFF
--- a/Common/Quests/QuestDebugging.cs
+++ b/Common/Quests/QuestDebugging.cs
@@ -179,6 +179,18 @@ public sealed class QuestDebugState : SmartUiState
 		StringBuilder stringBuilder = new();
 		QuestModPlayer playerQuests = Main.LocalPlayer.GetModPlayer<QuestModPlayer>();
 
+		void AdvanceQuestForDebug(Quest quest, int delta)
+		{
+			if (delta > 0 && !quest.Active)
+			{
+				int targetStep = Math.Min(delta - 1, quest.QuestSteps.Count);
+				playerQuests.StartQuest(quest.FullName, targetStep);
+				return;
+			}
+
+			quest.Advance(Main.LocalPlayer, delta);
+		}
+
 		foreach (Quest quest in playerQuests.QuestsByName.Values.OrderBy(q => q.Name))
 		{
 			if (!string.IsNullOrEmpty(SearchBar.CurrentValue) && !quest.Name.Contains(SearchBar.CurrentValue, StringComparison.InvariantCultureIgnoreCase))
@@ -228,7 +240,7 @@ public sealed class QuestDebugState : SmartUiState
 						return;
 					}
 
-					quest.Advance(Main.LocalPlayer, delta: -1);
+					AdvanceQuestForDebug(quest, delta: -1);
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
 
@@ -244,7 +256,7 @@ public sealed class QuestDebugState : SmartUiState
 						return;
 					}
 
-					quest.Advance(Main.LocalPlayer, delta: -2);
+					AdvanceQuestForDebug(quest, delta: -2);
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
 
@@ -260,7 +272,7 @@ public sealed class QuestDebugState : SmartUiState
 
 				e.SetDimensions(x: (0.0f, +buttonX), y: (0.0f, +24), width: (0.0f, +128), height: (0f, +32));
 				e.AddComponent(new UIDynamicText(x => quest.Completed ? "Completed" : (quest.Active ? $"Stage {quest.CurrentStep + 1} of {quest.QuestSteps.Count}" : "Inactive")));
-
+				
 				buttonX += e.Width.Pixels;
 			});
 			// Advance '+' button.
@@ -283,14 +295,7 @@ public sealed class QuestDebugState : SmartUiState
 						return;
 					}
 
-					if (!quest.Active)
-					{
-						Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest(quest.FullName);
-					}
-					else
-					{
-						quest.Advance(Main.LocalPlayer, delta: 1);
-					}
+					AdvanceQuestForDebug(quest, delta: 1);
 
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};
@@ -302,14 +307,7 @@ public sealed class QuestDebugState : SmartUiState
 						return;
 					}
 
-					if (!quest.Active)
-					{
-						Main.LocalPlayer.GetModPlayer<QuestModPlayer>().StartQuest(quest.FullName);
-					}
-					else
-					{
-						quest.Advance(Main.LocalPlayer, delta: 2);
-					}
+					AdvanceQuestForDebug(quest, delta: 2);
 
 					SmartUiLoader.GetUiState<QuestsUIState>().Refresh();
 				};

--- a/Common/Quests/QuestUtils.cs
+++ b/Common/Quests/QuestUtils.cs
@@ -26,4 +26,38 @@ internal static class QuestUtils
 	{
 		return _ => BossTracker.TotalBossesDowned.Contains(npcId);
 	}
+
+	/// <summary>
+	/// Returns true when the player should be offered a free re-grant of <paramref name="itemType"/>
+	/// from a quest-giver: the quest is active, the player no longer holds the item, and the
+	/// quest's <see cref="Quest.CurrentStep"/> is between the giveaway step and the step that
+	/// counts as the boss being defeated. Once the player advances past <paramref name="lastActiveStep"/>
+	/// (i.e. the boss has been killed) the regrant disappears so players have to farm maps instead.
+	/// </summary>
+	public static bool ShouldRegrantQuestItem<TQuest>(Player player, int itemType, int firstActiveStep, int lastActiveStep)
+		where TQuest : Quest
+	{
+		string questName = ModContent.GetInstance<TQuest>().FullName;
+
+		if (!player.GetModPlayer<QuestModPlayer>().QuestsByName.TryGetValue(questName, out Quest quest))
+		{
+			return false;
+		}
+
+		return quest.Active
+			&& quest.CurrentStep >= firstActiveStep
+			&& quest.CurrentStep <= lastActiveStep
+			&& !player.HasItem(itemType);
+	}
+
+	/// <summary> Spawns and syncs a quest item gift from <paramref name="npc"/>. </summary>
+	public static void GiftQuestItem(NPC npc, int itemType)
+	{
+		int item = Item.NewItem(new EntitySource_Gift(npc), npc.Hitbox, itemType, noGrabDelay: true);
+
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			NetMessage.SendData(MessageID.SyncItem, -1, -1, null, item);
+		}
+	}
 }

--- a/Common/Systems/Questing/Quest.cs
+++ b/Common/Systems/Questing/Quest.cs
@@ -182,6 +182,11 @@ public abstract class Quest : ModType, ILocalizedModType
 		}
 
 		state = State.InProgress;
+
+		for (int i = 0; i < QuestSteps.Count; i++)
+		{
+			QuestSteps[i].IsDone = i < CurrentStep;
+		}
 	}
 
 	public void Complete(Player player)

--- a/Content/NPCs/Town/BlacksmithNPC.cs
+++ b/Content/NPCs/Town/BlacksmithNPC.cs
@@ -5,12 +5,14 @@ using PathOfTerraria.Common.NPCs.Dialogue;
 using PathOfTerraria.Common.NPCs.Effects;
 using PathOfTerraria.Common.NPCs.OverheadDialogue;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.BossTrackingSystems;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Common.Utilities.Extensions;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Gear.Weapons.Battleaxe;
 using PathOfTerraria.Content.Items.Gear.Weapons.Sword;
 using PathOfTerraria.Content.Items.Placeable.Mapping;
@@ -154,6 +156,12 @@ public class BlacksmithNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOv
 		                         QuestUnlockManager.CanStartQuest<GolemQuest>();
 
 		button2 = hasAvailableQuest ? Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest") : "";
+
+		if (QuestUtils.ShouldRegrantQuestItem<GolemQuest>(Main.LocalPlayer, ModContent.ItemType<GolemMap>(), 3, 4))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<GolemMap>();
+		}
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)
@@ -163,7 +171,14 @@ public class BlacksmithNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOv
 			shopName = "Shop";
 			return;
 		}
-		
+
+		if (QuestUtils.ShouldRegrantQuestItem<GolemQuest>(Main.LocalPlayer, ModContent.ItemType<GolemMap>(), 3, 4))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<GolemMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetGolemMapAgain").Value;
+			return;
+		}
+
 		if (QuestUnlockManager.CanStartQuest<BlacksmithStartQuest>())
 		{
 			Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.BlacksmithNPC.Dialogue.Quest");

--- a/Content/NPCs/Town/FishermanNPC.cs
+++ b/Content/NPCs/Town/FishermanNPC.cs
@@ -4,10 +4,12 @@ using PathOfTerraria.Common.NPCs.Components;
 using PathOfTerraria.Common.NPCs.Dialogue;
 using PathOfTerraria.Common.NPCs.OverheadDialogue;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Common.Utilities.Extensions;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
@@ -87,9 +89,15 @@ public class FishermanNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpaw
 		button = Language.GetTextValue("LegacyInterface.28"); // Shop
 
 		bool hasAvailableQuest = QuestUnlockManager.CanStartQuest<FishronQuest>();
-		//                         QuestUnlockManager.CanStartQuest<TwinsQuest>() || 
+		//                         QuestUnlockManager.CanStartQuest<TwinsQuest>() ||
 
 		button2 = hasAvailableQuest ? Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest") : "";
+
+		if (QuestUtils.ShouldRegrantQuestItem<FishronQuest>(Main.LocalPlayer, ModContent.ItemType<FishronMap>(), 3, 4))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<FishronMap>();
+		}
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)
@@ -97,6 +105,13 @@ public class FishermanNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpaw
 		if (firstButton)
 		{
 			shopName = "Shop";
+			return;
+		}
+
+		if (QuestUtils.ShouldRegrantQuestItem<FishronQuest>(Main.LocalPlayer, ModContent.ItemType<FishronMap>(), 3, 4))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<FishronMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetFishronMapAgain").Value;
 			return;
 		}
 

--- a/Content/NPCs/Town/GarrickNPC.cs
+++ b/Content/NPCs/Town/GarrickNPC.cs
@@ -4,6 +4,7 @@ using PathOfTerraria.Common.NPCs.Components;
 using PathOfTerraria.Common.NPCs.Effects;
 using PathOfTerraria.Common.NPCs.OverheadDialogue;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
@@ -126,6 +127,11 @@ public sealed class GarrickNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, 
 			button2 = this.GetLocalization("AnotherMap").Value;
 			Main.npcChatCornerItem = ModContent.ItemType<KingSlimeMap>();
 		}
+		else if (QuestUtils.ShouldRegrantQuestItem<QueenSlimeQuest>(Main.LocalPlayer, ModContent.ItemType<QueenSlimeMap>(), 3, 4))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<QueenSlimeMap>();
+		}
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)
@@ -149,6 +155,13 @@ public sealed class GarrickNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, 
 				}
 
 				Main.npcChatText = this.GetLocalization("Dialogue.GetKingMapAgain").Value;
+				return;
+			}
+
+			if (QuestUtils.ShouldRegrantQuestItem<QueenSlimeQuest>(Main.LocalPlayer, ModContent.ItemType<QueenSlimeMap>(), 3, 4))
+			{
+				QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<QueenSlimeMap>());
+				Main.npcChatText = this.GetLocalization("Dialogue.GetQueenSlimeMapAgain").Value;
 				return;
 			}
 

--- a/Content/NPCs/Town/MorganaNPC.cs
+++ b/Content/NPCs/Town/MorganaNPC.cs
@@ -4,11 +4,13 @@ using PathOfTerraria.Common.NPCs.Components;
 using PathOfTerraria.Common.NPCs.Dialogue;
 using PathOfTerraria.Common.NPCs.Effects;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Common.Utilities.Extensions;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Gear.Weapons.Grimoire;
 using Terraria.DataStructures;
 using Terraria.GameContent;
@@ -93,6 +95,12 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 		                         QuestUnlockManager.CanStartQuest<QueenBeeQuest>();
 
 		button2 = hasAvailableQuest ? Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest") : "";
+
+		if (QuestUtils.ShouldRegrantQuestItem<PlanteraQuest>(Main.LocalPlayer, ModContent.ItemType<PlanteraMap>(), 2, 3))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<PlanteraMap>();
+		}
 	}
 
 	//TODO: This should probably be a base NPC functionality as many NPC's will have multiple quests. 
@@ -118,6 +126,13 @@ public class MorganaNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC
 		if (firstButton)
 		{
 			shopName = "Shop";
+			return;
+		}
+
+		if (QuestUtils.ShouldRegrantQuestItem<PlanteraQuest>(Main.LocalPlayer, ModContent.ItemType<PlanteraMap>(), 2, 3))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<PlanteraMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetPlanteraMapAgain").Value;
 			return;
 		}
 

--- a/Content/NPCs/Town/TinkerNPC.cs
+++ b/Content/NPCs/Town/TinkerNPC.cs
@@ -4,10 +4,12 @@ using PathOfTerraria.Common.NPCs.Components;
 using PathOfTerraria.Common.NPCs.Dialogue;
 using PathOfTerraria.Common.NPCs.OverheadDialogue;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Common.Utilities.Extensions;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
@@ -89,12 +91,28 @@ public class TinkerNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpawnIn
 	{
 		button = Language.GetTextValue("LegacyInterface.28"); // Shop
 
-		bool hasAvailableQuest = QuestUnlockManager.CanStartQuest<TinkerIntroQuest>() || 
-		                         QuestUnlockManager.CanStartQuest<TwinsQuest>() || 
-		                         QuestUnlockManager.CanStartQuest<DestroyerQuest>() || 
+		bool hasAvailableQuest = QuestUnlockManager.CanStartQuest<TinkerIntroQuest>() ||
+		                         QuestUnlockManager.CanStartQuest<TwinsQuest>() ||
+		                         QuestUnlockManager.CanStartQuest<DestroyerQuest>() ||
 		                         QuestUnlockManager.CanStartQuest<SkelePrimeQuest>();
 
 		button2 = hasAvailableQuest ? Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest") : "";
+
+		if (QuestUtils.ShouldRegrantQuestItem<TwinsQuest>(Main.LocalPlayer, ModContent.ItemType<TwinsMap>(), 5, 6))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<TwinsMap>();
+		}
+		else if (QuestUtils.ShouldRegrantQuestItem<DestroyerQuest>(Main.LocalPlayer, ModContent.ItemType<DestroyerMap>(), 3, 4))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<DestroyerMap>();
+		}
+		else if (QuestUtils.ShouldRegrantQuestItem<SkelePrimeQuest>(Main.LocalPlayer, ModContent.ItemType<PrimeMap>(), 2, 3))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<PrimeMap>();
+		}
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)
@@ -102,6 +120,27 @@ public class TinkerNPC : ModNPC, IQuestMarkerNPC, IOverheadDialogueNPC, ISpawnIn
 		if (firstButton)
 		{
 			shopName = "Shop";
+			return;
+		}
+
+		if (QuestUtils.ShouldRegrantQuestItem<TwinsQuest>(Main.LocalPlayer, ModContent.ItemType<TwinsMap>(), 5, 6))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<TwinsMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetTwinsMapAgain").Value;
+			return;
+		}
+
+		if (QuestUtils.ShouldRegrantQuestItem<DestroyerQuest>(Main.LocalPlayer, ModContent.ItemType<DestroyerMap>(), 3, 4))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<DestroyerMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetDestroyerMapAgain").Value;
+			return;
+		}
+
+		if (QuestUtils.ShouldRegrantQuestItem<SkelePrimeQuest>(Main.LocalPlayer, ModContent.ItemType<PrimeMap>(), 2, 3))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<PrimeMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetPrimeMapAgain").Value;
 			return;
 		}
 

--- a/Content/NPCs/Town/WizardNPC.cs
+++ b/Content/NPCs/Town/WizardNPC.cs
@@ -5,11 +5,13 @@ using PathOfTerraria.Common.NPCs.Dialogue;
 using PathOfTerraria.Common.NPCs.Effects;
 using PathOfTerraria.Common.NPCs.OverheadDialogue;
 using PathOfTerraria.Common.NPCs.QuestMarkers;
+using PathOfTerraria.Common.Quests;
 using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Common.Utilities.Extensions;
+using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Currency;
 using PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 using PathOfTerraria.Content.Items.Gear.Weapons.Wand;
@@ -158,11 +160,22 @@ public class WizardNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverhe
 	public override void SetChatButtons(ref string button, ref string button2)
 	{
 		button = Language.GetTextValue("LegacyInterface.28");
-		
+
 		bool hasAvailableQuest = QuestUnlockManager.CanStartQuest<WizardStartQuest>() ||
 		    QuestUnlockManager.CanStartQuest<EoLQuest>();
 
 		button2 = hasAvailableQuest ? Language.GetTextValue("Mods.PathOfTerraria.NPCs.Quest") : "";
+
+		if (QuestUtils.ShouldRegrantQuestItem<EoLQuest>(Main.LocalPlayer, ModContent.ItemType<EoLMap>(), 2, 3))
+		{
+			button2 = this.GetLocalization("AnotherMap").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<EoLMap>();
+		}
+		else if (QuestUtils.ShouldRegrantQuestItem<EoLQuest>(Main.LocalPlayer, ModContent.ItemType<CrystalVisors>(), 0, 3))
+		{
+			button2 = this.GetLocalization("AnotherCrystalVisors").Value;
+			Main.npcChatCornerItem = ModContent.ItemType<CrystalVisors>();
+		}
 	}
 
 	public override void OnChatButtonClicked(bool firstButton, ref string shopName)
@@ -172,7 +185,21 @@ public class WizardNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverhe
 			shopName = "Shop";
 			return;
 		}
-		
+
+		if (QuestUtils.ShouldRegrantQuestItem<EoLQuest>(Main.LocalPlayer, ModContent.ItemType<EoLMap>(), 2, 3))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<EoLMap>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetEoLMapAgain").Value;
+			return;
+		}
+
+		if (QuestUtils.ShouldRegrantQuestItem<EoLQuest>(Main.LocalPlayer, ModContent.ItemType<CrystalVisors>(), 0, 3))
+		{
+			QuestUtils.GiftQuestItem(NPC, ModContent.ItemType<CrystalVisors>());
+			Main.npcChatText = this.GetLocalization("Dialogue.GetCrystalVisorsAgain").Value;
+			return;
+		}
+
 		Quest quest = QuestUnlockManager.CanStartQuest<WizardStartQuest>() ? Quest.GetLocalPlayerInstance<WizardStartQuest>() : Quest.GetLocalPlayerInstance<EoLQuest>();
 
 		switch (quest)

--- a/Localization/de-DE/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		// Quest2: Fantastic! I'll fix the old forge up quick as I can. Here, take this sword. It's a practice forge I made right before the attack. I'd like for you to test it on some zombies; those buggers are awful to deal with. If you'd be so kind, I'd also enjoy some more materials. Then I think we can get the Iron Anvil truly back to her feet!
 		// Quest3: It almost brings a tear to the eye. The Iron Forge is almost ready for work! Here, this is a lesson I've got from my history in battle: Sometimes, you gotta go crazy. Just be careful! And come back whenever you wish - you've been a great help!
 		// OldManDialogue: Hello there, traveler!...what do you say? A man referred me to you? Hm...I recall a man, cloaked in red, come around here...some time ago. Can't tell you how long ago now, but a while. He came asking for some specific things...a book of evil, two candles, and a bar of evil. He said something about throwing evil powder on a book...but...that's all I can say. Not sure what the guy was on about.
+		// GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			// Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	// Entry: A jovial dwarf, Thrain enjoys hearty discussion, a nice drink, and making the best weapons you've ever seen. He can usually be found in his forge, making weapons.
+	// AnotherMap: Map
 	// DownedForest: After beating the Forest domain
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		// TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		// CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.
 		// GetKingMapAgain: Ah, couldn't manage it? Lost the map or something? Either way, here you are. You're lucky I carry cartography equipment everywhere...just in case.
+		// GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			// 0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			// 1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			// 2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		// GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		// GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
+	// AnotherMap: Map
+	// AnotherCrystalVisors: Crystal Visors
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -604,9 +612,12 @@ MorganaNPC: {
 			// 1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			// 2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		// GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	// Entry: Eccentric but decievingly powerful, Morgana offers a lot to Ravencrest. Sure, she may be nearly incomprehensible sometimes, and some might say offputting a lot of the time, but she's good at what she does. Huh? "What does she do?" Uh...
+	// AnotherMap: Map
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -908,6 +919,9 @@ TinkerNPC: {
 		// TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		// TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		// TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		// GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		// GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		// GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -931,6 +945,7 @@ TinkerNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 
@@ -946,6 +961,7 @@ FishermanNPC: {
 		// FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		// FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		// FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		// GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -969,6 +985,7 @@ FishermanNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 

--- a/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		Quest2: Fantastic! I'll fix the old forge up quick as I can. Here, take this sword. It's a practice forge I made right before the attack. I'd like for you to test it on some zombies; those buggers are awful to deal with. If you'd be so kind, I'd also enjoy some more materials. Then I think we can get the Iron Anvil truly back to her feet!
 		Quest3: It almost brings a tear to the eye. The Iron Forge is almost ready for work! Here, this is a lesson I've got from my history in battle: Sometimes, you gotta go crazy. Just be careful! And come back whenever you wish - you've been a great help!
 		OldManDialogue: Hello there, traveler!...what do you say? A man referred me to you? Hm...I recall a man, cloaked in red, come around here...some time ago. Can't tell you how long ago now, but a while. He came asking for some specific things...a book of evil, two candles, and a bar of evil. He said something about throwing evil powder on a book...but...that's all I can say. Not sure what the guy was on about.
+		GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	Entry: A jovial dwarf, Thrain enjoys hearty discussion, a nice drink, and making the best weapons you've ever seen. He can usually be found in his forge, making weapons.
+	AnotherMap: Map
 	DownedForest: After beating the Forest domain
 	Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.
 		GetKingMapAgain: Ah, couldn't manage it? Lost the map or something? Either way, here you are. You're lucky I carry cartography equipment everywhere...just in case.
+		GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
+	AnotherMap: Map
+	AnotherCrystalVisors: Crystal Visors
 	Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -604,9 +612,12 @@ MorganaNPC: {
 			1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	Entry: Eccentric but decievingly powerful, Morgana offers a lot to Ravencrest. Sure, she may be nearly incomprehensible sometimes, and some might say offputting a lot of the time, but she's good at what she does. Huh? "What does she do?" Uh...
+	AnotherMap: Map
 	Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -908,6 +919,9 @@ TinkerNPC: {
 		TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -931,6 +945,7 @@ TinkerNPC: {
 	}
 
 	Entry: Todo:
+	AnotherMap: Map
 	Census.SpawnCondition: Conditions unknown
 }
 
@@ -946,6 +961,7 @@ FishermanNPC: {
 		FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -969,6 +985,7 @@ FishermanNPC: {
 	}
 
 	Entry: Todo:
+	AnotherMap: Map
 	Census.SpawnCondition: Conditions unknown
 }
 

--- a/Localization/es-ES/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		// Quest2: Fantastic! I'll fix the old forge up quick as I can. Here, take this sword. It's a practice forge I made right before the attack. I'd like for you to test it on some zombies; those buggers are awful to deal with. If you'd be so kind, I'd also enjoy some more materials. Then I think we can get the Iron Anvil truly back to her feet!
 		// Quest3: It almost brings a tear to the eye. The Iron Forge is almost ready for work! Here, this is a lesson I've got from my history in battle: Sometimes, you gotta go crazy. Just be careful! And come back whenever you wish - you've been a great help!
 		// OldManDialogue: Hello there, traveler!...what do you say? A man referred me to you? Hm...I recall a man, cloaked in red, come around here...some time ago. Can't tell you how long ago now, but a while. He came asking for some specific things...a book of evil, two candles, and a bar of evil. He said something about throwing evil powder on a book...but...that's all I can say. Not sure what the guy was on about.
+		// GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			// Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	// Entry: A jovial dwarf, Thrain enjoys hearty discussion, a nice drink, and making the best weapons you've ever seen. He can usually be found in his forge, making weapons.
+	// AnotherMap: Map
 	// DownedForest: After beating the Forest domain
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		// TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		// CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.
 		// GetKingMapAgain: Ah, couldn't manage it? Lost the map or something? Either way, here you are. You're lucky I carry cartography equipment everywhere...just in case.
+		// GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			// 0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			// 1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			// 2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		// GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		// GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
+	// AnotherMap: Map
+	// AnotherCrystalVisors: Crystal Visors
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -604,9 +612,12 @@ MorganaNPC: {
 			// 1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			// 2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		// GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	// Entry: Eccentric but decievingly powerful, Morgana offers a lot to Ravencrest. Sure, she may be nearly incomprehensible sometimes, and some might say offputting a lot of the time, but she's good at what she does. Huh? "What does she do?" Uh...
+	// AnotherMap: Map
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -908,6 +919,9 @@ TinkerNPC: {
 		// TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		// TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		// TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		// GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		// GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		// GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -931,6 +945,7 @@ TinkerNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 
@@ -946,6 +961,7 @@ FishermanNPC: {
 		// FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		// FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		// FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		// GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -969,6 +985,7 @@ FishermanNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 

--- a/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		Quest2: Fantastique ! Je vais réparer l'ancienne forge aussi vite que possible. Tiens, prends cette épée. C'est un prototype que j'ai fabriqué juste avant l'attaque. J'aimerais que tu la testes sur quelques zombies ; ces saletés sont vraiment pénibles à combattre. Si tu veux bien, j'aimerais aussi avoir un peu plus de matériaux. Je pense qu'on pourra alors vraiment remettre l'enclume de fer sur pied !
 		Quest3: Cela me fait presque venir les larmes aux yeux. La forge de fer est presque prête à fonctionner ! Voici une leçon que j'ai tirée de mon expérience au combat : parfois, il faut savoir se lâcher. Mais soyez prudent ! Et revenez quand vous le souhaitez, vous m'avez été d'une grande aide !
 		OldManDialogue: Bonjour, voyageur !... Que dites-vous ? Un homme m'a parlé de vous ? Hum... Je me souviens d'un homme vêtu d'une cape rouge qui est venu ici... il y a quelque temps. Je ne sais plus exactement quand, mais ça fait un moment. Il est venu demander des choses bien précises... un livre maléfique, deux bougies et une barre maléfique. Il a parlé de jeter de la poudre maléfique sur un livre... mais... c'est tout ce que je peux dire. Je ne sais pas trop de quoi il parlait.
+		// GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			// Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	Entry: Thrain est un nain jovial qui aime les discussions animées, les bons verres et fabriquer les meilleures armes que vous ayez jamais vues. On le trouve généralement dans sa forge, en train de fabriquer des armes.
+	// AnotherMap: Map
 	// DownedForest: After beating the Forest domain
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		TradeLunarLiquid: Ah, je me suis entraîné pour ça. Mais attention, ce n'est pas une aventure à prendre à la légère.
 		CantTradeLiquid: Oh, tu as perdu le liquide ? Il me faudra quelques éclats lunaires pour le refaire, j'en ai bien peur. Reviens me voir avec au moins 5 éclats.
 		GetKingMapAgain: Ah, tu n'as pas réussi ? Tu as perdu la carte ou quoi ? Quoi qu'il en soit, tu es là. Tu as de la chance que j'emporte toujours mon matériel de cartographie avec moi... au cas où.
+		// GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			// 0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			// 1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			// 2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		// GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		// GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	Entry: Peut-être le sorcier le plus puissant de tous les temps, Alaric continue d'agir comme quelqu'un qui prétend être le sorcier le plus puissant de tous les temps. S'il est d'humeur capricieuse, il peut provoquer une véritable catastrophe instantanée.
+	// AnotherMap: Map
+	// AnotherCrystalVisors: Crystal Visors
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -604,9 +612,12 @@ MorganaNPC: {
 			// 1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			// 2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		// GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	Entry: Excentrique mais d'une puissance trompeuse, Morgana apporte beaucoup à Ravencrest. Certes, elle peut parfois être difficile à comprendre, et certains pourraient dire qu'elle est souvent rebutante, mais elle est douée dans ce qu'elle fait. Que fait-elle ?... Elle continue.
+	// AnotherMap: Map
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -908,6 +919,9 @@ TinkerNPC: {
 		// TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		// TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		// TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		// GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		// GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		// GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -931,6 +945,7 @@ TinkerNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 
@@ -946,6 +961,7 @@ FishermanNPC: {
 		// FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		// FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		// FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		// GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -969,6 +985,7 @@ FishermanNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 

--- a/Localization/pl-PL/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		// Quest2: Fantastic! I'll fix the old forge up quick as I can. Here, take this sword. It's a practice forge I made right before the attack. I'd like for you to test it on some zombies; those buggers are awful to deal with. If you'd be so kind, I'd also enjoy some more materials. Then I think we can get the Iron Anvil truly back to her feet!
 		// Quest3: It almost brings a tear to the eye. The Iron Forge is almost ready for work! Here, this is a lesson I've got from my history in battle: Sometimes, you gotta go crazy. Just be careful! And come back whenever you wish - you've been a great help!
 		// OldManDialogue: Hello there, traveler!...what do you say? A man referred me to you? Hm...I recall a man, cloaked in red, come around here...some time ago. Can't tell you how long ago now, but a while. He came asking for some specific things...a book of evil, two candles, and a bar of evil. He said something about throwing evil powder on a book...but...that's all I can say. Not sure what the guy was on about.
+		// GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			// Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	// Entry: A jovial dwarf, Thrain enjoys hearty discussion, a nice drink, and making the best weapons you've ever seen. He can usually be found in his forge, making weapons.
+	// AnotherMap: Map
 	// DownedForest: After beating the Forest domain
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		// TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		// CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.
 		// GetKingMapAgain: Ah, couldn't manage it? Lost the map or something? Either way, here you are. You're lucky I carry cartography equipment everywhere...just in case.
+		// GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			// 0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			// 1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			// 2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		// GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		// GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
+	// AnotherMap: Map
+	// AnotherCrystalVisors: Crystal Visors
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -604,9 +612,12 @@ MorganaNPC: {
 			// 1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			// 2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		// GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	// Entry: Eccentric but decievingly powerful, Morgana offers a lot to Ravencrest. Sure, she may be nearly incomprehensible sometimes, and some might say offputting a lot of the time, but she's good at what she does. Huh? "What does she do?" Uh...
+	// AnotherMap: Map
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -908,6 +919,9 @@ TinkerNPC: {
 		// TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		// TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		// TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		// GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		// GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		// GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -931,6 +945,7 @@ TinkerNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 
@@ -946,6 +961,7 @@ FishermanNPC: {
 		// FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		// FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		// FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		// GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -969,6 +985,7 @@ FishermanNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 

--- a/Localization/pt-BR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		// Quest2: Fantastic! I'll fix the old forge up quick as I can. Here, take this sword. It's a practice forge I made right before the attack. I'd like for you to test it on some zombies; those buggers are awful to deal with. If you'd be so kind, I'd also enjoy some more materials. Then I think we can get the Iron Anvil truly back to her feet!
 		// Quest3: It almost brings a tear to the eye. The Iron Forge is almost ready for work! Here, this is a lesson I've got from my history in battle: Sometimes, you gotta go crazy. Just be careful! And come back whenever you wish - you've been a great help!
 		// OldManDialogue: Hello there, traveler!...what do you say? A man referred me to you? Hm...I recall a man, cloaked in red, come around here...some time ago. Can't tell you how long ago now, but a while. He came asking for some specific things...a book of evil, two candles, and a bar of evil. He said something about throwing evil powder on a book...but...that's all I can say. Not sure what the guy was on about.
+		// GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			// Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	// Entry: A jovial dwarf, Thrain enjoys hearty discussion, a nice drink, and making the best weapons you've ever seen. He can usually be found in his forge, making weapons.
+	// AnotherMap: Map
 	// DownedForest: After beating the Forest domain
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		// TradeLunarLiquid: Ah, I've trained for this. Do care though, these aren't a casual adventure to make.
 		// CantTradeLiquid: Oh, lost the Liquid? I'll need a few Lunar Shards to remake it, I'm afraid. Return to me with 5 or more.
 		// GetKingMapAgain: Ah, couldn't manage it? Lost the map or something? Either way, here you are. You're lucky I carry cartography equipment everywhere...just in case.
+		// GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			// 0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			// 1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			// 2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		// GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		// GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
+	// AnotherMap: Map
+	// AnotherCrystalVisors: Crystal Visors
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -604,9 +612,12 @@ MorganaNPC: {
 			// 1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			// 2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		// GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	// Entry: Eccentric but decievingly powerful, Morgana offers a lot to Ravencrest. Sure, she may be nearly incomprehensible sometimes, and some might say offputting a lot of the time, but she's good at what she does. Huh? "What does she do?" Uh...
+	// AnotherMap: Map
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -908,6 +919,9 @@ TinkerNPC: {
 		// TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		// TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		// TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		// GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		// GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		// GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -931,6 +945,7 @@ TinkerNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 
@@ -946,6 +961,7 @@ FishermanNPC: {
 		// FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		// FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		// FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		// GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -969,6 +985,7 @@ FishermanNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 

--- a/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
@@ -13,6 +13,7 @@ BlacksmithNPC: {
 		Quest2: Отлично! Я быстро приведу старую кузницу в порядок. Вот, возьми этот меч. Выковал его прямо перед атакой — пробный вариант. Хочу, чтобы ты испытал его на зомби: с этими тварями возни больше всего. Если не затруднит, принеси ещё материалов. Тогда, думаю, мы сможем вернуть Железную Наковальню в строй!
 		Quest3: Ты почти пробил меня на слезу. Железная кузница почти готова к работе! Держи, вот тебе урок, который я вынес из своего боевого прошлого: иногда надо сойти с ума. Только будь осторожен! И возвращайся, когда захочешь - ты мне здорово помог!
 		OldManDialogue: Привет, путешественник!... что ты сказал? Кто-то направил тебя ко мне? Хм... я помню человека, закутанного в красное, он был здесь... некоторое время назад. Не могу сказать, сколько прошло времени, но довольно давно. Он просил кое-что конкретное... книгу зла, две свечи и слиток зла. Он говорил что-то о том, чтобы посыпать книгу порошком зла... но... это всё, что я могу сказать. Не уверен, о чём он говорил.
+		// GetGolemMapAgain: Lost the temple map, did you? No shame in it. Lihzahrd craft is strange, and these old notes are stranger still. Here, take another and give that beast a proper wallop.
 
 		Golem: {
 			// Intro: Ah! Grand adventurer. I've been looking for more smithwork, but with all these new events I've got my eye on something. There's a temple deep in the jungle that may have some interesting new metalsmithing...bricksmithing? I've yet to figure it out. It's guarded, so be wary!
@@ -49,6 +50,7 @@ BlacksmithNPC: {
 	}
 
 	Entry: Весёлый гном, Трейн любит весёлые беседы, хороший напиток и изготовление лучшего оружия, которое вы когда-либо видели. Обычно его можно найти в его кузне, изготавливающем оружие.
+	// AnotherMap: Map
 	// DownedForest: After beating the Forest domain
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Forge.
 }
@@ -161,6 +163,7 @@ GarrickNPC: {
 		TradeLunarLiquid: А, я тренировался для этого. Но будь осторожен, эти не для случайного приключения.
 		CantTradeLiquid: О, потерял Жидкость? Мне понадобится несколько Лунных Осколков, чтобы переделать её, боюсь. Вернись ко мне с 5 или более.
 		GetKingMapAgain: А, не справился? Потерял карту или что-то ещё? В любом случае, вот она. Тебе повезло, что я ношу картографическое оборудование везде... на случай, если что.
+		// GetQueenSlimeMapAgain: Another royal appointment, then? Take this map and mind your footing. Slime royalty has a way of making the ground itself disagree with you.
 
 		QueenSlime: {
 			// 0: Do you feel it, explorer? The land itself has shifted, and something unnatural radiates from the creatures in that new glowing area. I need you to gather this energy. Bring it back to me so we can understand what power we're truly dealing with.
@@ -232,6 +235,9 @@ WizardNPC: {
 			// 1: Curious crystals...yes. Their power rivals most - not mine - and belies a world most cannot see - NOT including myself. I see into all realms, [plrclass/l:l]. I simply choose not to act on it. Huzzah! Your curious map device should handle this parchment well.
 			// 2: Hmm...the Empress of Light, so you say? An old rival of mine. Not on my caliber, of course. She'd marvel at the explo- spells I can cast! Regardless, thank you. I almost though I'd have to...use my substantial and unending power for once. Not that I don't use it.
 		}
+
+		// GetEoLMapAgain: Misplaced the parchment? Worry not. I have conjured, copied, and quite possibly improved another. The Empress awaits, and so does my inevitable vindication.
+		// GetCrystalVisorsAgain: Ah, the visors have vanished? A minor inconvenience for a wizard of my magnitude. Wear these, and try not to lose sight of them again.
 	}
 
 	BubbleDialogue: {
@@ -261,6 +267,8 @@ WizardNPC: {
 	}
 
 	Entry: Возможно, самый могущественный волшебник всех времён, Аларик всё ещё ведёт себя так, будто притворяется самым могущественным волшебником всех времён. Если ему весело, он может вызвать настоящую и мгновенную катастрофу.
+	// AnotherMap: Map
+	// AnotherCrystalVisors: Crystal Visors
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 }
 
@@ -593,9 +601,12 @@ MorganaNPC: {
 			// 1: Hm, hm, hm. Yes! Such is Her growth, Her splendor. Thank you for the boons, [plrclass/l,1:l]! But - you must fight Her! Plantera has risen! I need to study the vicious plant, for it bears...peculiarities beyond reknown. Go, go!
 			// 2: What a treacherous boon, obtained by a strong adventurer! Oh, this'll serve us all well, I'm sure...thank you, kind fellow. I must...toil over my labors. Perhaps I can give you a boon in due time, in return. Yes! I shall, I shall!
 		}
+
+		// GetPlanteraMapAgain: The bloom still calls, yes? Then take another map and go, go! Plants regrow, paths twist, and experiments require persistence!
 	}
 
 	Entry: Соберите 2 пера совы и 1 пару крыльев летучей мыши.
+	// AnotherMap: Map
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Burrow.
 }
 
@@ -897,6 +908,9 @@ TinkerNPC: {
 		// TinkerSkeletronPrimeDialogue1: Adventurer, my instruments are once again spiking with a new signal, one even darker than before. It is radiating from the old dungeon, where Skeletron once kept his vigil. The signature is thick with both necrotic and mechanical energy. Whoever forged the Twins and the Destroyer has not stopped. They have rebuilt the dungeon's guardian itself into something far worse. I will need souls steeped in shadow, a good supply of bones, and any mechanical scraps from the dungeon you can find to finish my calibrations.
 		// TinkerSkeletronPrimeDialogue2: Yes, these materials are perfect! The readings are clear now. The creature waiting below is Skeletron Prime, a reconstruction of the cursed guardian, enhanced with gears, cannons, and blades. It is more machine than bone now. The teleporter is ready whenever you are, but be prepared. This will surely be your toughest battle yet.
 		// TinkerSkeletronPrimeDialogue3: Oh! The readings go silent. Well done, this means one of two things: my job is finished, or I have to make a new scanner...go! I've got to get to work on this new machine.
+		// GetTwinsMapAgain: Lost the Twins coordinates? No problem. I saved a backup, a backup of the backup, and one that may be slightly singed. Take this one.
+		// GetDestroyerMapAgain: The Destroyer's signal is hard to miss, but apparently maps are easier to lose. Here, I printed another route for you.
+		// GetPrimeMapAgain: Skeletron Prime is still broadcasting clear as day. Here is another calibrated map. Try not to let the dungeon keep this one.
 	}
 
 	BubbleDialogue: {
@@ -920,6 +934,7 @@ TinkerNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 
@@ -935,6 +950,7 @@ FishermanNPC: {
 		// FishermanFishronDialogue2: So you saw it, didn't you? That tear in the seabed... the Rift. Never thought I'd live to see the ocean split open like a wound. The water around it stinks of death, and the fish you caught seemed to react poorly when near it. Whatever waits inside that dark hollow, it's no natural beast. If my hunch is right, the Rift's calling for one thing... the reclusive Truffle Worm. Bring me one, adventurer, and we'll have our answer.
 		// FishermanFishronDialogue3: You've got the worm... by the tides... I don't envy you for holding that thing, it writhes like it knows where it's headed. The ocean's Rift is hungry, and this bait is the key. Cast it into the Rift's maw, and what stirs will come for you. Duke Fishron, the abyssal tyrant... he'll rise to defend his throne. Steel yourself, adventurer. This is no fishing trip. It's a reckoning.
 		// FishermanFishronDialogue4: You went in... and somehow lived to tell the tale. I can scarcely believe it. The Rift shook with fury when you fought him. I felt it from the shore. And then, silence. The Duke's reign is broken, if only for now. Still, the Rift remains... a scar at the ocean's floor, watching and waiting. You've proven stronger than this tide, adventurer, but never forget, the sea always takes back what it's owed.
+		// GetFishronMapAgain: The sea swallowed your route, did it? Happens more than sailors admit. Take another map, and keep it dry until the Rift takes you.
 	}
 
 	BubbleDialogue: {
@@ -958,6 +974,7 @@ FishermanNPC: {
 	}
 
 	// Entry: Todo:
+	// AnotherMap: Map
 	// Census.SpawnCondition: Conditions unknown
 }
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1886 

### Description of Work
* Adds in getting a new map or visors where needed when failing/missing.
* Adds some flavor text around each of the npcs as well for getting the new maps
* Fixes the quest debug menu not advancing current step correctly - which made testing weird

### Comments
* Maybe we should add a check, once per ravencrest visit or something to prevent getting a ton of them? Unsure
* Maybe even make them a quest map, and they are tagged differently than natty drop ones