### PR TITLE
feat: Adds passive zooming to the tree

### DIFF
--- a/Common/UI/AllocatableElement.cs
+++ b/Common/UI/AllocatableElement.cs
@@ -38,13 +38,32 @@ internal abstract class AllocatableElement : SmartUiElement, IConnectedAllocatab
 
 		Node = node;
 	}
+	
+	/// <summary> Walks up the parent chain and returns the zoom level of the enclosing <see cref="AllocatableInnerPanel"/>, or 1 if none is found. </summary>
+	protected float GetZoom()
+	{
+		UIElement current = Parent;
+		while (current is not null)
+		{
+			if (current is AllocatableInnerPanel panel)
+			{
+				return panel.Zoom;
+			}
+
+			current = current.Parent;
+		}
+
+		return 1f;
+	}
 
 	protected override void DrawSelf(SpriteBatch spriteBatch)
 	{
 		base.DrawSelf(spriteBatch);
 
-		DrawNode(Node, spriteBatch, GetDimensions().Center());
-		DrawOnto(spriteBatch, GetDimensions().Center());
+		float zoom = GetZoom();
+		Vector2 center = GetDimensions().Center();
+		DrawNode(Node, spriteBatch, center, zoom);
+		DrawOnto(spriteBatch, center);
 
 		if (_flashTimer > 0)
 		{
@@ -92,7 +111,7 @@ internal abstract class AllocatableElement : SmartUiElement, IConnectedAllocatab
 		}
 	}
 
-	public virtual void DrawNode(Allocatable node, SpriteBatch spriteBatch, Vector2 center)
+	public virtual void DrawNode(Allocatable node, SpriteBatch spriteBatch, Vector2 center, float scale = 1f)
 	{
 		Texture2D tex = node.Texture.Value;
 		Color color = Color.Gray;
@@ -108,11 +127,11 @@ internal abstract class AllocatableElement : SmartUiElement, IConnectedAllocatab
 		}
 
 		center = center.Floor();
-		spriteBatch.Draw(tex, center, null, color, 0, node.Size * 0.5f, 1, 0, 0);
-
+		spriteBatch.Draw(tex, center, null, color, 0, node.Size * 0.5f, scale, 0, 0);
+		
 		if (node.MaxLevel > 1)
 		{
-			Utils.DrawBorderString(spriteBatch, $"{node.Level}/{node.MaxLevel}", center + node.Size * 0.5f, color, 1, 0.5f, 0.5f);
+			Utils.DrawBorderString(spriteBatch, $"{node.Level}/{node.MaxLevel}", center + node.Size * 0.5f * scale, color, scale, 0.5f, 0.5f);
 		}
 	}
 

--- a/Common/UI/AllocatableInnerPanel.cs
+++ b/Common/UI/AllocatableInnerPanel.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using PathOfTerraria.Common.Mechanics;
+using PathOfTerraria.Common.Utilities;
 using PathOfTerraria.Core.UI.SmartUI;
 using ReLogic.Content;
+using Terraria.GameContent;
 using Terraria.UI;
 using Terraria.Utilities;
 
@@ -14,6 +16,24 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 
 	private readonly HashSet<UIElement> _draggable = [];
 
+	private readonly Dictionary<UIElement, (float OrigLeft, float OrigTop, float OrigWidth, float OrigHeight)> _origPositions = [];
+
+	private const float ZoomMin = 0.2f;
+	private const float ZoomMax = 2.25f;
+	private const float ZoomStep = 0.15f;
+
+	/// <summary> Whether this panel supports scroll-wheel zoom. Override in a subclass to enable. </summary>
+	protected virtual bool EnableZoom => false;
+
+	/// <summary> Target zoom level that the current zoom will interpolate towards. </summary>
+	public float TargetZoom { get; private set; } = 1f;
+
+	/// <summary> Current zoom level. 1 is the default; range is [<see cref="ZoomMin"/>, <see cref="ZoomMax"/>]. </summary>
+	public float Zoom { get; private set; } = 1f;
+	
+	/// <summary> Target drag center that interpolates along with zoom. </summary>
+	private Vector2 _targetDragCenter;
+	
 	protected Vector2 DragOffset;
 	protected Vector2 DragCenter;
 
