### PR TITLE
Add in CI around changelogs + fixes worm segment loot explosions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,4 @@
-﻿### Link Issues
-Resolves:
-
-### Description of Work
+﻿### Description of Work
 
 
 ### Comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
             

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -27,8 +27,10 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const COMMENT_MARKER = '<!-- pot-changelog-bot -->';
-            const BODY_START = '<!-- pot-changelog-closes:start -->';
-            const BODY_END = '<!-- pot-changelog-closes:end -->';
+            const CLOSES_START = '<!-- pot-changelog-closes:start -->';
+            const CLOSES_END = '<!-- pot-changelog-closes:end -->';
+            const DESC_START = '<!-- pot-changelog-desc:start -->';
+            const DESC_END = '<!-- pot-changelog-desc:end -->';
 
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
@@ -62,10 +64,8 @@ jobs:
               const scopeIssues = [...scope.matchAll(/#(\d+)/g)].map(x => Number(x[1]));
               for (const n of scopeIssues) closes.add(n);
 
-              const linked = scopeIssues.length
-                ? ' (' + scopeIssues.map(n => `#${n}`).join(', ') + ')'
-                : '';
-              groups[type].entries.push(`- ${subject}${linked} (${c.sha.slice(0, 7)})`);
+              // Plain-text bullet — no commit hash, no issue links — so it copy-pastes cleanly into wiki articles.
+              groups[type].entries.push(`- ${subject}`);
             }
 
             const sections = [];
@@ -100,20 +100,33 @@ jobs:
               await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
             }
 
-            // Update the PR body's managed section so GitHub auto-closes the linked issues on merge.
             const currentBody = pr.body || '';
-            const managed = closesList.length
-              ? `${BODY_START}\n${closesList.map(n => `Closes #${n}`).join('\n')}\n${BODY_END}`
-              : `${BODY_START}\n${BODY_END}`;
+            let newBody = currentBody;
 
