### PR TITLE
More misc fixes

### DIFF
--- a/Common/AI/NPCMovement.cs
+++ b/Common/AI/NPCMovement.cs
@@ -3,6 +3,7 @@ using PathOfTerraria.Common.Utilities;
 using PathOfTerraria.Core.Time;
 using PathOfTerraria.Utilities;
 using PathOfTerraria.Utilities.Terraria;
+using Terraria.DataStructures;
 
 #nullable enable
 
@@ -86,7 +87,12 @@ internal sealed class NPCMovement : NPCComponent<MovementData>
 		{
 			if (npc.velocity.Y == 0f) { Collision.StepDown(ref npc.position, ref npc.velocity, npc.width, npc.height, ref npc.stepSpeed, ref npc.gfxOffY); }
 
-			Collision.StepUp(ref npc.position, ref npc.velocity, npc.width, npc.height, ref npc.stepSpeed, ref npc.gfxOffY);
+			Point16 center = npc.Center.ToTileCoordinates16();
+
+			if (WorldGen.InWorld(center.X, center.Y, 10))
+			{
+				Collision.StepUp(ref npc.position, ref npc.velocity, npc.width, npc.height, ref npc.stepSpeed, ref npc.gfxOffY);
+			}
 		}
 
 		if ((!npc.HasValidTarget && !Data.TargetOverride.HasValue) || Data.NoAccelerationTime.Value > 0)

--- a/Common/NPCs/IChatButton.cs
+++ b/Common/NPCs/IChatButton.cs
@@ -93,8 +93,8 @@ public interface IChatButton
 						continue;
 					}
 
-					buttons[i].Draw(basePosition, Main.LocalPlayer.TalkNPC, out float width);
-					drawPosition.X -= width + 6;
+					buttons[i].Draw(drawPosition, Main.LocalPlayer.TalkNPC, out float width);
+					drawPosition.X -= width + 20;
 				}
 			}
 

--- a/Content/NPCs/Town/WizardNPC.cs
+++ b/Content/NPCs/Town/WizardNPC.cs
@@ -9,11 +9,13 @@ using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
+using PathOfTerraria.Common.Systems.StructureImprovementSystem;
 using PathOfTerraria.Common.Utilities.Extensions;
 using PathOfTerraria.Content.Items.Currency;
 using PathOfTerraria.Content.Items.Gear.Armor.Helmet;
 using PathOfTerraria.Content.Items.Quest;
 using PathOfTerraria.Content.Tiles.BossDomain;
+using PathOfTerraria.Content.Tiles.Town;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
@@ -54,12 +56,35 @@ public class WizardNPC : ModNPC, IQuestMarkerNPC, ISpawnInRavencrestNPC, IOverhe
 		NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, drawModifiers);
 
 		LocalizedText text = this.GetLocalization("Recover");
-		Buttons = [new IChatButton.ChatButton(text.Key, RecoverItems, null, () => 
-		{ 
-			QuestModPlayer questModPlayer = Main.LocalPlayer.GetModPlayer<QuestModPlayer>();
-			questModPlayer.SpawnRecoveryItems(Vector2.Zero, true, out int id);
-			return questModPlayer.HasAnyRecoveryItem && id != -1; 
-		})];
+		LocalizedText build = this.GetLocalization("Rebuild");
+
+		Buttons = [
+			// Recover button
+			new IChatButton.ChatButton(text.Key, RecoverItems, null, () => 
+			{ 
+				QuestModPlayer questModPlayer = Main.LocalPlayer.GetModPlayer<QuestModPlayer>();
+				questModPlayer.SpawnRecoveryItems(Vector2.Zero, true, out int id);
+				return questModPlayer.HasAnyRecoveryItem && id != -1; 
+			}), 
+
+			// Rebuild button - workaround for players having to bomb their Ravencrest, instead allowing instant rebuild
+			new IChatButton.ChatButton(build.Key, _ => 
+			{
+				RavencrestSystem.UpgradeBuilding("Library", 2);
+				Main.npcChatText = Language.GetTextValue("Mods.PathOfTerraria.NPCs.WizardNPC.RebuildDialogue." + Main.rand.Next(3));
+			}, null, () => 
+			{
+				ImprovableStructure library = RavencrestSystem.Structures["Library"];
+				return Main.hardMode && !CheckHiddenBookshelf();
+			})
+		];
+	}
+
+	private static bool CheckHiddenBookshelf()
+	{
+		Point pos = RavencrestSystem.Structures["Library"].Position;
+		Tile tile = Main.tile[pos.X + 56, pos.Y + 50];
+		return tile.HasTile && tile.TileType == ModContent.TileType<HiddenBookcase>();
 	}
 
 	public static void RecoverItems(NPC self)

