### PR TITLE
Fixing Lethal Overdose Tooltip

### DIFF
--- a/Content/Passives/Ranged/Masteries/LethalDoseMastery.cs
+++ b/Content/Passives/Ranged/Masteries/LethalDoseMastery.cs
@@ -27,5 +27,5 @@ internal class LethalDoseMastery : Passive
 	
 	const float MaxDamageBoost = 40;
 
-	public override string DisplayTooltip => Language.GetText($"Mods.PathOfTerraria.Passives.{Name}.Tooltip").Format(Value, 30);
+	public override string DisplayTooltip => Language.GetText($"Mods.PathOfTerraria.Passives.{Name}.Tooltip").Format(Value, MaxDamageBoost);
 }


### PR DESCRIPTION
It was a hardcoded 30, now it takes the "MaxDamageBoost" variable, so that it stays consistent.
