### PR TITLE
feat: Added HasElementType helper and fixed elemental masteries proccing on any damage type

### DIFF
--- a/Common/Systems/ElementalDamage/ElementalPlayer.cs
+++ b/Common/Systems/ElementalDamage/ElementalPlayer.cs
@@ -329,7 +329,7 @@ public class ElementalPlayer : ModPlayer
 	/// <summary>
 	/// Checks if the current hit deals any damage of the specified <see cref="ElementType"/>.<br/>
 	/// </summary>
-	internal static bool HasElementType(ElementType type, ElementalContainer container, ElementalContainer other, Item? item)
+	internal static bool DealsElementalDamage(ElementType type, ElementalContainer container, ElementalContainer other, Item item)
 	{
 		ElementInstance ele = container[type];
 

--- a/Common/Systems/ElementalDamage/ElementalPlayer.cs
+++ b/Common/Systems/ElementalDamage/ElementalPlayer.cs
@@ -325,4 +325,17 @@ public class ElementalPlayer : ModPlayer
 
 		return false;
 	}
+
+	/// <summary>
+	/// Checks if the current hit deals any damage of the specified <see cref="ElementType"/>.<br/>
+	/// </summary>
+	internal static bool HasElementType(ElementType type, ElementalContainer container, ElementalContainer other, Item? item)
+	{
+		ElementInstance ele = container[type];
+
+		float totalConversion = GetConversionMultiplier(ele, item, other);
+		float flatDamage = ele.GetFlatDamage(other);
+
+		return totalConversion > 0 || flatDamage > 0;
+	}
 }

--- a/Content/Passives/Magic/Masteries/BurstingFuryMastery.cs
+++ b/Content/Passives/Magic/Masteries/BurstingFuryMastery.cs
@@ -17,7 +17,7 @@ internal class BurstingFuryMastery : Passive
 				return;
 			}
 
