### PR TITLE
fix: Magic Masteries damage type restrictions and ShockChancePassive value fix

### DIFF
--- a/Content/Passives/Magic/Masteries/AutomagicMissileMastery.cs
+++ b/Content/Passives/Magic/Masteries/AutomagicMissileMastery.cs
@@ -10,7 +10,7 @@ internal class AutomagicMissileMastery : Passive
 	{
 		public override void OnHitNPCWithProj(Projectile proj, NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (!Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<AutomagicMissileMastery>(out float value) || Main.rand.NextFloat() > value / 100f)
+			if (!Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<AutomagicMissileMastery>(out float value) || Main.rand.NextFloat() > value / 100f || !hit.DamageType.CountsAsClass(DamageClass.Magic))
 			{
 				return;
 			}

--- a/Content/Passives/Magic/Masteries/CenterOfTheUniverseMastery.cs
+++ b/Content/Passives/Magic/Masteries/CenterOfTheUniverseMastery.cs
@@ -18,12 +18,15 @@ internal class CenterOfTheUniverseMastery : Passive
 
 		public override void OnHitNPCWithItem(Item item, NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			CheckSpawnPlanet(Player.GetSource_OnHit(target), Player, damageDone);
+			if (hit.DamageType.CountsAsClass(DamageClass.Magic))
+			{
+				CheckSpawnPlanet(Player.GetSource_OnHit(target), Player, damageDone);
+			}
 		}
 
 		public override void OnHitNPCWithProj(Projectile proj, NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (proj.type != ModContent.ProjectileType<OrbitingPlanet>())
+			if (proj.type != ModContent.ProjectileType<OrbitingPlanet>() && hit.DamageType.CountsAsClass(DamageClass.Magic))
 			{
 				CheckSpawnPlanet(Player.GetSource_OnHit(target), Player, damageDone);
 			}

--- a/Content/Passives/Magic/Masteries/ReverberationMastery.cs
+++ b/Content/Passives/Magic/Masteries/ReverberationMastery.cs
@@ -38,7 +38,7 @@ internal class ReverberationMastery : Passive
 		{
 			bool notChanneled = player.channel && !CustomItemSets.VisualChannelOnly[item.type]; // Only spawn if this is not channeled or if this is from a visual channel item
 
-			if (notChanneled || !player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ReverberationMastery>(out float value))
+			if (notChanneled || !player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<ReverberationMastery>(out float value) || !projectile.DamageType.CountsAsClass(DamageClass.Magic))
 			{
 				return;
 			}

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: 5% chance to apply Shock
+	// Tooltip: {0}% chance to apply Shock
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	Name: Added Shock Chance
-	Tooltip: 5% chance to apply Shock
+	Tooltip: {0}% chance to apply Shock
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: 5% chance to apply Shock
+	// Tooltip: {0}% chance to apply Shock
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	Name: Champ énergétique
-	Tooltip: Ajoute 5% de chances supplémentaires d'infliger Choc à un ennemi par niveau.
+	Tooltip: Ajoute {0}% de chances supplémentaires d'infliger Choc à un ennemi par niveau.
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: 5% chance to apply Shock
+	// Tooltip: {0}% chance to apply Shock
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: 5% chance to apply Shock
+	// Tooltip: {0}% chance to apply Shock
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	Name: Энергетическое поле
-	Tooltip: Добавляет дополнительный 5% шанс нанести врагу шок за уровень.
+	Tooltip: Добавляет дополнительный {0}% шанс нанести врагу шок за уровень.
 }
 
 IncreasedMinionDamagePassive: {


### PR DESCRIPTION
﻿### Link Issues
Resolves: [#1974](https://github.com/Path-of-Terraria/PathOfTerraria/issues/1974)

### Description of Work
- Three masteries (Center of the Universe, Automagic Missile, and Reverberation) were triggering on any damage type. I added checks to restrict them to Magic damage only, as stated in their tooltips.
- The ShockChancePassive was hardcoded to 5% in localization, while the JSON defined it as 10%. I removed the hardcoded values and linked the tooltip to the dynamic {0}% argument from the JSON. Note: If 5% was the intended balance, the value should now be changed in Passives.json

### Comments