@@ -30,17 +50,18 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 	{
 		Append(e);
 		_draggable.Add(e);
+		_origPositions[e] = (e.Left.Pixels, e.Top.Pixels, e.Width.Pixels, e.Height.Pixels);
 	}
 
 	protected override void DrawChildren(SpriteBatch spriteBatch)
 	{
 		// Drawing connections here means it gets clipped by OverflowHidden correctly
-		DrawEdgeConnections(spriteBatch, CollectionsMarshal.AsSpan(Connections));
-
+		DrawEdgeConnections(spriteBatch, CollectionsMarshal.AsSpan(Connections), Zoom);
+		
 		base.DrawChildren(spriteBatch);
 	}
 
-	public static void DrawEdgeConnections(SpriteBatch spriteBatch, ReadOnlySpan<Edge<IConnectedAllocatableNode>> connections)
+	public static void DrawEdgeConnections(SpriteBatch spriteBatch, ReadOnlySpan<Edge<IConnectedAllocatableNode>> connections, float scale = 1f)
 	{
 		Vector2 center = default;
 		Texture2D chainTex = _chainTex.Value;
@@ -77,10 +98,12 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 
 			if (!edge.Flags.HasFlag(EdgeFlags.EffectsOnly))
 			{
-				for (float k = 0; k <= 1; k += 1 / (Vector2.Distance(startPos, endPos) / 16))
+				// Step size keeps link count constant regardless of zoom; each link is drawn at the current scale.
+				float linkSize = 16 * scale;
+				for (float k = 0; k <= 1; k += 1 / (Vector2.Distance(startPos, endPos) / linkSize))
 				{
 					Vector2 pos = center + Vector2.Lerp(startPos, endPos, k);
-					spriteBatch.Draw(chainTex, pos, null, color, startPos.DirectionTo(endPos).ToRotation(), chainTex.Size() / 2, 1, 0, 0);
+					spriteBatch.Draw(chainTex, pos, null, color, startPos.DirectionTo(endPos).ToRotation(), chainTex.Size() / 2, scale, 0, 0);
 				}
 			}
 
@@ -97,12 +120,12 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 				{
 					float dist = Vector2.Distance(startPos, endPos);
 					float len = (40 + rand.Next(120)) * dist / 50;
-					float scale = 0.05f + rand.Next(10000) / 10000f * 0.15f;
-
+					float particleScale = 0.05f + rand.Next(10000) / 10000f * 0.15f;
+					
 					float progress = (Main.GameUpdateCount + 15 * k) % len / len;
 					Vector2 pos = center + Vector2.SmoothStep(startPos, endPos, progress);
-					float scale2 = (float)Math.Sin(progress * 3.14f) * (0.4f - scale);
-
+					float scale2 = (float)Math.Sin(progress * 3.14f) * (0.4f - particleScale) * scale;
+					
 					spriteBatch.Draw(glow, pos, null, glowColor * scale2, 0, glow.Size() / 2f, scale2, 0, 0);
 				}
 			}
@@ -116,10 +139,35 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 		Vector2 oldOffset = DragOffset;
 		DragOffset = Main.MouseScreen;
 
