### PR TITLE
balance: summoner / ranger

### DIFF
--- a/Common/Data/Passives/Passives.json
+++ b/Common/Data/Passives/Passives.json
@@ -4953,7 +4953,7 @@
 		"internalIdentifier": "RagingSpiritsMastery",
 		"referenceId": 1002,
 		"maxLevel": 1,
-		"value": 5,
+		"value": 10,
 		"position": {
 			"x": 86,
 			"y": -1085
@@ -5683,7 +5683,7 @@
 		"internalIdentifier": "SymbioticPulseMastery",
 		"referenceId": 1052,
 		"maxLevel": 1,
-		"value": 3,
+		"value": 2,
 		"position": {
 			"x": -480,
 			"y": -1155
@@ -6257,7 +6257,7 @@
 		"internalIdentifier": "ExplosiveSlugsMastery",
 		"referenceId": 1091,
 		"maxLevel": 1,
-		"value": 30,
+		"value": 10,
 		"position": {
 			"x": 450,
 			"y": 1210
@@ -6269,7 +6269,7 @@
 		"internalIdentifier": "AdvantageShotMastery",
 		"referenceId": 1092,
 		"maxLevel": 1,
-		"value": 3,
+		"value": 2,
 		"position": {
 			"x": 490,
 			"y": 1067
@@ -6396,7 +6396,7 @@
 		"internalIdentifier": "FatBulletsMastery",
 		"referenceId": 1100,
 		"maxLevel": 1,
-		"value": 40,
+		"value": 30,
 		"position": {
 			"x": -432,
 			"y": 920

--- a/Content/Passives/Summon/Masteries/OverhealMastery.cs
+++ b/Content/Passives/Summon/Masteries/OverhealMastery.cs
@@ -6,6 +6,20 @@ namespace PathOfTerraria.Content.Passives.Summon.Masteries;
 
 internal class OverhealMastery : Passive
 {
+	internal class OverhealPlayer : ModPlayer
+	{
+		public int overhealCooldown = 0;
+		public const int OVERHEAL_COOLDOWN_DURATION = 12;
+
+		public override void PostUpdate()
+		{
+			if (overhealCooldown > 0)
+			{
+				overhealCooldown--;
+			}
+		}
+	}
+
 	public override void OnLoad()
 	{
 		On_Player.Heal += HealTime;
@@ -19,12 +33,22 @@ internal class OverhealMastery : Passive
 
 		if (oldLife + amount > self.statLifeMax2)
 		{
+			OverhealPlayer overhealPlayer = self.GetModPlayer<OverhealPlayer>();
+			
+			if (overhealPlayer.overhealCooldown > 0)
+			{
+				return;
+			}
+
 			int overheal = (oldLife + amount) - self.statLifeMax2;
 
 			if (!self.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<OverhealMastery>(out float value))
 			{
 				return;
 			}
+
+			// Set cooldown
+			overhealPlayer.overhealCooldown = OverhealPlayer.OVERHEAL_COOLDOWN_DURATION;
 
 			float damageBase = (overheal / (float)amount) * value / 100f;
 

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	// Name: Ranged/Melee Chance to Bleed
-	// Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	// Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	// Name: Increased Bleed Damage
-	// Tooltip: +{0}% bleed damage
+	// Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	// Name: Increased Bleed Time
-	// Tooltip: +{0}% bleed time
+	// Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	Name: Ranged/Melee Chance to Bleed
-	Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	Name: Increased Bleed Damage
-	Tooltip: +{0}% bleed damage
+	Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	Name: Increased Bleed Time
-	Tooltip: +{0}% bleed time
+	Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	// Name: Ranged/Melee Chance to Bleed
-	// Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	// Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	// Name: Increased Bleed Damage
-	// Tooltip: +{0}% bleed damage
+	// Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	// Name: Increased Bleed Time
-	// Tooltip: +{0}% bleed time
+	// Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	// Name: Ranged/Melee Chance to Bleed
-	// Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	// Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	// Name: Increased Bleed Damage
-	// Tooltip: +{0}% bleed damage
+	// Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	// Name: Increased Bleed Time
-	// Tooltip: +{0}% bleed time
+	// Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	// Name: Ranged/Melee Chance to Bleed
-	// Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	// Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	// Name: Increased Bleed Damage
-	// Tooltip: +{0}% bleed damage
+	// Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	// Name: Increased Bleed Time
-	// Tooltip: +{0}% bleed time
+	// Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	// Name: Ranged/Melee Chance to Bleed
-	// Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	// Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	// Name: Increased Bleed Damage
-	// Tooltip: +{0}% bleed damage
+	// Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	// Name: Increased Bleed Time
-	// Tooltip: +{0}% bleed time
+	// Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -986,17 +986,17 @@ WideSwingsMastery: {
 
 RangerMeleeChanceToBleedPassive: {
 	// Name: Ranged/Melee Chance to Bleed
-	// Tooltip: +{0}% chance for ranged or melee hits to inflict Bleeding
+	// Tooltip: +{0}% chance for ranged or melee hits to apply Bleed
 }
 
 BleedEffectivenessPassive: {
 	// Name: Increased Bleed Damage
-	// Tooltip: +{0}% bleed damage
+	// Tooltip: +{0}% increased bleed damage
 }
 
 BleedTimePassive: {
 	// Name: Increased Bleed Time
-	// Tooltip: +{0}% bleed time
+	// Tooltip: +{0}% increased bleed duration
 }
 
 BleedTickPassive: {


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
balance: adds an 0.2 second cd to overheal mastery
balance: Reduced Explosive Slugs damage from 30% to 10%. The intent is for this to be a solid AOE mastery but not ALWAYS optimal on single target as it was previously.
balance: Reduced time standing still to trigger Advantage Shot mastery
balance: Reduced fat bullet multiplier to 30% to be more in line with other masteries damage bonuses.
balance: Changed Raging Spirits mastery to be a 10% chance from 5%
balance: Symbiotic summons drop an orb every 2 seconds down from 3 seconds
misc: small localization changes

### Comments
