### PR TITLE
Adding function for Additive Projectiles

### DIFF
--- a/Common/Utilities/AdditiveScalingModifier.cs
+++ b/Common/Utilities/AdditiveScalingModifier.cs
@@ -1,0 +1,56 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace PathOfTerraria.Common.Utilities;
+
+
+public static class AdditiveScalingModifier
+{
+	public static void ApplyAdditiveLikeScalingProjectile(Player player, Projectile projectile,  ref NPC.HitModifiers modifiers, float bonus)
+	{
+		if (player == null || projectile == null)
+			return;
+
+		// --- Get all additives from player ---
+		float additive = player.GetDamage(DamageClass.Generic).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Melee))
+			additive += player.GetDamage(DamageClass.Melee).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Ranged))
+			additive += player.GetDamage(DamageClass.Ranged).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Magic))
+			additive += player.GetDamage(DamageClass.Magic).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Summon))
+			additive += player.GetDamage(DamageClass.Summon).Additive -1;
+		
+		 // --- Calculated the modifier based on existing class bonuses .
+		 modifiers.SourceDamage += bonus / (1 + additive) ;
+	}
+	
+	public static void ApplyAdditiveLikeScalingItem(Player player, Item item,  ref NPC.HitModifiers modifiers, float bonus)
+	{
+		if (player == null || item == null)
+			return;
+
+		// --- Get all additives from player ---
+		float additive = player.GetDamage(DamageClass.Generic).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Melee))
+			additive += player.GetDamage(DamageClass.Melee).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Ranged))
+			additive += player.GetDamage(DamageClass.Ranged).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Magic))
+			additive += player.GetDamage(DamageClass.Magic).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Summon))
+			additive += player.GetDamage(DamageClass.Summon).Additive -1;
+		
+		// --- Calculated the modifier based on existing class bonuses .
+		modifiers.SourceDamage += bonus / (1 + additive) ;
+	}
+}

--- a/Content/Passives/Magic/Masteries/DeepPoolsMastery.cs
+++ b/Content/Passives/Magic/Masteries/DeepPoolsMastery.cs
@@ -10,7 +10,7 @@ internal class DeepPoolsMastery : Passive
 		{
 			if (Player.GetModPlayer<PassiveTreePlayer>().HasNode<DeepPoolsMastery>())
 			{
-				Player.GetDamage(DamageClass.Magic) += Player.statManaMax2 / 2500f;
+				Player.GetDamage(DamageClass.Generic) += Player.statManaMax2 / 2500f;
 			}
 		}
 	}

--- a/Content/Passives/Ranged/Masteries/LethalDoseMastery.cs
+++ b/Content/Passives/Ranged/Masteries/LethalDoseMastery.cs
@@ -1,8 +1,9 @@
 ﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.Utilities;
 using PathOfTerraria.Content.Buffs.ElementalBuffs;
 using Terraria.Localization;
 
-namespace PathOfTerraria.Content.Passives;
+namespace PathOfTerraria.Content.Passives.Ranged.Masteries;
 
 internal class LethalDoseMastery : Passive
 {
@@ -12,7 +13,7 @@ internal class LethalDoseMastery : Passive
 		{
 			if (player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<LethalDoseMastery>(out float value))
 			{
-				modifiers.FinalDamage += MathF.Min(npc.GetGlobalNPC<PoisonNPC>().Stacks.Length * value / 100f, MaxDamageBoost / 100f);
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingItem(player, item, ref modifiers, MathF.Min(npc.GetGlobalNPC<PoisonNPC>().Stacks.Length * value / 100f, MaxDamageBoost / 100f));
 			}
 		}
 
@@ -20,7 +21,8 @@ internal class LethalDoseMastery : Passive
 		{
 			if (projectile.TryGetOwner(out Player player) && projectile.friendly && player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<LethalDoseMastery>(out float value))
 			{
-				modifiers.FinalDamage += MathF.Min(npc.GetGlobalNPC<PoisonNPC>().Stacks.Length * value / 100f, MaxDamageBoost / 100f);
+				Player projOwner = Main.player[projectile.owner];
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, MathF.Min(npc.GetGlobalNPC<PoisonNPC>().Stacks.Length * value / 100f, MaxDamageBoost / 100f));
 			}
 		}
 	}

--- a/Content/Passives/Ranged/Masteries/SniperMastery.cs
+++ b/Content/Passives/Ranged/Masteries/SniperMastery.cs
@@ -8,6 +8,8 @@ internal class SniperMastery : Passive
 	{
 		public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers)
 		{
+			if (!Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<SniperMastery>(out float value))
+				return;
 			if (target.DistanceSQ(Player.Center) > PoTMod.NearbyDistanceSq && modifiers.DamageType.CountsAsClass(DamageClass.Ranged))
 			{
 				modifiers.SourceDamage *= Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<SniperMastery>() / 100f;

--- a/Content/Passives/Ranged/Masteries/SniperMastery.cs
+++ b/Content/Passives/Ranged/Masteries/SniperMastery.cs
@@ -10,7 +10,7 @@ internal class SniperMastery : Passive
 		{
 			if (target.DistanceSQ(Player.Center) > PoTMod.NearbyDistanceSq && modifiers.DamageType.CountsAsClass(DamageClass.Ranged))
 			{
-				modifiers.FinalDamage += Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<SniperMastery>() / 100f;
+				modifiers.SourceDamage *= Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<SniperMastery>() / 100f;
 			}
 		}
 	}

--- a/Content/Passives/Ranged/SmallPassives/LongRangePassive.cs
+++ b/Content/Passives/Ranged/SmallPassives/LongRangePassive.cs
@@ -1,4 +1,5 @@
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.Utilities;
 
 namespace PathOfTerraria.Content.Passives;
 
@@ -6,13 +7,16 @@ internal class LongRangePassive : Passive
 {
 	internal class LongRangeGlobalNPC : GlobalNPC
 	{
+		// Enables projectile outside of "DistanceSQ" to deal increased damage
 		public override void ModifyHitByProjectile(NPC npc, Projectile projectile, ref NPC.HitModifiers modifiers)
 		{
 			if (projectile.TryGetOwner(out Player plr) && projectile.DistanceSQ(npc.Center) < PoTMod.NearbyDistanceSq
 				&& plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<LongRangePassive>(out float value))
 			{
-				modifiers.FinalDamage += value / 100f;
+				Player projOwner = Main.player[projectile.owner];
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, value / 100f);
 			}
 		}
+		
 	}
 }

