### PR TITLE
Sniper additive to Multiplication issue

### DIFF
--- a/Content/Passives/Ranged/Masteries/SniperMastery.cs
+++ b/Content/Passives/Ranged/Masteries/SniperMastery.cs
@@ -12,7 +12,7 @@ internal class SniperMastery : Passive
 				return;
 			if (target.DistanceSQ(Player.Center) > PoTMod.NearbyDistanceSq && modifiers.DamageType.CountsAsClass(DamageClass.Ranged))
 			{
-				modifiers.SourceDamage *= Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<SniperMastery>() / 100f;
+				modifiers.SourceDamage *= 1 + Player.GetModPlayer<PassiveTreePlayer>().GetCumulativeValue<SniperMastery>() / 100f;
 			}
 		}
 	}


### PR DESCRIPTION
When changing it from (+) additive Damage to (*) Multiplicative Damage, i forgot to add a +1 to make it 1.2, so its currently making you deal 20% of damage instead of 20% more damage. 