### PR TITLE
fix:SummonInteractions

### DIFF
--- a/Common/Data/Passives/Passives.json
+++ b/Common/Data/Passives/Passives.json
@@ -6057,7 +6057,7 @@
 		"internalIdentifier": "ShatteredBondMastery",
 		"referenceId": 1078,
 		"maxLevel": 1,
-		"value": 300,
+		"value": 200,
 		"position": {
 			"x": -610,
 			"y": -890

--- a/Content/Passives/Melee/Masteries/BloodbenderMastery.cs
+++ b/Content/Passives/Melee/Masteries/BloodbenderMastery.cs
@@ -7,12 +7,23 @@ internal class BloodbenderMastery : Passive
 {
 	internal class BloodbenderPlayer : ModPlayer
 	{
+		private int healCooldown = 0;
+		
+		public override void PostUpdate()
+		{
+			if (healCooldown > 0)
+			{
+				healCooldown--;
+			}
+		}
+
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (hit.Crit && Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<BloodbenderMastery>(out float value) 
-				&& target.TryGetGlobalNPC(out BleedDebuffNPC bleed) && bleed.Stacks is { Length: > 0 and int length })
+			if (hit.Crit && healCooldown <= 0 && Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<BloodbenderMastery>(out float value) 
+			    && target.TryGetGlobalNPC(out BleedDebuffNPC bleed) && bleed.Stacks is { Length: > 0 and int length })
 			{
 				Player.Heal((int)(damageDone * value / 100f * length / Player.GetModPlayer<BleedPlayer>().MaxBleedStacks));
+				healCooldown = 18;
 			}
 		}
 	}

--- a/Content/Passives/Summon/Masteries/RagingSpiritsMastery.cs
+++ b/Content/Passives/Summon/Masteries/RagingSpiritsMastery.cs
@@ -1,20 +1,22 @@
 ﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Content.Projectiles.PassiveProjectiles;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Content.Passives.Summon.Masteries;
 
 internal class RagingSpiritsMastery : Passive
 {
-	internal class RagingSpiritsPlayer : ModPlayer
+	internal class RagingSpiritsProjectile : GlobalProjectile
 	{
-		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
+		public override void OnHitNPC(Projectile projectile, NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (hit.DamageType.CountsAsClass(DamageClass.Summon) && Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<RagingSpiritsMastery>(out float value)
-				&& Main.rand.NextFloat() < value / 100f)
+			if (projectile.minion && projectile.TryGetOwner(out Player owner) &&
+			    owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<RagingSpiritsMastery>(out float value) &&
+			    Main.rand.NextFloat() < value / 100f)
 			{
-				IEntitySource src = Player.GetSource_OnHit(target);
-				Projectile.NewProjectile(src, target.Center, new Vector2(0, -14), ModContent.ProjectileType<RagingSpirit>(), damageDone, 0, Player.whoAmI);
+				IEntitySource src = owner.GetSource_OnHit(target);
+				Projectile.NewProjectile(src, target.Center, new Vector2(0, -14), ModContent.ProjectileType<RagingSpirit>(), damageDone / 2, 0, owner.whoAmI);
 			}
 		}
 	}

--- a/Content/Passives/Summon/Masteries/ShatteredBondMastery.cs
+++ b/Content/Passives/Summon/Masteries/ShatteredBondMastery.cs
@@ -17,7 +17,7 @@ internal class ShatteredBondMastery : Passive
 		{
 			if (projectile.TryGetOwner(out Player plr) && plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ShatteredBondMastery>(out float value))
 			{
-				ExplosionHitbox.QuickSpawn(projectile.GetSource_Death(), projectile, projectile.damage * 3, plr.whoAmI, new Vector2(240, 240), ExplosionSpawnInfo.PlayerOwned(plr.whoAmI));
+				ExplosionHitbox.QuickSpawn(projectile.GetSource_Death(), projectile, projectile.damage * 2, plr.whoAmI, new Vector2(240, 240), ExplosionSpawnInfo.PlayerOwned(plr.whoAmI));
 			}
 		}
 	}

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	// Name: Raging Spirits
-	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	Name: Raging Spirits
-	Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	// Name: Raging Spirits
-	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	// Name: Raging Spirits
-	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	// Name: Raging Spirits
-	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	// Name: Raging Spirits
-	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -756,7 +756,7 @@ SoulReaveMastery: {
 
 RagingSpiritsMastery: {
 	// Name: Raging Spirits
-	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon
+	// Tooltip: Minions have a {0}% chance to spawn a Raging Spirit, which counts as a summon. This cannot critically strike.
 }
 
 ChaoticReverberationMastery: {


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Raging Spirits can not only proc on MINION damage, not SUMMON damage. This will prevent recursive loops.
- Raging spirits damage nerfed to 50% from 100% of hit.
- Bloodbender now has a short internal CD.
- Shattered Bond reduced from 300% to 200% explosion damage


### Comments
