### PR TITLE
feat: experience rework

### DIFF
--- a/Common/Data/Mobs/PathOfTerraria/Abominable.json
+++ b/Common/Data/Mobs/PathOfTerraria/Abominable.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 2500
-			},
 			"affixes": [
 				{
 					"name": "ColdAffix"

--- a/Common/Data/Mobs/PathOfTerraria/AntlionTrapper.json
+++ b/Common/Data/Mobs/PathOfTerraria/AntlionTrapper.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Antlion Trapper",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 35
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/AshWraith.json
+++ b/Common/Data/Mobs/PathOfTerraria/AshWraith.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Ash Wraith",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 35
-			},
-			"affixes": null,
-			"requirements": "Underworld"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/CanopyBird.json
+++ b/Common/Data/Mobs/PathOfTerraria/CanopyBird.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Canopy Crow",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 120
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/ClumsyEntling.json
+++ b/Common/Data/Mobs/PathOfTerraria/ClumsyEntling.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Entling",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 20
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/CryoStalker.json
+++ b/Common/Data/Mobs/PathOfTerraria/CryoStalker.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1500
-			},
 			"affixes": [
 				{
 					"name": "ColdAffix"

--- a/Common/Data/Mobs/PathOfTerraria/DragonFly.json
+++ b/Common/Data/Mobs/PathOfTerraria/DragonFly.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Dragonfollow",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1000
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/Ent.json
+++ b/Common/Data/Mobs/PathOfTerraria/Ent.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Ent",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 90
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/Entling.json
+++ b/Common/Data/Mobs/PathOfTerraria/Entling.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Entling",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 20
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/EntlingAlt.json
+++ b/Common/Data/Mobs/PathOfTerraria/EntlingAlt.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Entling",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 20
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/FallenSavage.json
+++ b/Common/Data/Mobs/PathOfTerraria/FallenSavage.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1000
-			},
 			"affixes": [
 				{
 					"name": "FlamingAffix"

--- a/Common/Data/Mobs/PathOfTerraria/FallenSchemer.json
+++ b/Common/Data/Mobs/PathOfTerraria/FallenSchemer.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1100
-			},
 			"affixes": [
 				{
 					"name": "FlamingAffix"

--- a/Common/Data/Mobs/PathOfTerraria/FallenShaman.json
+++ b/Common/Data/Mobs/PathOfTerraria/FallenShaman.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 2500
-			},
 			"affixes": [
 				{
 					"name": "FlamingAffix"

--- a/Common/Data/Mobs/PathOfTerraria/FallenTyrant.json
+++ b/Common/Data/Mobs/PathOfTerraria/FallenTyrant.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1500
-			},
 			"affixes": [
 				{
 					"name": "FlamingAffix"

--- a/Common/Data/Mobs/PathOfTerraria/FireMaw.json
+++ b/Common/Data/Mobs/PathOfTerraria/FireMaw.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Fire Maw",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 25
-			},
-			"affixes": null,
-			"requirements": "Underworld"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/GiantEel.json
+++ b/Common/Data/Mobs/PathOfTerraria/GiantEel.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Mammoth Moss-Eel",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1000000
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/GreaterFairy.json
+++ b/Common/Data/Mobs/PathOfTerraria/GreaterFairy.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Greater Fairy",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 500
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/Grovetender.json
+++ b/Common/Data/Mobs/PathOfTerraria/Grovetender.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Elder Grovekeeper",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1500
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/HauntedHead.json
+++ b/Common/Data/Mobs/PathOfTerraria/HauntedHead.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Haunted Head",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 35
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/InfernalBoss.json
+++ b/Common/Data/Mobs/PathOfTerraria/InfernalBoss.json
@@ -14,10 +14,6 @@
 					}
 				}
 			],
-			"stats": {
-				"level": 1,
-				"experience": 10000
-			},
 			"requirements": null
 		}
 	]

--- a/Common/Data/Mobs/PathOfTerraria/Minitera.json
+++ b/Common/Data/Mobs/PathOfTerraria/Minitera.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Budding Plantera",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 3000
-			},
-			"affixes": null,
-			"requirements": "Jungle"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/Mudsquit.json
+++ b/Common/Data/Mobs/PathOfTerraria/Mudsquit.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Mudsquit",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 500
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/Prismatism.json
+++ b/Common/Data/Mobs/PathOfTerraria/Prismatism.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Greater Fairy",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 600
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/ScarabSwarmController.json
+++ b/Common/Data/Mobs/PathOfTerraria/ScarabSwarmController.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Swarm Scarab",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 120
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/Shambling.json
+++ b/Common/Data/Mobs/PathOfTerraria/Shambling.json
@@ -5,10 +5,6 @@
 			"scale": null,
 			"prefix": null,
 			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 750
