### PR TITLE
Fat Bullet Fix + Adding the additive scaling

### DIFF
--- a/Common/Utilities/AdditiveScalingModifier.cs
+++ b/Common/Utilities/AdditiveScalingModifier.cs
@@ -11,7 +11,7 @@ public static class AdditiveScalingModifier
 		if (player == null || projectile == null)
 			return;
 
-		// --- Get all additives from player based on type of damage of the projectile ---
+		// --- Get all additives from player ---
 		float additive = player.GetDamage(DamageClass.Generic).Additive -1;
 
 		if (projectile.DamageType.CountsAsClass(DamageClass.Melee))
@@ -35,7 +35,7 @@ public static class AdditiveScalingModifier
 		if (player == null || item == null)
 			return;
 
-		// --- Get all additives from player based on type of damage of the hit ---
+		// --- Get all additives from player ---
 		float additive = player.GetDamage(DamageClass.Generic).Additive -1;
 
 		if (item.DamageType.CountsAsClass(DamageClass.Melee))

--- a/Common/Utilities/AdditiveScalingModifier.cs
+++ b/Common/Utilities/AdditiveScalingModifier.cs
@@ -1,0 +1,56 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace PathOfTerraria.Common.Utilities;
+
+
+public static class AdditiveScalingModifier
+{
+	public static void ApplyAdditiveLikeScalingProjectile(Player player, Projectile projectile,  ref NPC.HitModifiers modifiers, float bonus)
+	{
+		if (player == null || projectile == null)
+			return;
+
+		// --- Get all additives from player based on type of damage of the projectile ---
+		float additive = player.GetDamage(DamageClass.Generic).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Melee))
+			additive += player.GetDamage(DamageClass.Melee).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Ranged))
+			additive += player.GetDamage(DamageClass.Ranged).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Magic))
+			additive += player.GetDamage(DamageClass.Magic).Additive -1;
+
+		if (projectile.DamageType.CountsAsClass(DamageClass.Summon))
+			additive += player.GetDamage(DamageClass.Summon).Additive -1;
+		
+		 // --- Calculated the modifier based on existing class bonuses .
+		 modifiers.SourceDamage += bonus / (1 + additive) ;
+	}
+	
+	public static void ApplyAdditiveLikeScalingItem(Player player, Item item,  ref NPC.HitModifiers modifiers, float bonus)
+	{
+		if (player == null || item == null)
+			return;
+
+		// --- Get all additives from player based on type of damage of the hit ---
+		float additive = player.GetDamage(DamageClass.Generic).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Melee))
+			additive += player.GetDamage(DamageClass.Melee).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Ranged))
+			additive += player.GetDamage(DamageClass.Ranged).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Magic))
+			additive += player.GetDamage(DamageClass.Magic).Additive -1;
+
+		if (item.DamageType.CountsAsClass(DamageClass.Summon))
+			additive += player.GetDamage(DamageClass.Summon).Additive -1;
+		
+		// --- Calculated the modifier based on existing class bonuses .
+		modifiers.SourceDamage += bonus / (1 + additive) ;
+	}
+}

--- a/Content/Passives/Ranged/Masteries/FatBulletsMastery.cs
+++ b/Content/Passives/Ranged/Masteries/FatBulletsMastery.cs
@@ -1,59 +1,53 @@
 ﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+using PathOfTerraria.Common.Utilities;
 using Terraria.DataStructures;
+using Terraria.ID;
 
-namespace PathOfTerraria.Content.Passives;
+namespace PathOfTerraria.Content.Passives.Ranged.Masteries;
 
 internal class FatBulletsMastery : Passive
 {
 	internal class FatBulletsProjectile : GlobalProjectile
 	{
 		public override bool InstancePerEntity => true;
-
-		private float _originalMagnitude = -1;
+		private float _value;
+		private string _ammoOld;
 
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<FatBulletsMastery>(out float value)
-				&& ammo.Item.CountsAsClass(DamageClass.Ranged))
+			if (source is EntitySource_ItemUse_WithAmmo ammo && ammo.Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<FatBulletsMastery>(out float value) && ammo.Item.CountsAsClass(DamageClass.Ranged))
 			{
-				projectile.scale *= 1 + (value / 100f);
-				projectile.damage = (int)(projectile.damage * (1 + (value / 100f)));
-				projectile.velocity *= 5f;
-
-				int extras = (int)(projectile.velocity.Length() / 16f);
-
-				if (extras > 0)
-				{
-					projectile.extraUpdates += extras;
-					projectile.velocity /= (float)extras;
-				}
-
-				_originalMagnitude = projectile.velocity.Length();
-			}
-		}
-
-		public override bool PreAI(Projectile projectile)
-		{
-			if (_originalMagnitude != -1)
-			{
-				projectile.velocity *= 0.96f;
-				projectile.Opacity = MathF.Min(1, projectile.velocity.Length() / 4f);
+				_value = value;
+				projectile.scale *= 1 + (50 / 100f); // due to Vortex beater/Phantasm coding, this also scales the bow/gun size.
+				projectile.velocity *= 0.5f; // make the bullets feel heavier aka slow them down by 50%
 				
-				if (projectile.velocity.LengthSquared() <= 0.1f)
+				// This makes it so that a bullet can at most live 60 ticks aka a second, this is roughly the amount necessary to make them fly as far as previously
+				if (ammo.Item.useAmmo == AmmoID.Bullet)
 				{
-					projectile.Kill();
-					return false;
+					projectile.timeLeft = 60;
+					_ammoOld = "Bullet";
+				}
+
+				if (ammo.Item.useAmmo == AmmoID.Arrow)
+				{
+					projectile.timeLeft = 90;
+					_ammoOld = "Arrow";
 				}
 			}
-
-			return true;
 		}
-
+		// this adds the (at the time of writing this) 30% damage modifier based on the remaining arrow lifetime, making it both not ask every tick and much more friendly to manage than the old one.
+		// Arrows use 90 due to the inherently slower flight time to reach the same distance as the old function.
+		
 		public override void ModifyHitNPC(Projectile projectile, NPC target, ref NPC.HitModifiers modifiers)
 		{
-			if (_originalMagnitude != -1)
+			Player projOwner = Main.player[projectile.owner];
+			if (_ammoOld == "Bullet")
 			{
-				modifiers.FinalDamage *= projectile.velocity.Length() / _originalMagnitude * 0.75f + 0.25f;
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, projectile.timeLeft / 60f * _value / 100f);
+			}
+			else if (_ammoOld == "Arrow")
+			{
+				AdditiveScalingModifier.ApplyAdditiveLikeScalingProjectile(projOwner, projectile, ref modifiers, projectile.timeLeft / 90f *  _value / 100f);
 			}
 		}
 	}


### PR DESCRIPTION
Separated it from the Elemental one and took out all the old code

- Fat Bullet now scales additively
- Fixed Fat Bullet causing Phantasm/Vortex Beater to rapidfire

This requires the Additive Mastery PR for the Function
