### PR TITLE
fix: bloodbender again

### DIFF
--- a/Common/Data/Passives/Passives.json
+++ b/Common/Data/Passives/Passives.json
@@ -6664,7 +6664,7 @@
 		"internalIdentifier": "BloodbenderMastery",
 		"referenceId": 1118,
 		"maxLevel": 1,
-		"value": 10,
+		"value": 2,
 		"position": {
 			"x": -1180,
 			"y": -600

--- a/Content/Passives/Melee/Masteries/BloodbenderMastery.cs
+++ b/Content/Passives/Melee/Masteries/BloodbenderMastery.cs
@@ -22,8 +22,8 @@ internal class BloodbenderMastery : Passive
 			if (hit.Crit && healCooldown <= 0 && Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<BloodbenderMastery>(out float value) 
 			    && target.TryGetGlobalNPC(out BleedDebuffNPC bleed) && bleed.Stacks is { Length: > 0 and int length })
 			{
-				Player.Heal((int)(damageDone * value / 100f * length / Player.GetModPlayer<BleedPlayer>().MaxBleedStacks));
-				healCooldown = 18;
+				Player.Heal((int)(damageDone * value / 100f * length));
+				healCooldown = 30;
 			}
 		}
 	}


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
- Fixes bloodbender scaling via max bleed stacks
- Bloodbender damage scaling changed from 10% to 2% to account for this.
- Bloodbender internal cooldown is now 0.5 seconds.


### Comments
