### PR TITLE
fix: chests not rolling loot correctly for item rarity

### DIFF
--- a/Common/ItemDropping/MapChestLoot.cs
+++ b/Common/ItemDropping/MapChestLoot.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.MobSystem;
 using PathOfTerraria.Core.Items;
@@ -37,6 +38,28 @@ internal static class MapChestLoot
 		}
 
 		return DropTable.RollManyMobDrops(count, PoTItemHelper.PickItemLevel(), rarity, random: WorldGen.genRand);
+	}
+
+	/// <summary>
+	/// Builds a chest <see cref="Item"/> from a rolled <see cref="ItemDatabase.ItemRecord"/>, applying the
+	/// record's rolled rarity and re-running the affix roll so the chest item actually reflects the gear pool's
+	/// rarity selection. The default <c>new Item(type)</c> path leaves <see cref="PoTInstanceItemData.Rarity"/>
+	/// at <see cref="ItemRarity.Normal"/>, which silently produces zero affixes regardless of what the gear pool rolled.
+	/// </summary>
+	public static Item BuildChestItem(ItemDatabase.ItemRecord record)
+	{
+		var item = new Item(record.ItemId, record.Item.stack);
+
+		if (item.TryGetGlobalItem<PoTInstanceItemData>(out _))
+		{
+			PoTInstanceItemData data = item.GetInstanceData();
+			PoTStaticItemData staticData = item.GetStaticData();
+
+			data.Rarity = staticData.IsUnique ? ItemRarity.Unique : record.Rarity;
+			PoTItemHelper.Roll(item, PoTItemHelper.PickItemLevel());
+		}
+
+		return item;
 	}
 }
 

--- a/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenSlimeDomain.cs
@@ -147,7 +147,7 @@ internal class QueenSlimeDomain : BossDomainSubworld
 						ItemDatabase.ItemRecord drop = drops[k];
 						if (drop.Item != null)
 						{
-							chest.item[k] = new Item(drop.ItemId, drop.Item.stack);
+							chest.item[k] = MapChestLoot.BuildChestItem(drop);
 						}
 					}
 					else

--- a/Common/Subworlds/MappingAreas/DesertArea.cs
+++ b/Common/Subworlds/MappingAreas/DesertArea.cs
@@ -492,7 +492,7 @@ internal class DesertArea : MappingWorld, IOverrideBiome, IExplorationWorld
 
 						if (drop.Item is not null)
 						{
-							chest.item[k] = new Item(drop.ItemId, drop.Item.stack);
+							chest.item[k] = MapChestLoot.BuildChestItem(drop);
 						}
 					}
 					else

--- a/Common/Subworlds/MappingAreas/ForestArea.cs
+++ b/Common/Subworlds/MappingAreas/ForestArea.cs
@@ -358,7 +358,7 @@ internal class ForestArea : MappingWorld, IOverrideBiome, IExplorationWorld
 
 					if (drop.Item is not null)
 					{
-						chest.item[k] = new Item(drop.ItemId, drop.Item.stack);
+						chest.item[k] = MapChestLoot.BuildChestItem(drop);
 					}
 				}
 			}

--- a/Content/Swamp/BranchTreeMicrobiome.cs
+++ b/Content/Swamp/BranchTreeMicrobiome.cs
@@ -180,7 +180,7 @@ internal class BranchTreeMicrobiome : MicroBiome
 
 					if (drop.Item is not null)
 					{
-						chest.item[k] = new Item(drop.ItemId, drop.Item.stack);
+						chest.item[k] = MapChestLoot.BuildChestItem(drop);
 					}
 				}
 				else

