### PR TITLE
feat: make it so all accessories are just accessories and not classif…

### DIFF
--- a/Common/Data/VanillaItemData/AnkhShield.json
+++ b/Common/Data/VanillaItemData/AnkhShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/CobaltShield.json
+++ b/Common/Data/VanillaItemData/CobaltShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/EoCShield.json
+++ b/Common/Data/VanillaItemData/EoCShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/FrozenShield.json
+++ b/Common/Data/VanillaItemData/FrozenShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/HeroShield.json
+++ b/Common/Data/VanillaItemData/HeroShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/ObsidianShield.json
+++ b/Common/Data/VanillaItemData/ObsidianShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/PaladinsShield.json
+++ b/Common/Data/VanillaItemData/PaladinsShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Data/VanillaItemData/SquireShield.json
+++ b/Common/Data/VanillaItemData/SquireShield.json
@@ -1,5 +1,5 @@
 {
-  "ItemType": "Offhand",
+  "ItemType": "Accessories",
   "ElementProportions": {
     "Fire": 0,
     "Cold": 0,

--- a/Common/Enums/ItemType.cs
+++ b/Common/Enums/ItemType.cs
@@ -38,11 +38,12 @@ public enum ItemType : long
 	Focus = 1 << 27,
 	Summon = 1 << 28,
 	Yoyo = 1 << 29,
-	TypeCount = 30,
+	Accessory = 1 << 30,
+	TypeCount = 31,
 
 	Armor = Helmet | Chestplate | Leggings,
-	Accessories = Ring | Charm | Amulet,
-	Equipment = Armor | Accessories,
+	Accessories = Accessory,
+	Equipment = Armor | Ring | Charm | Amulet | Accessories,
 	Offhand = Shield | Quiver | Talisman | Focus,
 
 	Melee = Sword | Spear | MeleeFlail | WarShield | Battleaxe | Yoyo,

--- a/Core/Items/VanillaItemDataExporter.cs
+++ b/Core/Items/VanillaItemDataExporter.cs
@@ -28,11 +28,6 @@ internal class VanillaItemDataExporter : ModSystem
 			if (item.accessory && !item.vanity)
 			{
 				type = ItemType.Accessories;
-
-				if (item.shieldSlot > 0)
-				{
-					type = ItemType.Shield;
-				}
 			}
 			else if (item.defense > 0 && !item.vanity)
 			{


### PR DESCRIPTION
…ied as something else

﻿### Link Issues
Resolves: N/A

### Description of Work
* Updates all accessories that were classified as something other than an accessory back to an accessory.


### Comments
* This was actually something we thought about a long time ago BEFORE we had accessory slots back into the game. So this was just a missed thing that was not cleaned up