### PR TITLE
feat: add support for chaos damage in mob data

### DIFF
--- a/Common/Data/Models/MobData.cs
+++ b/Common/Data/Models/MobData.cs
@@ -38,6 +38,7 @@ public class MobDamage
 	public MobElementStats Fire { get; set; }
 	public MobElementStats Cold { get; set; }
 	public MobElementStats Lightning { get; set; }
+	public MobElementStats Chaos { get; set; }
 }
 
 public class MobElementStats

--- a/Common/Systems/ElementalDamage/ElementalNPC.cs
+++ b/Common/Systems/ElementalDamage/ElementalNPC.cs
@@ -62,6 +62,12 @@ internal class ElementalNPC : GlobalNPC
 						damageModifier = damageModifier.ApplyOverride(mobDamage.Lightning.Added, mobDamage.Lightning.Conversion);
 					}
 
+					if (mobDamage.Chaos != null)
+					{
+						ref ElementalDamage damageModifier = ref Container[ElementType.Chaos].DamageModifier;
+						damageModifier = damageModifier.ApplyOverride(mobDamage.Chaos.Added, mobDamage.Chaos.Conversion);
+					}
+
 					break;
 				}
 			}


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
* Adds developer support for added and converted chaos damage in mob data

### Comments
