### PR TITLE
Remove multiplayer check from RecursiveMine method

### DIFF
--- a/Content/Passives/Utility/Masteries/SpelunkyMastery.cs
+++ b/Content/Passives/Utility/Masteries/SpelunkyMastery.cs
@@ -31,11 +31,6 @@ internal class SpelunkyMastery : Passive
 
 		private static void RecursiveMine(int x, int y, int tileType, HashSet<Point16> takenPositions)
 		{
-			if (Main.netMode == NetmodeID.MultiplayerClient)
-			{
-				NetMessage.SendData(MessageID.TileManipulation, -1, -1, null, 0, x, y);
-			}
-			
 			WorldGen.KillTile(x, y);
 			takenPositions.Add(new Point16(x, y));
 


### PR DESCRIPTION
Removed multiplayer tile manipulation message from RecursiveMine method.

﻿### Link Issues
Resolves:

### Description of Work


### Comments