-			},
 			"affixes": [
 				{
 					"name": "ColdAffix"

--- a/Common/Data/Mobs/PathOfTerraria/SwampCroc.json
+++ b/Common/Data/Mobs/PathOfTerraria/SwampCroc.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Crocolog",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 1500
-			},
-			"affixes": null,
-			"requirements": "Surface"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/SwarmScarab.json
+++ b/Common/Data/Mobs/PathOfTerraria/SwarmScarab.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Swarm Scarab",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 120
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/PathOfTerraria/WormLightning.json
+++ b/Common/Data/Mobs/PathOfTerraria/WormLightning.json
@@ -1,16 +1,4 @@
 {
 	"friendlyName": "Antlion Trapper",
-	"entries": [
-		{
-			"scale": null,
-			"prefix": null,
-			"weight": 1,
-			"stats": {
-				"level": 1,
-				"experience": 35
-			},
-			"affixes": null,
-			"requirements": "Desert"
-		}
-	]
+	"entries": []
 }

--- a/Common/Data/Mobs/Vanilla/AngryBones.json
+++ b/Common/Data/Mobs/Vanilla/AngryBones.json
@@ -1,17 +1,5 @@
 {
   "netId": 31,
   "friendlyName": "Angry Bones",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": "",
-      "weight": 1,
-      "stats": {
-        "level": 9,
-        "experience": 14
-      },
-      "affixes": [],
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/AnomuraFungus.json
+++ b/Common/Data/Mobs/Vanilla/AnomuraFungus.json
@@ -1,17 +1,5 @@
 {
   "netId": 257,
   "friendlyName": "Anomura Fungus",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": "",
-      "weight": 1,
-      "stats": {
-        "level": 7,
-        "experience": 12
-      },
-      "affixes": [],
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Antlion.json
+++ b/Common/Data/Mobs/Vanilla/Antlion.json
@@ -1,17 +1,5 @@
 {
   "netId": 69,
   "friendlyName": "Antlion",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": "",
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 5
-      },
-      "affixes": [],
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ArmedZombie.json
+++ b/Common/Data/Mobs/Vanilla/ArmedZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 430,
   "friendlyName": "Armed Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BabySlime.json
+++ b/Common/Data/Mobs/Vanilla/BabySlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -5,
   "friendlyName": "Baby Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BaldZombie.json
+++ b/Common/Data/Mobs/Vanilla/BaldZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 132,
   "friendlyName": "Bald Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BigBaldZombie.json
+++ b/Common/Data/Mobs/Vanilla/BigBaldZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -29,
   "friendlyName": "Big Bald Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BigFemaleZombie.json
+++ b/Common/Data/Mobs/Vanilla/BigFemaleZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -45,
   "friendlyName": "Big Female Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BigSlimedZombie.json
+++ b/Common/Data/Mobs/Vanilla/BigSlimedZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -33,
   "friendlyName": "Big Slimed Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 4,
-        "experience": 4
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BigSwampZombie.json
+++ b/Common/Data/Mobs/Vanilla/BigSwampZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -35,
   "friendlyName": "Big Swamp Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BigTwiggyZombie.json
+++ b/Common/Data/Mobs/Vanilla/BigTwiggyZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -37,
   "friendlyName": "Big Twiggy Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BigZombie.json
+++ b/Common/Data/Mobs/Vanilla/BigZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -27,
   "friendlyName": "Big Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BlackSlime.json
+++ b/Common/Data/Mobs/Vanilla/BlackSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -6,
   "friendlyName": "Black Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 4
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BloodZombie.json
+++ b/Common/Data/Mobs/Vanilla/BloodZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 489,
   "friendlyName": "Blood Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 7,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/BlueSlime.json
+++ b/Common/Data/Mobs/Vanilla/BlueSlime.json
@@ -2,25 +2,10 @@
   "netId": 1,
   "friendlyName": "Blue Slime",
   "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 5,
-      "stats": {
-        "level": 1,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    },
   {
     "scale": 2,
     "prefix": "Bulky",
     "weight": 0.75,
-    "stats": {
-      "level": 3,
-      "experience": 5
-    },
     "affixes": [
       {
         "name": "DoubleLife"
@@ -32,10 +17,6 @@
     "scale": null,
     "prefix": "Electric",
     "weight": 0.75,
-    "stats": {
-      "level": 3,
-      "experience": 5
-    },
     "affixes": null,
     "requirements": "PreHardmodeSurface",
     "damageOverrides": [

--- a/Common/Data/Mobs/Vanilla/BunnySlimed.json
+++ b/Common/Data/Mobs/Vanilla/BunnySlimed.json
@@ -1,17 +1,5 @@
 {
   "netId": 303,
   "friendlyName": "Bunny Slimed",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/CorruptSlime.json
+++ b/Common/Data/Mobs/Vanilla/CorruptSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 81,
   "friendlyName": "Corrupt Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 10,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Crimslime.json
+++ b/Common/Data/Mobs/Vanilla/Crimslime.json
@@ -1,17 +1,5 @@
 {
   "netId": 183,
   "friendlyName": "Crimslime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 10,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/DemonEye.json
+++ b/Common/Data/Mobs/Vanilla/DemonEye.json
@@ -1,17 +1,5 @@
 {
   "netId": 2,
   "friendlyName": "Demon Eye",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/DemonEye2.json
+++ b/Common/Data/Mobs/Vanilla/DemonEye2.json
@@ -1,17 +1,5 @@
 {
   "netId": -43,
   "friendlyName": "Demon Eye2",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/DoctorBones.json
+++ b/Common/Data/Mobs/Vanilla/DoctorBones.json
@@ -1,17 +1,5 @@
 {
   "netId": 52,
   "friendlyName": "Doctor Bones",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 15,
-        "experience": 20
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/DungeonSlime.json
+++ b/Common/Data/Mobs/Vanilla/DungeonSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 71,
   "friendlyName": "Dungeon Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 15,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Eyezor.json
+++ b/Common/Data/Mobs/Vanilla/Eyezor.json
@@ -1,17 +1,5 @@
 {
   "netId": 251,
   "friendlyName": "Eyezor",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 25,
-        "experience": 15
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/FemaleZombie.json
+++ b/Common/Data/Mobs/Vanilla/FemaleZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 200,
   "friendlyName": "Female Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Gastropod.json
+++ b/Common/Data/Mobs/Vanilla/Gastropod.json
@@ -1,17 +1,5 @@
 {
   "netId": 122,
   "friendlyName": "Gastropod",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 10,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/GoldenSlime.json
+++ b/Common/Data/Mobs/Vanilla/GoldenSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 667,
   "friendlyName": "Golden Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 20
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/GreenSlime.json
+++ b/Common/Data/Mobs/Vanilla/GreenSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -3,
   "friendlyName": "Green Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Hellbat.json
+++ b/Common/Data/Mobs/Vanilla/Hellbat.json
@@ -21,10 +21,6 @@
   {
     "weight": 0.75,
     "prefix": "Electric",
-    "stats": {
-      "level": 3,
-      "experience": 5
-    },
     "damageOverrides": [
       {
         "minLevel": 1,

--- a/Common/Data/Mobs/Vanilla/IceSlime.json
+++ b/Common/Data/Mobs/Vanilla/IceSlime.json
@@ -22,10 +22,6 @@
       "scale": null,
       "prefix": null,
       "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
       "affixes": null,
       "requirements": "PreHardmodeSurface",
       "damageOverrides": [

--- a/Common/Data/Mobs/Vanilla/IlluminantSlime.json
+++ b/Common/Data/Mobs/Vanilla/IlluminantSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 138,
   "friendlyName": "Illuminant Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 10,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/JungleSlime.json
+++ b/Common/Data/Mobs/Vanilla/JungleSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -10,
   "friendlyName": "Jungle Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 4,
-        "experience": 4
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/KingSlime.json
+++ b/Common/Data/Mobs/Vanilla/KingSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 50,
   "friendlyName": "King Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 20,
-        "experience": 150
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/LavaSlime.json
+++ b/Common/Data/Mobs/Vanilla/LavaSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 59,
   "friendlyName": "Lava Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/MaggotZombie.json
+++ b/Common/Data/Mobs/Vanilla/MaggotZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 632,
   "friendlyName": "Maggot Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/MotherSlime.json
+++ b/Common/Data/Mobs/Vanilla/MotherSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 16,
   "friendlyName": "Mother Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/PincushionZombie.json
+++ b/Common/Data/Mobs/Vanilla/PincushionZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 186,
   "friendlyName": "Pincushion Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Pinky.json
+++ b/Common/Data/Mobs/Vanilla/Pinky.json
@@ -1,17 +1,5 @@
 {
   "netId": -4,
   "friendlyName": "Pinky",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 25
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/PurpleSlime.json
+++ b/Common/Data/Mobs/Vanilla/PurpleSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -7,
   "friendlyName": "Purple Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/RainbowSlime.json
+++ b/Common/Data/Mobs/Vanilla/RainbowSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 244,
   "friendlyName": "Rainbow Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 25,
-        "experience": 50
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/RedSlime.json
+++ b/Common/Data/Mobs/Vanilla/RedSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -8,
   "friendlyName": "Red Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SandSlime.json
+++ b/Common/Data/Mobs/Vanilla/SandSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 537,
   "friendlyName": "Sand Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Shimmerfly.json
+++ b/Common/Data/Mobs/Vanilla/Shimmerfly.json
@@ -1,17 +1,5 @@
 {
   "netId": 677,
   "friendlyName": "Shimmerfly",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SlimeSpiked.json
+++ b/Common/Data/Mobs/Vanilla/SlimeSpiked.json
@@ -1,17 +1,5 @@
 {
   "netId": 535,
   "friendlyName": "Slime Spiked",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 15,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Slimeling.json
+++ b/Common/Data/Mobs/Vanilla/Slimeling.json
@@ -1,17 +1,5 @@
 {
   "netId": -1,
   "friendlyName": "Slimeling",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Slimer.json
+++ b/Common/Data/Mobs/Vanilla/Slimer.json
@@ -1,17 +1,5 @@
 {
   "netId": 121,
   "friendlyName": "Slimer",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 10,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Slimer2.json
+++ b/Common/Data/Mobs/Vanilla/Slimer2.json
@@ -1,17 +1,5 @@
 {
   "netId": -2,
   "friendlyName": "Slimer2",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 10,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallBaldZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallBaldZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -28,
   "friendlyName": "Small Bald Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallFemaleZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallFemaleZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -44,
   "friendlyName": "Small Female Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallPincushionZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallPincushionZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -30,
   "friendlyName": "Small Pincushion Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallSlimedZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallSlimedZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -32,
   "friendlyName": "Small Slimed Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallSwampZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallSwampZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -34,
   "friendlyName": "Small Swamp Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallTwiggyZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallTwiggyZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -36,
   "friendlyName": "Small Twiggy Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 4,
-        "experience": 4
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SmallZombie.json
+++ b/Common/Data/Mobs/Vanilla/SmallZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": -26,
   "friendlyName": "Small Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SpikedIceSlime.json
+++ b/Common/Data/Mobs/Vanilla/SpikedIceSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 184,
   "friendlyName": "Spiked Ice Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SpikedJungleSlime.json
+++ b/Common/Data/Mobs/Vanilla/SpikedJungleSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 204,
   "friendlyName": "Spiked Jungle Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 5
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/SwampZombie.json
+++ b/Common/Data/Mobs/Vanilla/SwampZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 188,
   "friendlyName": "Swamp Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/TheBride.json
+++ b/Common/Data/Mobs/Vanilla/TheBride.json
@@ -1,17 +1,5 @@
 {
   "netId": 536,
   "friendlyName": "The Bride",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/TheGroom.json
+++ b/Common/Data/Mobs/Vanilla/TheGroom.json
@@ -1,17 +1,5 @@
 {
   "netId": 53,
   "friendlyName": "The Groom",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/TorchZombie.json
+++ b/Common/Data/Mobs/Vanilla/TorchZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 590,
   "friendlyName": "Torch Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ToxicSludge.json
+++ b/Common/Data/Mobs/Vanilla/ToxicSludge.json
@@ -1,17 +1,5 @@
 {
   "netId": 141,
   "friendlyName": "Toxic Sludge",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 8,
-        "experience": 10
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/TwiggyZombie.json
+++ b/Common/Data/Mobs/Vanilla/TwiggyZombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 189,
   "friendlyName": "Twiggy Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 4,
-        "experience": 4
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/UmbrellaSlime.json
+++ b/Common/Data/Mobs/Vanilla/UmbrellaSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": 225,
   "friendlyName": "Umbrella Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/WalkingAntlion.json
+++ b/Common/Data/Mobs/Vanilla/WalkingAntlion.json
@@ -1,17 +1,5 @@
 {
   "netId": 580,
   "friendlyName": "Walking Antlion",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": "",
-      "weight": 1,
-      "stats": {
-        "level": 5,
-        "experience": 7
-      },
-      "affixes": [],
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/WindyBalloon.json
+++ b/Common/Data/Mobs/Vanilla/WindyBalloon.json
@@ -1,17 +1,5 @@
 {
   "netId": 594,
   "friendlyName": "Windy Balloon",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 0
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/YellowSlime.json
+++ b/Common/Data/Mobs/Vanilla/YellowSlime.json
@@ -1,17 +1,5 @@
 {
   "netId": -9,
   "friendlyName": "Yellow Slime",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/Zombie.json
+++ b/Common/Data/Mobs/Vanilla/Zombie.json
@@ -1,17 +1,5 @@
 {
   "netId": 3,
   "friendlyName": "Zombie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 1
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ZombieDoctor.json
+++ b/Common/Data/Mobs/Vanilla/ZombieDoctor.json
@@ -1,17 +1,5 @@
 {
   "netId": 319,
   "friendlyName": "Zombie Doctor",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ZombiePixie.json
+++ b/Common/Data/Mobs/Vanilla/ZombiePixie.json
@@ -1,17 +1,5 @@
 {
   "netId": 321,
   "friendlyName": "Zombie Pixie",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ZombieRaincoat.json
+++ b/Common/Data/Mobs/Vanilla/ZombieRaincoat.json
@@ -1,17 +1,5 @@
 {
   "netId": 223,
   "friendlyName": "Zombie Raincoat",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 1,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ZombieSuperman.json
+++ b/Common/Data/Mobs/Vanilla/ZombieSuperman.json
@@ -1,17 +1,5 @@
 {
   "netId": 320,
   "friendlyName": "Zombie Superman",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 2,
-        "experience": 2
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ZombieSweater.json
+++ b/Common/Data/Mobs/Vanilla/ZombieSweater.json
@@ -1,17 +1,5 @@
 {
   "netId": 332,
   "friendlyName": "Zombie Sweater",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Mobs/Vanilla/ZombieXmas.json
+++ b/Common/Data/Mobs/Vanilla/ZombieXmas.json
@@ -1,17 +1,5 @@
 {
   "netId": 331,
   "friendlyName": "Zombie Xmas",
-  "entries": [
-    {
-      "scale": null,
-      "prefix": null,
-      "weight": 1,
-      "stats": {
-        "level": 3,
-        "experience": 3
-      },
-      "affixes": null,
-      "requirements": "PreHardmodeSurface"
-    }
-  ]
+  "entries": []
 }

--- a/Common/Data/Models/MobData.cs
+++ b/Common/Data/Models/MobData.cs
@@ -14,7 +14,6 @@ public class MobEntry
 	public float? Scale { get; set; }
 	public string Prefix { get; set; }
 	public decimal Weight { get; set; }
-	public MobStats Stats { get; set; }
 	public List<MobDamage> DamageOverrides { get; set; }
 	public List<MobEntryAffix> Affixes { get; set; }
 	public string Requirements { get; set; }
@@ -23,12 +22,6 @@ public class MobEntry
 public class MobEntryAffix
 {
 	public string Name { get; set; }
-}
-
-public class MobStats
-{
-	public int Level { get; set; }
-	public int Experience { get; set; }
 }
 
 public class MobDamage

--- a/Common/Subworlds/MappingNPC.cs
+++ b/Common/Subworlds/MappingNPC.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+using PathOfTerraria.Common.Systems.MobSystem;
 using PathOfTerraria.Common.Systems.Synchronization;
 using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
@@ -15,6 +16,9 @@ internal class MappingNPC : GlobalNPC
 {
 	public override void SetDefaults(NPC entity)
 	{
+		// Capture before our scaling below, in case this hook runs before ArpgNPC.SetDefaults.
+		entity.GetGlobalNPC<ArpgNPC>().CaptureBaseLifeMax(entity);
+
 		if (SubworldSystem.Current is MappingWorld && MappingWorld.Affixes is not null)
 		{
 			foreach (MapAffix affix in MappingWorld.Affixes)

--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -32,7 +32,8 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 
 	public override bool InstancePerEntity => true;
 
-	public int? Experience;
+	/// <summary>Snapshot of lifeMax before rarity/map/area scaling, used for HP-scaled XP. -1 = not captured.</summary>
+	public int BaseLifeMax = -1;
 	public ItemRarity Rarity = ItemRarity.Normal;
 	public List<MobAffix> Affixes = [];
 
@@ -117,6 +118,15 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 	{
 		float progress = MathHelper.Clamp((areaLevel - 1f) / 84f, 0f, 1f);
 		return MathHelper.Lerp(0.2f, 0.15f, progress);
+	}
+
+	// First caller wins so later SetDefaults modifiers (rarity, map affixes, area scaling) don't pollute the snapshot.
+	internal void CaptureBaseLifeMax(NPC npc)
+	{
+		if (BaseLifeMax < 0)
+		{
+			BaseLifeMax = npc.lifeMax;
+		}
 	}
 
 	public override void OnKill(NPC npc)
@@ -223,6 +233,8 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		{
 			return;
 		}
+
+		CaptureBaseLifeMax(npc);
 
 		// We only want to trigger these changes on hostile non-boss, mortal & damageable non-critter NPCs that aren't in NoAffixesSet
 		if (npc.IsABestiaryIconDummy || npc.friendly || npc.boss || Main.gameMenu || npc.immortal || npc.dontTakeDamage || NPCID.Sets.ProjectileNPC[npc.type]
@@ -360,8 +372,6 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 
 	private void ApplyMobEntry(NPC npc, MobEntry entry)
 	{
-		Experience = entry.Stats.Experience;
-
 		if (!string.IsNullOrEmpty(entry.Prefix))
 		{
 			npc.GivenName = $"{Language.GetTextValue($"Mods.{PoTMod.ModName}.EnemyPrefixes." + entry.Prefix)} {npc.GivenOrTypeName}";

--- a/Common/Systems/MobSystem/MobExperienceGlobalNPC.cs
+++ b/Common/Systems/MobSystem/MobExperienceGlobalNPC.cs
@@ -25,23 +25,17 @@ public class MobExperienceGlobalNPC : GlobalNPC
 		{
 			return;
 		}
-		
-#if DEBUG
-		if (npcSystem.Experience == null)
-		{
-			Main.NewText($"No experience entry for {npc.TypeName} - {npc.netID}");
-		}
-#endif
-		
-		int amount = npcSystem.Experience ?? (int)Math.Max(1, npc.lifeMax * 0.25f);
 
-		amount = npcSystem.Rarity
-			switch //We will need to evaluate this as magic/rare natively get more HP. So we do even want this? Was just POC, maybe just change amount evaluation?
-			{
-				ItemRarity.Rare => (int)(amount * 1.1f), //Rare mobs give 10% increase xp
-				ItemRarity.Magic => (int)(amount * 1.05f), //Magic mobs give 5% increase xp
-				_ => amount
-			};
+		// Use base HP so affix HP buffs don't inflate XP; fall back if SetDefaults was bypassed.
+		int baseLife = npcSystem.BaseLifeMax >= 0 ? npcSystem.BaseLifeMax : npc.lifeMax;
+		int amount = (int)Math.Max(1, baseLife * 0.25f);
+
+		amount = npcSystem.Rarity switch
+		{
+			ItemRarity.Rare => (int)(amount * 1.1f), //Rare mobs give 10% increase xp
+			ItemRarity.Magic => (int)(amount * 1.05f), //Magic mobs give 5% increase xp
+			_ => amount
+		};
 
 		if (SubworldSystem.Current is MappingWorld world)
 		{


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work

- Monster experience is now always based on a monster's base health pool rather than hand-tuned per-enemy values. Tougher enemies naturally reward more XP.
- HP buffs from map affixes or mob affixes (e.g. a monster rolling as Rare or Magic) no longer inflate XP beyond the rarity bonus — the XP comes from what the monster started with, not what it ended up with after scaling.
- Rare monsters still grant +10% XP and Magic monsters +5% XP.
- Map modifiers continue to boost XP as before.

### Comments
- Requirements did nothing. So it was removed from these entries