+		// Smoothly interpolate zoom and drag center towards targets
+		float oldZoom = Zoom;
+		Zoom = MathUtils.Damp(Zoom, TargetZoom, 0.02f, (float)gameTime.ElapsedGameTime.TotalSeconds);
+		DragCenter = MathUtils.Damp(DragCenter, _targetDragCenter, 0.02f, (float)gameTime.ElapsedGameTime.TotalSeconds);
+
+		// If zoom changed due to interpolation, update element positions
+		if (Math.Abs(Zoom - oldZoom) > 0.001f)
+		{
+			foreach (UIElement c in _draggable)
+			{
+				if (!_origPositions.TryGetValue(c, out var orig))
+				{
+					continue;
+				}
+
+				c.Left.Pixels = orig.OrigLeft * Zoom + DragCenter.X;
+				c.Top.Pixels = orig.OrigTop * Zoom + DragCenter.Y;
+				c.Width.Pixels = orig.OrigWidth * Zoom;
+				c.Height.Pixels = orig.OrigHeight * Zoom;
+			}
+
+			Recalculate();
+		}
+
 		if (ContainsPoint(Main.MouseScreen) && Main.mouseLeft) //Manually check mouse input because other elements shouldn't be allowed to interfere
 		{
 			Vector2 velocity = DragOffset - oldOffset;
 			DragCenter += velocity;
+			_targetDragCenter += velocity; // Keep target in sync when dragging
 
 			foreach (UIElement c in _draggable)
 			{
@@ -129,5 +177,83 @@ internal abstract class AllocatableInnerPanel : SmartUiElement
 
 			Recalculate();
 		}
+	}
+	
+	public override void SafeScrollWheel(UIScrollWheelEvent evt)
+	{
+		if (!EnableZoom || !ContainsPoint(Main.MouseScreen))
+		{
+			return;
+		}
+
+		float delta = evt.ScrollWheelValue > 0 ? ZoomStep : -ZoomStep;
+		float newTargetZoom = Math.Clamp(TargetZoom + delta, ZoomMin, ZoomMax);
+
+		if (newTargetZoom == TargetZoom)
+		{
+			return;
+		}
+
+		// Zoom toward the mouse cursor so the point under the cursor stays fixed.
+		CalculatedStyle dims = GetDimensions();
+		var panelCenter = new Vector2(dims.X + dims.Width * 0.5f, dims.Y + dims.Height * 0.5f);
+		Vector2 mouseRelCenter = Main.MouseScreen - panelCenter;
+
+		// Calculate the new target drag center based on zoom-to-mouse logic
+		float ratio = newTargetZoom / TargetZoom;
+		_targetDragCenter = mouseRelCenter * (1f - ratio) + _targetDragCenter * ratio;
+
+		TargetZoom = newTargetZoom;
+	}
+
+	protected override void DrawSelf(SpriteBatch spriteBatch)
+	{
+		base.DrawSelf(spriteBatch);
+		
+		// Draw zoom bar if zoom is enabled
+		if (EnableZoom)
+		{
+			DrawZoomBar(spriteBatch);
+		}
+	}
+
+	private void DrawZoomBar(SpriteBatch spriteBatch)
+	{
+		CalculatedStyle dims = GetDimensions();
+		
+		// Position in middle-right
+		const float barWidth = 12f;
+		const float barHeight = 120f;
+		const float margin = 20f;
+		
+		Vector2 barPos = new Vector2(dims.X + dims.Width - barWidth - margin, dims.Y + (dims.Height - barHeight) * 0.5f);
+		
+		// Background
+		var bgRect = new Rectangle((int)barPos.X, (int)barPos.Y, (int)barWidth, (int)barHeight);
+		spriteBatch.Draw(TextureAssets.MagicPixel.Value, bgRect, Color.Black * 0.6f);
+		
+		// Fill based on zoom level
+		float zoomProgress = (Zoom - ZoomMin) / (ZoomMax - ZoomMin);
+		float fillHeight = (barHeight - 2) * zoomProgress;
+		var fillRect = new Rectangle((int)barPos.X + 1, (int)(barPos.Y + barHeight - 1 - fillHeight), (int)barWidth - 2, (int)fillHeight);
+		Color fillColor = Color.Lerp(Color.Orange, Color.Cyan, zoomProgress);
+		spriteBatch.Draw(TextureAssets.MagicPixel.Value, fillRect, fillColor);
+		
+		var topBorder = new Rectangle((int)barPos.X, (int)barPos.Y, (int)barWidth, 1);
+		var bottomBorder = new Rectangle((int)barPos.X, (int)(barPos.Y + barHeight - 1), (int)barWidth, 1);
+		var leftBorder = new Rectangle((int)barPos.X, (int)barPos.Y, 1, (int)barHeight);
+		var rightBorder = new Rectangle((int)(barPos.X + barWidth - 1), (int)barPos.Y, 1, (int)barHeight);
+		
+		Color borderColor = Color.White * 0.8f;
+		spriteBatch.Draw(TextureAssets.MagicPixel.Value, topBorder, borderColor);
+		spriteBatch.Draw(TextureAssets.MagicPixel.Value, bottomBorder, borderColor);
+		spriteBatch.Draw(TextureAssets.MagicPixel.Value, leftBorder, borderColor);
+		spriteBatch.Draw(TextureAssets.MagicPixel.Value, rightBorder, borderColor);
+		
+		// Zoom percentage text (to the left of the bar)
+		string zoomText = $"{(int)(Zoom * 100)}%";
+		Vector2 textSize = FontAssets.MouseText.Value.MeasureString(zoomText) * 0.8f;
+		Vector2 textPos = barPos + new Vector2(-textSize.X - 8f, (barHeight - textSize.Y) * 0.5f);
+		Utils.DrawBorderString(spriteBatch, zoomText, textPos, Color.White, 0.8f);
 	}
 }

