### PR TITLE
fix(#1888): Fixes limited opening and Movement Buff after Summoning p…

### DIFF
--- a/Content/Passives/Summon/Masteries/LimitedEntranceMastery.cs
+++ b/Content/Passives/Summon/Masteries/LimitedEntranceMastery.cs
@@ -19,19 +19,16 @@ internal class LimitedEntranceMastery : Passive
 
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (source is EntitySource_Parent { Entity: Player plr } && HasNode(plr, out float value))
+			if (projectile.owner is < 0 or >= Main.maxPlayers)
+			{
+				return;
+			}
+
+			Player plr = Main.player[projectile.owner];
+			if (plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<LimitedEntranceMastery>(out float value))
 			{
 				_buffTime = (int)(value * 60);
 			}
-			else if (source is EntitySource_Parent { Entity: Projectile proj } && proj.TryGetOwner(out Player projOwner) && HasNode(projOwner, out float value2))
-			{
-				_buffTime = (int)(value2 * 60);
-			}
-		}
-
-		private static bool HasNode(Player plr, out float value)
-		{
-			return plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<LimitedEntranceMastery>(out value);
 		}
 
 		public override bool PreAI(Projectile projectile)

--- a/Content/Passives/Summon/SmallPassives/MoveIncreaseOnSummonPassive.cs
+++ b/Content/Passives/Summon/SmallPassives/MoveIncreaseOnSummonPassive.cs
@@ -15,18 +15,12 @@ internal class MoveIncreaseOnSummonPassive : Passive
 
 		public override void OnSpawn(Projectile projectile, IEntitySource source)
 		{
-			if (source is EntitySource_Parent { Entity: Player plr })
+			if (projectile.owner is < 0 or >= Main.maxPlayers)
 			{
-				TryFunctionality(plr);
+				return;
 			}
-			else if (source is EntitySource_Parent { Entity: Projectile proj } && proj.TryGetOwner(out Player projOwner))
-			{
-				TryFunctionality(projOwner);
-			}
-		}
 
-		private static void TryFunctionality(Player plr)
-		{
+			Player plr = Main.player[projectile.owner];
 			if (plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MoveIncreaseOnSummonPassive>(out float value))
 			{
 				plr.AddBuff(ModContent.BuffType<HastySummonBuff>(), (int)(value * 60), false);


### PR DESCRIPTION
…assives

﻿### Link Issues
Resolves: #1888 

### Description of Work
*  Fixes limited opening and Movement Buff after Summoning passives

### Comments
* Uses the same tracking as other minion passives that were reporting - Such as the sentries ones