### PR TITLE
fix: add missing quotes to ShockChancePassive tooltip

### DIFF
--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: {0}% chance to apply Shock
+	// Tooltip: "{0}% chance to apply Shock"
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	Name: Added Shock Chance
-	Tooltip: {0}% chance to apply Shock
+	Tooltip: "{0}% chance to apply Shock"
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: {0}% chance to apply Shock
+	// Tooltip: "{0}% chance to apply Shock"
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: {0}% chance to apply Shock
+	// Tooltip: "{0}% chance to apply Shock"
 }
 
 IncreasedMinionDamagePassive: {

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -116,7 +116,7 @@ StrongerChillPassive: {
 
 ShockChancePassive: {
 	// Name: Added Shock Chance
-	// Tooltip: {0}% chance to apply Shock
+	// Tooltip: "{0}% chance to apply Shock"
 }
 
 IncreasedMinionDamagePassive: {


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
Wrapped the {0}% chance to apply Shock tooltip in quotes within the HJSON localization files

### Comments