--- a/Common/UI/PassiveTree/MultiPassiveElement.cs
+++ b/Common/UI/PassiveTree/MultiPassiveElement.cs
@@ -14,6 +14,7 @@ internal class MultiPassiveElement : PassiveElement
 
 	private readonly Edge<IConnectedAllocatableNode>[] _extraEdges;
 
+	private AllocatableInnerPanel _parentPanel;
 	public int AnimationTime { get; set; }
 	public int AnimationTimeMax => 60;
 	public Passive[] InnerPassives { get; }
@@ -62,7 +63,16 @@ internal class MultiPassiveElement : PassiveElement
 			distance = MathF.Max(distance, center.DistanceSQ(target));
 		}
 
-		return distance + 120 * 120;
+		_parentPanel ??= Parent as AllocatableInnerPanel;
+		float zoom = _parentPanel?.Zoom ?? 1f;
+		return (distance + 120 * 120) * zoom * zoom;	
+	}
+
+	public override bool AppearsAsAllocated(Allocatable? nodeOverride = null)
+	{
+		// MasteryPassive.OnAllocate intentionally skips Level increment, so Node.Allocated is always false.
+		// Use the active inner choice as the authoritative "is this mastery allocated" signal instead.
+		return nodeOverride is not null ? base.AppearsAsAllocated(nodeOverride) : ActivePassive is not null;
 	}
 
 	protected override void DrawSelf(SpriteBatch spriteBatch)
@@ -71,7 +81,7 @@ internal class MultiPassiveElement : PassiveElement
 
 		if (ActivePassive is { } inner)
 		{
-			DrawNode(inner, spriteBatch, GetDimensions().Center());
+			DrawNode(inner, spriteBatch, GetDimensions().Center(), GetZoom());
 		}
 	}
 
@@ -81,7 +91,7 @@ internal class MultiPassiveElement : PassiveElement
 
 		if (Children.Any())
 		{
-			AllocatableInnerPanel.DrawEdgeConnections(spriteBatch, _extraEdges);
+			AllocatableInnerPanel.DrawEdgeConnections(spriteBatch, _extraEdges, GetZoom());
 		}
 
 		DrawChildren(spriteBatch);