--- a/Content/Passives/Melee/Masteries/PuppeteerMastery.cs
+++ b/Content/Passives/Melee/Masteries/PuppeteerMastery.cs
@@ -51,7 +51,12 @@ internal class PuppeteerMastery : Passive
 
 		public override void PostAI(NPC npc)
 		{
-			if (YoyoIdentity == -1 || Yoyo is not Projectile { active: true } yoyo)
+			if (YoyoIdentity == -1)
+			{
+				return;
+			}
+
+			if (Yoyo is not Projectile { active: true } yoyo || yoyo.Center.HasNaNs() || yoyo.DistanceSQ(npc.Center) > 1500 * 1500)
 			{
 				YoyoIdentity = -1;
 				return;

--- a/Content/Passives/Ranged/Masteries/MarksmanMastery.cs
+++ b/Content/Passives/Ranged/Masteries/MarksmanMastery.cs
@@ -12,7 +12,7 @@ internal class MarksmanMastery : Passive
 		private static readonly Asset<Texture2D> Icon = ModContent.Request<Texture2D>("PathOfTerraria/Assets/Misc/VFX/MarkedIcon");
 
 		[ThreadStatic]
-		private static bool _markedDamage = false;
+		private static bool _markedDamage;
 
 		public override void OnHitByProjectile(NPC npc, Projectile projectile, NPC.HitInfo hit, int damageDone)
 		{
@@ -21,7 +21,8 @@ internal class MarksmanMastery : Passive
 				return;
 			}
 
-			if (projectile.TryGetOwner(out Player plr) && projectile.friendly && plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MarksmanMastery>(out float value))
+			if (projectile.TryGetOwner(out Player plr) && projectile.friendly && plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<MarksmanMastery>(out float value)
+				&& plr.GetModPlayer<MarkedPlayer>().TargetNpc == npc.whoAmI)
 			{
 				damageDone = (int)(damageDone * value / 100f);
 

--- a/Content/Passives/Summon/Masteries/SacrificialSummonsMastery.cs
+++ b/Content/Passives/Summon/Masteries/SacrificialSummonsMastery.cs
@@ -1,6 +1,9 @@
-﻿using PathOfTerraria.Common.Systems.PassiveTreeSystem;
+﻿using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Common.Systems.ModPlayers.LivesSystem;
+using PathOfTerraria.Common.Systems.PassiveTreeSystem;
 using PathOfTerraria.Content.Buffs;
 using PathOfTerraria.Content.Projectiles.PassiveProjectiles;
+using SubworldLibrary;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -38,6 +41,12 @@ internal class SacrificialSummonsMastery : Passive
 
 				Player.statLife = 100;
 				Player.SetImmuneTimeForAllTypes(120);
+
+				if (SubworldSystem.Current is MappingWorld) // Counteract the default life loss, since this runs after BossDomainLivesPlayer's PreKill
+				{
+					Player.GetModPlayer<BossDomainLivesPlayer>().LivesLost--;
+				}
+
 				return false;
 			}
 

--- a/Localization/de-DE/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	// Recover: Recover
+	// Rebuild: Rebuild
 
 	RecoverDialogue: {
 		// 0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		// 1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		// 2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/de-DE/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.NPCs.hjson
@@ -273,7 +273,7 @@ WizardNPC: {
 	}
 
 	RebuildDialogue: {
-		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
 		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
 		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
@@ -942,6 +942,12 @@ TinkerNPC: {
 			// 0: Rain hisses against my workshop, and yet the gears sing their own song. Fascinating!
 			// 1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			// 2: The storm stirs more than just water... it awakens the thrill of invention!
+		}
+
+		Goblins: {
+			// 0: Tsk. Harm my inventions and I shall rain down electric fury!
+			// 1: Hmm...a perfect time to test my...more unstable creations.
+			// 2: Calibration is SO much harder with all this ruckus...
 		}
 	}
 

--- a/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
 	Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	Recover: Recover
+	Rebuild: Rebuild
 
 	RecoverDialogue: {
 		0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
+		1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.NPCs.hjson
@@ -943,6 +943,12 @@ TinkerNPC: {
 			1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			2: The storm stirs more than just water... it awakens the thrill of invention!
 		}
+
+		Goblins: {
+			0: Tsk. Harm my inventions and I shall rain down electric fury!
+			1: Hmm...a perfect time to test my...more unstable creations.
+			2: Calibration is SO much harder with all this ruckus...
+		}
 	}
 
 	Entry: Todo:

--- a/Localization/es-ES/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	// Recover: Recover
+	// Rebuild: Rebuild
 
 	RecoverDialogue: {
 		// 0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		// 1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		// 2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/es-ES/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.NPCs.hjson
@@ -273,7 +273,7 @@ WizardNPC: {
 	}
 
 	RebuildDialogue: {
-		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
 		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
 		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
@@ -942,6 +942,12 @@ TinkerNPC: {
 			// 0: Rain hisses against my workshop, and yet the gears sing their own song. Fascinating!
 			// 1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			// 2: The storm stirs more than just water... it awakens the thrill of invention!
+		}
+
+		Goblins: {
+			// 0: Tsk. Harm my inventions and I shall rain down electric fury!
+			// 1: Hmm...a perfect time to test my...more unstable creations.
+			// 2: Calibration is SO much harder with all this ruckus...
 		}
 	}
 

--- a/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
@@ -273,7 +273,7 @@ WizardNPC: {
 	}
 
 	RebuildDialogue: {
-		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
 		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
 		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
@@ -942,6 +942,12 @@ TinkerNPC: {
 			// 0: Rain hisses against my workshop, and yet the gears sing their own song. Fascinating!
 			// 1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			// 2: The storm stirs more than just water... it awakens the thrill of invention!
+		}
+
+		Goblins: {
+			// 0: Tsk. Harm my inventions and I shall rain down electric fury!
+			// 1: Hmm...a perfect time to test my...more unstable creations.
+			// 2: Calibration is SO much harder with all this ruckus...
 		}
 	}
 

--- a/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	Entry: Peut-être le sorcier le plus puissant de tous les temps, Alaric continue d'agir comme quelqu'un qui prétend être le sorcier le plus puissant de tous les temps. S'il est d'humeur capricieuse, il peut provoquer une véritable catastrophe instantanée.
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	// Recover: Recover
+	// Rebuild: Rebuild
 
 	RecoverDialogue: {
 		// 0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		// 1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		// 2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/pl-PL/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	// Recover: Recover
+	// Rebuild: Rebuild
 
 	RecoverDialogue: {
 		// 0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		// 1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		// 2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/pl-PL/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.NPCs.hjson
@@ -273,7 +273,7 @@ WizardNPC: {
 	}
 
 	RebuildDialogue: {
-		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
 		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
 		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
@@ -942,6 +942,12 @@ TinkerNPC: {
 			// 0: Rain hisses against my workshop, and yet the gears sing their own song. Fascinating!
 			// 1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			// 2: The storm stirs more than just water... it awakens the thrill of invention!
+		}
+
+		Goblins: {
+			// 0: Tsk. Harm my inventions and I shall rain down electric fury!
+			// 1: Hmm...a perfect time to test my...more unstable creations.
+			// 2: Calibration is SO much harder with all this ruckus...
 		}
 	}
 

--- a/Localization/pt-BR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	// Entry: Perhaps the most powerful wizard of all time, Alaric still acts like someone who's pretending to be the most powerful wizard of all time. If he's feeling funny, he might cause true and instant catastrophe.
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	// Recover: Recover
+	// Rebuild: Rebuild
 
 	RecoverDialogue: {
 		// 0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		// 1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		// 2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/pt-BR/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.NPCs.hjson
@@ -273,7 +273,7 @@ WizardNPC: {
 	}
 
 	RebuildDialogue: {
-		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
 		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
 		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
@@ -942,6 +942,12 @@ TinkerNPC: {
 			// 0: Rain hisses against my workshop, and yet the gears sing their own song. Fascinating!
 			// 1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			// 2: The storm stirs more than just water... it awakens the thrill of invention!
+		}
+
+		Goblins: {
+			// 0: Tsk. Harm my inventions and I shall rain down electric fury!
+			// 1: Hmm...a perfect time to test my...more unstable creations.
+			// 2: Calibration is SO much harder with all this ruckus...
 		}
 	}
 

--- a/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
@@ -264,11 +264,18 @@ WizardNPC: {
 	Entry: Возможно, самый могущественный волшебник всех времён, Аларик всё ещё ведёт себя так, будто притворяется самым могущественным волшебником всех времён. Если ему весело, он может вызвать настоящую и мгновенную катастрофу.
 	// Census.SpawnCondition: Spawns by default in Ravencrest. Home is the Library.
 	// Recover: Recover
+	// Rebuild: Rebuild
 
 	RecoverDialogue: {
 		// 0: Lost some items? Here they are...haha! I've found them hidden within your mind. Note their frailty; I have much other use of my strength!
 		// 1: Seems like the world's stolen your items? Reminds me of some goblins...thousands of years of work...ultimately, couldn't save her...oh! Anyway, those items are temporary. Be careful!
 		// 2: Boom! Hah. Just kidding! There you are. Don't overrely on them - they won't last you forever!
+	}
+
+	RebuildDialogue: {
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
+		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
 }
 

--- a/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.NPCs.hjson
@@ -273,7 +273,7 @@ WizardNPC: {
 	}
 
 	RebuildDialogue: {
-		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [prclass/l,1:l];
+		// 0: Oh? Has my library gone into disarray? ...no? Huh. Thanks for the concern regardless, [plrclass/l,1:l].
 		// 1: Tada! Feast before your eyes, a library that's not seen hardship! I grant you a strong thought of appreciation for your input.
 		// 2: ...aha! As you can see, the library is restored. Why did I not do this the first time? ...I was busy around then.
 	}
@@ -931,6 +931,12 @@ TinkerNPC: {
 			// 0: Rain hisses against my workshop, and yet the gears sing their own song. Fascinating!
 			// 1: Moisture and machinery... usually a disaster. Tonight, maybe a spectacle!
 			// 2: The storm stirs more than just water... it awakens the thrill of invention!
+		}
+
+		Goblins: {
+			// 0: Tsk. Harm my inventions and I shall rain down electric fury!
+			// 1: Hmm...a perfect time to test my...more unstable creations.
+			// 2: Calibration is SO much harder with all this ruckus...
 		}
 	}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves: #1889 

### Description of Work
Clarification on second commit, which I didn't split properly:
- Added safeguards to Puppeteer mastery to avoid "depsawning" NPCs
- Fixed Marksman mastery adding splash damage to all hits
- Fixed Sacrificial Summons mastery not stopping losing a life in domains

### Comments
Alaric repairing his own building is a bit of a workaround, but may be used for players who switch worlds who cannot repeat a quest too. None of this was tested in multiplayer, but should not negatively impact any functionality.