### PR TITLE
feat: give thunder claps on nova skill tree max level of 2

### DIFF
--- a/Content/SkillPassives/NovaTree/ThunderClaps.cs
+++ b/Content/SkillPassives/NovaTree/ThunderClaps.cs
@@ -3,7 +3,12 @@ using PathOfTerraria.Common.Systems.Skills;
 
 namespace PathOfTerraria.Content.SkillPassives.NovaTree;
 
-internal class ThunderClaps(SkillTree tree) : SkillPassive(tree)
+internal class ThunderClaps : SkillPassive
 {
 	public override object[] TooltipArguments => ["5"];
+		
+	public ThunderClaps(SkillTree tree) : base(tree)
+	{
+		MaxLevel = 2;
+	}
 }


### PR DESCRIPTION
﻿### Link Issues
Resolves: #2008 

### Description of Work
* Thunder Claps on the Nova Passive Tree now has a max level of 2

### Comments