-            const sectionRe = new RegExp(`${BODY_START}[\\s\\S]*?${BODY_END}`);
-            let newBody;
-            if (sectionRe.test(currentBody)) {
-              newBody = currentBody.replace(sectionRe, managed);
+            // Inject the changelog sections under the PR template's "### Description of Work" heading, if present.
+            // The block is delimited by markers so re-runs replace it in place instead of stacking duplicates.
+            const descBlock = sections.length
+              ? `${DESC_START}\n${sections.join('\n\n')}\n${DESC_END}`
+              : `${DESC_START}\n${DESC_END}`;
+            const descRe = new RegExp(`${DESC_START}[\\s\\S]*?${DESC_END}`);
+            const headingRe = /^(\s*#{1,6}\s+Description of Work\s*)$/m;
+
+            if (descRe.test(newBody)) {
+              newBody = newBody.replace(descRe, descBlock);
+            } else if (sections.length && headingRe.test(newBody)) {
+              newBody = newBody.replace(headingRe, `$1\n\n${descBlock}`);
+            }
+
+            // Maintain a managed Closes block so GitHub auto-closes the linked issues on merge.
+            const closesBlock = closesList.length
+              ? `${CLOSES_START}\n${closesList.map(n => `Closes #${n}`).join('\n')}\n${CLOSES_END}`
+              : `${CLOSES_START}\n${CLOSES_END}`;
+            const closesRe = new RegExp(`${CLOSES_START}[\\s\\S]*?${CLOSES_END}`);
+
+            if (closesRe.test(newBody)) {
+              newBody = newBody.replace(closesRe, closesBlock);
             } else if (closesList.length) {
-              newBody = currentBody ? `${currentBody}\n\n${managed}` : managed;
-            } else {
-              newBody = currentBody;
+              newBody = newBody ? `${newBody}\n\n${closesBlock}` : closesBlock;
             }
 
             if (newBody !== currentBody) {

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -1,0 +1,121 @@
+name: PR Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.POT_GH_APP_APP_ID }}
+          private-key: ${{ secrets.POT_GH_APP_PRIVATE_KEY }}
+
+      - name: Build and post changelog
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const COMMENT_MARKER = '<!-- pot-changelog-bot -->';
+            const BODY_START = '<!-- pot-changelog-closes:start -->';
+            const BODY_END = '<!-- pot-changelog-closes:end -->';
+
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const groups = {
+              feat:    { title: 'Features',  entries: [] },
+              balance: { title: 'Balance',   entries: [] },
+              fix:     { title: 'Bug Fixes', entries: [] },
+            };
+            const closes = new Set();
+
+            // type(scope)?: subject — only the first line of each commit message
+            const re = /^(feat|balance|fix)(?:\(([^)]*)\))?!?:\s*(.+)$/i;
+
+            for (const c of commits) {
+              const firstLine = (c.commit.message || '').split(/\r?\n/)[0].trim();
+              const m = firstLine.match(re);
+              if (!m) continue;
+
+              const type = m[1].toLowerCase();
+              const scope = (m[2] || '').trim();
+              const subject = m[3].trim();
+
+              const scopeIssues = [...scope.matchAll(/#(\d+)/g)].map(x => Number(x[1]));
+              for (const n of scopeIssues) closes.add(n);
+
+              const linked = scopeIssues.length
+                ? ' (' + scopeIssues.map(n => `#${n}`).join(', ') + ')'
+                : '';
+              groups[type].entries.push(`- ${subject}${linked} (${c.sha.slice(0, 7)})`);
+            }
+
+            const sections = [];
+            for (const key of ['feat', 'balance', 'fix']) {
+              const g = groups[key];
+              if (g.entries.length) sections.push(`### ${g.title}\n\n${g.entries.join('\n')}`);
+            }
+
+            const closesList = [...closes].sort((a, b) => a - b);
+            const closesSection = closesList.length
+              ? `### Closes\n\n${closesList.map(n => `- Closes #${n}`).join('\n')}`
+              : '';
+
+            const body = [
+              COMMENT_MARKER,
+              '## Changelog',
+              sections.length ? sections.join('\n\n') : '_No conventional commits (`feat:`, `balance:`, `fix:`) found in this PR._',
+              closesSection,
+            ].filter(Boolean).join('\n\n');
+
+            // Sticky comment: find existing bot comment and update, otherwise create.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+            }
+
+            // Update the PR body's managed section so GitHub auto-closes the linked issues on merge.
+            const currentBody = pr.body || '';
+            const managed = closesList.length
+              ? `${BODY_START}\n${closesList.map(n => `Closes #${n}`).join('\n')}\n${BODY_END}`
+              : `${BODY_START}\n${BODY_END}`;
+
+            const sectionRe = new RegExp(`${BODY_START}[\\s\\S]*?${BODY_END}`);
+            let newBody;
+            if (sectionRe.test(currentBody)) {
+              newBody = currentBody.replace(sectionRe, managed);
+            } else if (closesList.length) {
+              newBody = currentBody ? `${currentBody}\n\n${managed}` : managed;
+            } else {
+              newBody = currentBody;
+            }
+
+            if (newBody !== currentBody) {
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, body: newBody });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -338,4 +338,7 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 .idea/
+
+# Agents
 .claude/
+.junie/

--- a/Common/ItemDropping/BossLootExplosion.cs
+++ b/Common/ItemDropping/BossLootExplosion.cs
@@ -118,6 +118,9 @@ internal sealed class BossLootExplosion : GlobalNPC
 		return SubworldSystem.Current is BossDomainSubworld or MappingWorld;
 	}
 
+	private static readonly int[] EaterOfWorldsSegments = [NPCID.EaterofWorldsHead, NPCID.EaterofWorldsBody, NPCID.EaterofWorldsTail];
+	private static readonly int[] DestroyerSegments = [NPCID.TheDestroyer, NPCID.TheDestroyerBody, NPCID.TheDestroyerTail];
+
 	private static bool ShouldCountBossKill(NPC npc)
 	{
 		return npc.type switch
@@ -125,8 +128,35 @@ internal sealed class BossLootExplosion : GlobalNPC
 			NPCID.Retinazer => !NPC.AnyNPCs(NPCID.Spazmatism),
 			NPCID.Spazmatism => !NPC.AnyNPCs(NPCID.Retinazer),
 			NPCID.GolemFistLeft or NPCID.GolemFistRight or NPCID.GolemHead or NPCID.GolemHeadFree => false,
+			NPCID.EaterofWorldsHead or NPCID.EaterofWorldsBody or NPCID.EaterofWorldsTail => IsLastWormSegment(npc, EaterOfWorldsSegments),
+			NPCID.TheDestroyer or NPCID.TheDestroyerBody or NPCID.TheDestroyerTail => IsLastWormSegment(npc, DestroyerSegments),
 			_ => true,
 		};