@@ -153,7 +163,8 @@ internal class PassiveRadialElement : PassiveElement
 {
 	private readonly Vector2 _startOffset;
 	private readonly Vector2 _targetOffset;
-
+	private readonly Vector2 _origSize;
+	
 	public MultiPassiveElement? Handler => Parent is MultiPassiveElement e ? e : null;
 
 	private float Progress => Handler is { } handler ? (float)Handler.AnimationTime / Handler.AnimationTimeMax : 0f;
@@ -164,6 +175,7 @@ internal class PassiveRadialElement : PassiveElement
 
 		Debug.Assert(size.X > 1 && size.Y > 1);
 
+		_origSize = size.ToVector2();
 		_startOffset = startOffset;
 		_targetOffset = targetOffset;
 
@@ -176,6 +188,12 @@ internal class PassiveRadialElement : PassiveElement
 	public override void SafeUpdate(GameTime gameTime)
 	{
 		base.SafeUpdate(gameTime);
+		
+		float zoom = (Handler?.Parent as AllocatableInnerPanel)?.Zoom ?? 1f;
+
+		// Keep element bounds in sync with zoom so hit detection is accurate.
+		Width.Pixels = _origSize.X * zoom;
+		Height.Pixels = _origSize.Y * zoom;
 
 		static float EaseOutElastic(float x)
 		{
@@ -186,8 +204,8 @@ internal class PassiveRadialElement : PassiveElement
 
 		float animationProgress = Progress;
 		float lerpStep = EaseOutElastic(animationProgress);
-		var newPos = Vector2.Lerp(_startOffset, _targetOffset, lerpStep);
-
+		var newPos = Vector2.Lerp(_startOffset, _targetOffset * zoom, lerpStep);
+		
 		Left.Set(newPos.X - Width.Pixels * 0.5f, 0.5f);
 		Top.Set(newPos.Y - Height.Pixels * 0.5f, 0.5f);
 	}

--- a/Common/UI/PassiveTree/PassiveTreeInnerPanel.cs
+++ b/Common/UI/PassiveTree/PassiveTreeInnerPanel.cs
@@ -3,4 +3,6 @@
 internal class PassiveTreeInnerPanel : AllocatableInnerPanel
 {
 	public override string TabName => "PassiveTree";
+	
+	protected override bool EnableZoom => true;
 }

--- a/Common/UI/SkillsTree/SkillSpecialElement.cs
+++ b/Common/UI/SkillsTree/SkillSpecialElement.cs
@@ -11,7 +11,7 @@ internal class SkillSpecialElement : SkillElement
 		Special = node;
 	}
 
-	public override void DrawNode(Allocatable node, SpriteBatch spriteBatch, Vector2 center)
+	public override void DrawNode(Allocatable node, SpriteBatch spriteBatch, Vector2 center, float scale = 1f)
 	{
 		var special = (SkillSpecial)node;
 		Texture2D texture = node.Texture.Value;
@@ -27,18 +27,18 @@ internal class SkillSpecialElement : SkillElement
 			color = Color.White;
 		}
 
-		spriteBatch.Draw(texture, center, null, color, 0, texture.Size() / 2, 1, default, 0);
-
+		spriteBatch.Draw(texture, center, null, color, 0, texture.Size() / 2, scale, default, 0);
+		
 		if (special.Tree.Specialization == special)
 		{
 			float pulse = (float)Math.Sin(Main.timeForVisualEffects / 50f) * .25f + .5f;
 
 			Texture2D glow = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/GlowAlpha").Value;
 			var glowColor = new Color(255, 230, 150) { A = 0 };
-			spriteBatch.Draw(glow, center, null, glowColor * pulse, 0, glow.Size() / 2, 1, default, 0);
-
+			spriteBatch.Draw(glow, center, null, glowColor * pulse, 0, glow.Size() / 2, scale, default, 0);
+			
 			Texture2D outline = ModContent.Request<Texture2D>($"{PoTMod.ModName}/Assets/UI/SpecialFrame_Outline").Value;
-			spriteBatch.Draw(outline, center, null, Color.White * pulse, 0, outline.Size() / 2, 1, default, 0);
+			spriteBatch.Draw(outline, center, null, Color.White * pulse, 0, outline.Size() / 2, scale, default, 0);
 		}
 	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1802 

### Description of Work
fix: Highlighted lines now show from mastery to allocated nodes properly again.
feat: Adds the zoom feature to the passive tree with smooth interpolation.
feat: Adds a visual zoom bar to the passive tree on the middle right.

### Comments
Visual zoom bar could be done on our own, this is likely placeholder.