-			if (ElementalPlayer.HasElementType(ElementType.Fire, con, other, item) && finalDamage > 0 && target.life <= 0 && Player.GetModPlayer<PassiveTreePlayer>().HasNode<BurstingFuryMastery>())
+			if (ElementalPlayer.DealsElementalDamage(ElementType.Fire, con, other, item!) && finalDamage > 0 && target.life <= 0 && Player.GetModPlayer<PassiveTreePlayer>().HasNode<BurstingFuryMastery>())
 			{
 				int damage = (int)(finalDamage * Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<AfterburnMastery>() / 100f);
 				int type = ModContent.ProjectileType<Flameburst>();

--- a/Content/Passives/Magic/Masteries/BurstingFuryMastery.cs
+++ b/Content/Passives/Magic/Masteries/BurstingFuryMastery.cs
@@ -12,12 +12,12 @@ internal class BurstingFuryMastery : Passive
 	{
 		public void ElementalOnHitNPC(bool post, NPC target, ElementInstance ele, ElementalContainer con, ElementalContainer other, int finalDamage, NPC.HitInfo hitInfo, Item? item = null)
 		{
-			if (post)
+			if (post || ele.Type != ElementType.Fire)
 			{
 				return;
 			}
 
-			if (ele.Type == ElementType.Fire && finalDamage > 0 && target.life <= 0 && Player.GetModPlayer<PassiveTreePlayer>().HasNode<BurstingFuryMastery>())
+			if (ElementalPlayer.HasElementType(ElementType.Fire, con, other, item) && finalDamage > 0 && target.life <= 0 && Player.GetModPlayer<PassiveTreePlayer>().HasNode<BurstingFuryMastery>())
 			{
 				int damage = (int)(finalDamage * Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<AfterburnMastery>() / 100f);
 				int type = ModContent.ProjectileType<Flameburst>();

--- a/Content/Passives/Magic/Masteries/ChainLightningMastery.cs
+++ b/Content/Passives/Magic/Masteries/ChainLightningMastery.cs
@@ -10,14 +10,14 @@ internal class ChainLightningMastery : Passive
 	{
 		public void ElementalOnHitNPC(bool post, NPC target, ElementInstance ele, ElementalContainer con, ElementalContainer other, int finalDamage, NPC.HitInfo hitInfo, Item item = null)
 		{
-			if (post)
+			if (post || ele.Type != ElementType.Lightning)
 			{
 				return;
 			}
 
 			PassiveTreePlayer treePlayer = Player.GetModPlayer<PassiveTreePlayer>();
 
-			if (ele.Type == ElementType.Lightning && treePlayer.TryGetCumulativeValue<ChainLightningMastery>(out float value) && Main.rand.NextFloat() < value / 100f)
+			if (ElementalPlayer.HasElementType(ElementType.Lightning, con, other, item) && treePlayer.TryGetCumulativeValue<ChainLightningMastery>(out float value) && Main.rand.NextFloat() < value / 100f)
 			{
 				Terraria.DataStructures.IEntitySource src = Player.GetSource_OnHit(target);
 				Projectile.NewProjectile(src, target.Center, Vector2.Zero, ModContent.ProjectileType<ChainLightning>(), finalDamage, 0, Player.whoAmI, target.whoAmI);

--- a/Content/Passives/Magic/Masteries/ChainLightningMastery.cs
+++ b/Content/Passives/Magic/Masteries/ChainLightningMastery.cs
@@ -17,7 +17,7 @@ internal class ChainLightningMastery : Passive
 
 			PassiveTreePlayer treePlayer = Player.GetModPlayer<PassiveTreePlayer>();
 
-			if (ElementalPlayer.HasElementType(ElementType.Lightning, con, other, item) && treePlayer.TryGetCumulativeValue<ChainLightningMastery>(out float value) && Main.rand.NextFloat() < value / 100f)
+			if (ElementalPlayer.DealsElementalDamage(ElementType.Lightning, con, other, item!) && treePlayer.TryGetCumulativeValue<ChainLightningMastery>(out float value) && Main.rand.NextFloat() < value / 100f)
 			{
 				Terraria.DataStructures.IEntitySource src = Player.GetSource_OnHit(target);
 				Projectile.NewProjectile(src, target.Center, Vector2.Zero, ModContent.ProjectileType<ChainLightning>(), finalDamage, 0, Player.whoAmI, target.whoAmI);

--- a/Content/Passives/Magic/Masteries/ElectrostaticAttractionMastery.cs
+++ b/Content/Passives/Magic/Masteries/ElectrostaticAttractionMastery.cs
@@ -29,12 +29,12 @@ internal class ElectrostaticAttractionMastery : Passive
 
 		public void ElementalOnHitNPC(bool post, NPC target, ElementInstance ele, ElementalContainer con, ElementalContainer other, int finalDamage, NPC.HitInfo hitInfo, Item item = null)
 		{
-			if (post)
+			if (post || ele.Type != ElementType.Lightning)
 			{
 				return;
 			}
 
-			if (ele.Type == ElementType.Lightning && Player.GetModPlayer<PassiveTreePlayer>().HasNode<ElectrostaticAttractionMastery>())
+			if (ElementalPlayer.HasElementType(ElementType.Lightning, con, other, item) && Player.GetModPlayer<PassiveTreePlayer>().HasNode<ElectrostaticAttractionMastery>())
 			{
 				Player.AddBuff(ModContent.BuffType<ElectrostaticBuff>(), Duration);
 				stacks.Add(Duration);

--- a/Content/Passives/Magic/Masteries/ElectrostaticAttractionMastery.cs
+++ b/Content/Passives/Magic/Masteries/ElectrostaticAttractionMastery.cs
@@ -34,7 +34,7 @@ internal class ElectrostaticAttractionMastery : Passive
 				return;
 			}
 
-			if (ElementalPlayer.HasElementType(ElementType.Lightning, con, other, item) && Player.GetModPlayer<PassiveTreePlayer>().HasNode<ElectrostaticAttractionMastery>())
+			if (ElementalPlayer.DealsElementalDamage(ElementType.Lightning, con, other, item!) && Player.GetModPlayer<PassiveTreePlayer>().HasNode<ElectrostaticAttractionMastery>())
 			{
 				Player.AddBuff(ModContent.BuffType<ElectrostaticBuff>(), Duration);
 				stacks.Add(Duration);


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
Added a small helper `HasElementType` to check if a hit actually deals a specific damage type (counts both conversion and flat bonuses).
I also used this to fix several masteries that were proccing even if you weren't dealing the right type of damage:
- ChainLightningMastery: Now only procs on Lightning damage as intended.
- BurstingFuryMastery: Now only procs on Fire damage as intended.
- ElectrostaticAttractionMastery: Fixed unintended stacks from non-lightning hits.

### Comments