+	}
+
+	// Worm bosses are made of many segment NPCs that each fire OnKill. Only burst on the final segment so EoW/Destroyer
+	// don't drop a segment-count's worth of loot. The dying NPC may still appear in Main.npc here, so exclude by whoAmI.
+	private static bool IsLastWormSegment(NPC dying, int[] segmentTypes)
+	{
+		for (int i = 0; i < Main.maxNPCs; i++)
+		{
+			NPC other = Main.npc[i];
+
+			if (!other.active || other.whoAmI == dying.whoAmI)
+			{
+				continue;
+			}
+
+			for (int j = 0; j < segmentTypes.Length; j++)
+			{
+				if (other.type == segmentTypes[j])
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
 	}
 
 	private static int ComputeBurstCount(int areaLevel)

--- a/Common/ItemDropping/BossLootExplosion.cs
+++ b/Common/ItemDropping/BossLootExplosion.cs
@@ -118,9 +118,6 @@ internal sealed class BossLootExplosion : GlobalNPC
 		return SubworldSystem.Current is BossDomainSubworld or MappingWorld;
 	}
 
-	private static readonly int[] EaterOfWorldsSegments = [NPCID.EaterofWorldsHead, NPCID.EaterofWorldsBody, NPCID.EaterofWorldsTail];
-	private static readonly int[] DestroyerSegments = [NPCID.TheDestroyer, NPCID.TheDestroyerBody, NPCID.TheDestroyerTail];
-
 	private static bool ShouldCountBossKill(NPC npc)
 	{
 		return npc.type switch
@@ -128,35 +125,10 @@ internal sealed class BossLootExplosion : GlobalNPC
 			NPCID.Retinazer => !NPC.AnyNPCs(NPCID.Spazmatism),
 			NPCID.Spazmatism => !NPC.AnyNPCs(NPCID.Retinazer),
 			NPCID.GolemFistLeft or NPCID.GolemFistRight or NPCID.GolemHead or NPCID.GolemHeadFree => false,
-			NPCID.EaterofWorldsHead or NPCID.EaterofWorldsBody or NPCID.EaterofWorldsTail => IsLastWormSegment(npc, EaterOfWorldsSegments),
-			NPCID.TheDestroyer or NPCID.TheDestroyerBody or NPCID.TheDestroyerTail => IsLastWormSegment(npc, DestroyerSegments),
+			NPCID.EaterofWorldsBody or NPCID.EaterofWorldsTail => false,
+			NPCID.TheDestroyerBody or NPCID.TheDestroyerTail => false,
 			_ => true,
 		};
-	}
-
-	// Worm bosses are made of many segment NPCs that each fire OnKill. Only burst on the final segment so EoW/Destroyer
-	// don't drop a segment-count's worth of loot. The dying NPC may still appear in Main.npc here, so exclude by whoAmI.
-	private static bool IsLastWormSegment(NPC dying, int[] segmentTypes)
-	{
-		for (int i = 0; i < Main.maxNPCs; i++)
-		{
-			NPC other = Main.npc[i];
-
-			if (!other.active || other.whoAmI == dying.whoAmI)
-			{
-				continue;
-			}
-
-			for (int j = 0; j < segmentTypes.Length; j++)
-			{
-				if (other.type == segmentTypes[j])
-				{
-					return false;
-				}
-			}
-		}
-
-		return true;
 	}
 
 	private static int ComputeBurstCount(int areaLevel)


### PR DESCRIPTION
### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- add automatic changelog generation inside PRs
- add original pull request comment updating to changelog generation

### Bug Fixes

- Loot explosions no longer count segment boss NPCs
<!-- pot-changelog-desc:end -->
### Comments


<!-- pot-changelog-closes:start -->
Closes #2021
<!-- pot-changelog-closes:end -->