--- a/Localization/de-DE/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.UI.hjson
@@ -69,6 +69,24 @@ StatUI: {
 	// MaxHasteCharges: Maximum Haste Charges
 	// MaxFocusCharges: Maximum Focus Charges
 	// MaxAegisCharges: Maximum Aegis Charges
+	// GatheringHeader: Gathering
+	// MiningSpeed: Mining Speed
+	// BaitConservation: Bait Conservation
+	// TilePlacementSpeed: Tile Placement Speed
+	// WallPlacementSpeed: Wall Placement Speed
+	// ItemPickupRange: Item Pickup Range
+	// CoinPickupRange: Coin Pickup Range
+	// MobilityHeader: Mobility
+	// JumpHeight: Jump Height
+	// JumpSpeed: Jump Speed
+	// WingFlightTime: Wing Flight Time
+	// WingGlideControl: Wing Glide Control
+	// SwimSpeed: Swim Speed
+	// BreathCapacity: Breath Capacity
+	// SafeFallDistance: Safe Fall Distance
+	// ConsumablesHeader: Consumables
+	// PotionCooldownReduction: Potion Cooldown Reduction
+	// BuffDuration: Buff Duration
 	// MiscHeader: Misc
 	// MaxMinions: Maximum Minions
 	// AmmoConsumptionChance: Ammo Reservation

--- a/Localization/es-ES/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.UI.hjson
@@ -69,6 +69,24 @@ StatUI: {
 	// MaxHasteCharges: Maximum Haste Charges
 	// MaxFocusCharges: Maximum Focus Charges
 	// MaxAegisCharges: Maximum Aegis Charges
+	// GatheringHeader: Gathering
+	// MiningSpeed: Mining Speed
+	// BaitConservation: Bait Conservation
+	// TilePlacementSpeed: Tile Placement Speed
+	// WallPlacementSpeed: Wall Placement Speed
+	// ItemPickupRange: Item Pickup Range
+	// CoinPickupRange: Coin Pickup Range
+	// MobilityHeader: Mobility
+	// JumpHeight: Jump Height
+	// JumpSpeed: Jump Speed
+	// WingFlightTime: Wing Flight Time
+	// WingGlideControl: Wing Glide Control
+	// SwimSpeed: Swim Speed
+	// BreathCapacity: Breath Capacity
+	// SafeFallDistance: Safe Fall Distance
+	// ConsumablesHeader: Consumables
+	// PotionCooldownReduction: Potion Cooldown Reduction
+	// BuffDuration: Buff Duration
 	// MiscHeader: Misc
 	MaxMinions: Súbditos máximos
 	// AmmoConsumptionChance: Ammo Reservation

--- a/Localization/fr-FR/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.UI.hjson
@@ -69,6 +69,24 @@ StatUI: {
 	// MaxHasteCharges: Maximum Haste Charges
 	// MaxFocusCharges: Maximum Focus Charges
 	// MaxAegisCharges: Maximum Aegis Charges
+	// GatheringHeader: Gathering
+	// MiningSpeed: Mining Speed
+	// BaitConservation: Bait Conservation
+	// TilePlacementSpeed: Tile Placement Speed
+	// WallPlacementSpeed: Wall Placement Speed
+	// ItemPickupRange: Item Pickup Range
+	// CoinPickupRange: Coin Pickup Range
+	// MobilityHeader: Mobility
+	// JumpHeight: Jump Height
+	// JumpSpeed: Jump Speed
+	// WingFlightTime: Wing Flight Time
+	// WingGlideControl: Wing Glide Control
+	// SwimSpeed: Swim Speed
+	// BreathCapacity: Breath Capacity
+	// SafeFallDistance: Safe Fall Distance
+	// ConsumablesHeader: Consumables
+	// PotionCooldownReduction: Potion Cooldown Reduction
+	// BuffDuration: Buff Duration
 	// MiscHeader: Misc
 	MaxMinions: Serviteurs Maximum
 	// AmmoConsumptionChance: Ammo Reservation

--- a/Localization/pl-PL/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.UI.hjson
@@ -69,6 +69,24 @@ StatUI: {
 	// MaxHasteCharges: Maximum Haste Charges
 	// MaxFocusCharges: Maximum Focus Charges
 	// MaxAegisCharges: Maximum Aegis Charges
+	// GatheringHeader: Gathering
+	// MiningSpeed: Mining Speed
+	// BaitConservation: Bait Conservation
+	// TilePlacementSpeed: Tile Placement Speed
+	// WallPlacementSpeed: Wall Placement Speed
+	// ItemPickupRange: Item Pickup Range
+	// CoinPickupRange: Coin Pickup Range
+	// MobilityHeader: Mobility
+	// JumpHeight: Jump Height
+	// JumpSpeed: Jump Speed
+	// WingFlightTime: Wing Flight Time
+	// WingGlideControl: Wing Glide Control
+	// SwimSpeed: Swim Speed
+	// BreathCapacity: Breath Capacity
+	// SafeFallDistance: Safe Fall Distance
+	// ConsumablesHeader: Consumables
+	// PotionCooldownReduction: Potion Cooldown Reduction
+	// BuffDuration: Buff Duration
 	// MiscHeader: Misc
 	MaxMinions: Maks. przywołanych stworzeń
 	// AmmoConsumptionChance: Ammo Reservation

--- a/Localization/pt-BR/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.UI.hjson
@@ -69,6 +69,24 @@ StatUI: {
 	// MaxHasteCharges: Maximum Haste Charges
 	// MaxFocusCharges: Maximum Focus Charges
 	// MaxAegisCharges: Maximum Aegis Charges
+	// GatheringHeader: Gathering
+	// MiningSpeed: Mining Speed
+	// BaitConservation: Bait Conservation
+	// TilePlacementSpeed: Tile Placement Speed
+	// WallPlacementSpeed: Wall Placement Speed
+	// ItemPickupRange: Item Pickup Range
+	// CoinPickupRange: Coin Pickup Range
+	// MobilityHeader: Mobility
+	// JumpHeight: Jump Height
+	// JumpSpeed: Jump Speed
+	// WingFlightTime: Wing Flight Time
+	// WingGlideControl: Wing Glide Control
+	// SwimSpeed: Swim Speed
+	// BreathCapacity: Breath Capacity
+	// SafeFallDistance: Safe Fall Distance
+	// ConsumablesHeader: Consumables
+	// PotionCooldownReduction: Potion Cooldown Reduction
+	// BuffDuration: Buff Duration
 	// MiscHeader: Misc
 	// MaxMinions: Maximum Minions
 	// AmmoConsumptionChance: Ammo Reservation

--- a/Localization/ru-RU/Mods.PathOfTerraria.UI.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.UI.hjson
@@ -69,6 +69,24 @@ StatUI: {
 	// MaxHasteCharges: Maximum Haste Charges
 	// MaxFocusCharges: Maximum Focus Charges
 	// MaxAegisCharges: Maximum Aegis Charges
+	// GatheringHeader: Gathering
+	// MiningSpeed: Mining Speed
+	// BaitConservation: Bait Conservation
+	// TilePlacementSpeed: Tile Placement Speed
+	// WallPlacementSpeed: Wall Placement Speed
+	// ItemPickupRange: Item Pickup Range
+	// CoinPickupRange: Coin Pickup Range
+	// MobilityHeader: Mobility
+	// JumpHeight: Jump Height
+	// JumpSpeed: Jump Speed
+	// WingFlightTime: Wing Flight Time
+	// WingGlideControl: Wing Glide Control
+	// SwimSpeed: Swim Speed
+	// BreathCapacity: Breath Capacity
+	// SafeFallDistance: Safe Fall Distance
+	// ConsumablesHeader: Consumables
+	// PotionCooldownReduction: Potion Cooldown Reduction
+	// BuffDuration: Buff Duration
 	// MiscHeader: Misc
 	MaxMinions: Макс. миньонов
 	// AmmoConsumptionChance: Ammo Reservation


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
* Fixes chests always rolling gear with normal rarity

### Comments