--- a/Content/Passives/Ranged/SmallPassives/StillDamagePassive.cs
+++ b/Content/Passives/Ranged/SmallPassives/StillDamagePassive.cs
@@ -1,4 +1,5 @@
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.Utilities;
 
 namespace PathOfTerraria.Content.Passives;
 
@@ -6,12 +7,23 @@ internal class StillDamagePassive : Passive
 {
 	internal class StillPlayer : GlobalNPC
 	{
+		// Allows Projectiles that hit as you stand still to do the 10% damage
 		public override void ModifyHitByProjectile(NPC npc, Projectile projectile, ref NPC.HitModifiers modifiers)
 		{
 			if (projectile.TryGetOwner(out Player plr) && plr.velocity.LengthSquared() < 0.1f
 				&& plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<StillDamagePassive>(out float value))
 			{
-				modifiers.FinalDamage += value / 100f;
+				Player projOwner = Main.player[projectile.owner];
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, value / 100f);
+			}
+			
+		}
+		// Allows standing still with a Melee weapon - this was previously not an option 
+		public override void ModifyHitByItem(NPC npc, Player player, Item item, ref NPC.HitModifiers modifiers)
+		{
+			if (player.velocity.LengthSquared() < 0.1f && player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<StillDamagePassive>(out float value))
+			{
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingItem(player, item, ref modifiers, value / 100f);
 			}
 		}
 	}

--- a/Content/Passives/Summon/SmallPassives/IncreasedMinionDamagePassive.cs
+++ b/Content/Passives/Summon/SmallPassives/IncreasedMinionDamagePassive.cs
@@ -1,4 +1,5 @@
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.Utilities;
 
 namespace PathOfTerraria.Content.Passives;
 
@@ -6,13 +7,14 @@ internal class IncreasedMinionDamagePassive : Passive
 {
 	public sealed class IncreasedMinionDamagePassivePlayer : ModPlayer
 	{
-		public override void ModifyHitNPCWithProj(Projectile proj, NPC target, ref NPC.HitModifiers modifiers)
+		public override void ModifyHitNPCWithProj(Projectile projectile, NPC target, ref NPC.HitModifiers modifiers)
 		{
-			float level = Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<IncreasedMinionDamagePassive>();
+			float value = Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<IncreasedMinionDamagePassive>();
 
-			if (proj.minion)
+			if (projectile.minion)
 			{
-				modifiers.FinalDamage += level / 100f;
+				Player projOwner = Main.player[projectile.owner];
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, value / 100f);
 			}
 		}
 	}

--- a/Content/Passives/Summon/SmallPassives/IncreasedSentryDamagePassive.cs
+++ b/Content/Passives/Summon/SmallPassives/IncreasedSentryDamagePassive.cs
@@ -1,4 +1,5 @@
 using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.Utilities;
 using Terraria.ID;
 
 namespace PathOfTerraria.Content.Passives;
@@ -7,13 +8,14 @@ internal class IncreasedSentryDamagePassive : Passive
 {
 	public sealed class IncreasedSentryDamagePassivePlayer : ModPlayer
 	{
-		public override void ModifyHitNPCWithProj(Projectile proj, NPC target, ref NPC.HitModifiers modifiers)
+		public override void ModifyHitNPCWithProj(Projectile projectile, NPC target, ref NPC.HitModifiers modifiers)
 		{
-			float level = Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<IncreasedSentryDamagePassive>();
+			float value = Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<IncreasedSentryDamagePassive>();
 
-			if (proj.sentry || ProjectileID.Sets.SentryShot[proj.type])
+			if (projectile.sentry || ProjectileID.Sets.SentryShot[projectile.type])
 			{
-				modifiers.FinalDamage += level / 100.0f;
+				Player projOwner = Main.player[projectile.owner];
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, value / 100f);
 			}
 		}
 	}


### PR DESCRIPTION
Create a Function which allows someone to plug in **player, projectile, NPC Hitmodifier** and the desired **bonus damage** and it automatically calculated the expected damage increase that needs to be added to Sourcedamage in order to not be multiplicative.

- Applied this function on currently Multiplicatively scaling Masteries that are supposed to be additive.
  -> Lethal Dosage
  -> Increased Damage to Distant Enemies
  -> Increased Damage while Stationary
  -> Increased Minion Damage
  -> Increased Sentry Damage
  
- Made Sniper to be actually multiplicative with this new function. 

- Fixed Deep Pools reading all damage, but only increasing Magic Damage
- Made Increased Damage while Stationary work with Melee