### PR TITLE
Fixing Critdamage displaying 0% in Stat-screen

### DIFF
--- a/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
@@ -172,7 +172,7 @@ internal class PlayerStatInnerPanel : SmartUiElement
 		{
 			UniversalBuffingPlayer buffingPlayer = player.GetModPlayer<UniversalBuffingPlayer>();
 			float critMultiplier = (1+ buffingPlayer.UniversalModifier.CriticalDamage.Base) * buffingPlayer.UniversalModifier.CriticalMultiplier.Multiplicative * 100f;
-			return $"{critMultiplier:0.00}%";
+			return $"{critMultiplier:#0.##}%";
 		}));
 		list.Add(new PlayerStatUI(Localize("ProjectileSpeed"), player => 
 		{

--- a/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
@@ -171,8 +171,8 @@ internal class PlayerStatInnerPanel : SmartUiElement
 		list.Add(new PlayerStatUI(Localize("CriticalMultiplier"), player =>
 		{
 			UniversalBuffingPlayer buffingPlayer = player.GetModPlayer<UniversalBuffingPlayer>();
-			float critMultiplier = buffingPlayer.UniversalModifier.CriticalMultiplier.Base;
-			return $"{critMultiplier:#0.##}%";
+			float critMultiplier = (1+ buffingPlayer.UniversalModifier.CriticalDamage.Base) * buffingPlayer.UniversalModifier.CriticalMultiplier.Multiplicative * 100f;
+			return $"{critMultiplier:0.00}%";
 		}));
 		list.Add(new PlayerStatUI(Localize("ProjectileSpeed"), player => 
 		{


### PR DESCRIPTION
The old function tried to access the "Base" of CriticalMultiplier, which after a Debug, results in 0. 
0 * anything is 0.

Also Critical Damage and Critical Multiplier is saved in 2 different structs at the moment. Is that how its supposed to?

