### PR TITLE
Map persistence pass

### DIFF
--- a/Common/Subworlds/MappingWorld.cs
+++ b/Common/Subworlds/MappingWorld.cs
@@ -49,6 +49,18 @@ public class PersistentData
 			BossDowned = true;
 		}
 	}
+
+	/// <summary> Persists this instance into the given tag. Subclasses should override and call base. </summary>
+	public virtual void Save(TagCompound tag)
+	{
+		tag[nameof(BossDowned)] = BossDowned;
+	}
+
+	/// <summary> Restores this instance from the given tag. Subclasses should override and call base. </summary>
+	public virtual void Load(TagCompound tag)
+	{
+		BossDowned = tag.GetBool(nameof(BossDowned));
+	}
 }
 
 /// <summary>
@@ -83,6 +95,16 @@ public abstract class MappingWorld : Subworld
 			tag.Add("lastPath", LastSubworldSavePath);
 			tag.Add("timesKeys", (string[])[.. TimesEnteredByDomain.Keys]);
 			tag.Add("timesValues", (int[])[.. TimesEnteredByDomain.Values]);
+
+			// In a subworld, persist that subworld's PersistentData (e.g. BossDowned) into its own .twld
+			// so it survives reloads, subserver restarts, and the CachedBossesDowned overwrite that
+			// happens in ReadCopiedMainWorldData.
+			if (SubworldSystem.Current is { } current && PersistentDomainInfo.TryGetValue(current.FullName, out PersistentData? data))
+			{
+				TagCompound persistTag = [];
+				data.Save(persistTag);
+				tag.Add("persistentData", persistTag);
+			}
 		}
 
 		public override void LoadWorldData(TagCompound tag)
@@ -104,6 +126,16 @@ public abstract class MappingWorld : Subworld
 					TimesEnteredByDomain.Add(times[i], values[i]);
 				}
 			}
+
+			// Subworld-side: restore this subworld's PersistentData from its .twld (must come before
+			// ReadCopiedMainWorldData runs, which is the case because LoadWorldData is part of the
+			// world load and ReadCopiedMainWorldData runs afterwards).
+			if (SubworldSystem.Current is { } current && tag.TryGet("persistentData", out TagCompound persistTag))
+			{
+				PersistentData data = new();
+				data.Load(persistTag);
+				PersistentDomainInfo[current.FullName] = data;
+			}
 		}
 	}
 
@@ -123,18 +155,18 @@ public abstract class MappingWorld : Subworld
 
 	internal class SetLastSubworldPathHandler : Handler
 	{
-		public static void Send(string value)
+		public static void Send(string value, string fullName)
 		{
 			ModPacket packet = Networking.GetPacket<SetLastSubworldPathHandler>();
 			packet.Write(value);
+			packet.Write(fullName);
 			packet.Send();
 		}
 
 		internal override void Receive(BinaryReader reader, byte sender)
 		{
-			string value = reader.ReadString();
-
-			LastSubworldSavePath = value;
+			LastSubworldSavePath = reader.ReadString();
+			LastSubworldFullName = reader.ReadString();
 		}
 	}
 
@@ -199,6 +231,12 @@ public abstract class MappingWorld : Subworld
 	public static int MapTier = 0;
 
 	internal static string? LastSubworldSavePath { get; private set; }
+
+	/// <summary>
+	/// The <see cref="ModType.FullName"/> of the subworld whose save path is held in <see cref="LastSubworldSavePath"/>.
+	/// Tracked so we can stop the corresponding subserver before deleting that file.
+	/// </summary>
+	internal static string? LastSubworldFullName { get; private set; }
 
 	private static Point16 ActiveMapDevicePosition = new(-1, -1);
 	private static bool CloseActiveMapDeviceAfterFailedRun;
@@ -319,6 +357,7 @@ public abstract class MappingWorld : Subworld
 		if (SubworldSystem.Current is not null)
 		{
 			LastSubworldSavePath = TryGetCurrentPath();
+			LastSubworldFullName = SubworldSystem.Current.FullName;
 
 			if (!TimesEnteredByDomain.TryAdd(FullName, 1))
 			{
@@ -329,6 +368,7 @@ public abstract class MappingWorld : Subworld
 			{
 				ModPacket packet = Networking.GetPacket<SetLastSubworldPathHandler>();
 				packet.Write(LastSubworldSavePath!);
+				packet.Write(LastSubworldFullName!);
 				Networking.SendPacketToMainServer(packet);
 			}
 		}
@@ -496,24 +536,59 @@ public abstract class MappingWorld : Subworld
 
 	internal static void DeleteSavedSubworld(Subworld? subworld = null)
 	{
-		if (Main.netMode != NetmodeID.MultiplayerClient)
-		{
-			if (LastSubworldSavePath is { Length: > 0 } path)
-			{
-				DeleteSubworldFiles(path);
-			}
-
-			if (subworld is not null && TryGetSavePath(subworld) is { Length: > 0 } destinationPath && destinationPath != LastSubworldSavePath)
-			{
-				DeleteSubworldFiles(destinationPath);
-			}
-		}
-		else if (Main.netMode == NetmodeID.MultiplayerClient)
+		if (Main.netMode == NetmodeID.MultiplayerClient)
 		{
 			DeleteOnServerHandler.Send();
+			LastSubworldSavePath = null;
+			LastSubworldFullName = null;
+			return;
+		}
+
+		// In MP, the subserver process holds the .wld file open and silent IO failures here are how the
+		// "boss didn't reset / spawn point in arena / stale switches" bugs sneak in. Stop any subserver
+		// that could be holding the destination and the previously-entered subworld before deleting.
+		if (Main.netMode == NetmodeID.Server)
+		{
+			TryStopSubserver(subworld?.FullName);
+			TryStopSubserver(LastSubworldFullName);
+		}
+
+		if (LastSubworldSavePath is { Length: > 0 } path)
+		{
+			DeleteSubworldFiles(path);
+		}
+
+		if (subworld is not null && TryGetSavePath(subworld) is { Length: > 0 } destinationPath && destinationPath != LastSubworldSavePath)
+		{
+			DeleteSubworldFiles(destinationPath);
 		}
 
 		LastSubworldSavePath = null;
+		LastSubworldFullName = null;
+	}
+
+	private static void TryStopSubserver(string? fullName)
+	{
+		if (fullName is null or { Length: 0 })
+		{
+			return;
+		}
+
+		int index = SubworldSystem.GetIndex(fullName);
+
+		if (index < 0)
+		{
+			return;
+		}
+
+		try
+		{
+			SubworldSystem.StopSubserver(index);
+		}
+		catch (Exception ex)
+		{
+			PoTMod.Instance.Logger.Warn($"[DeleteSavedSubworld] Failed to stop subserver for '{fullName}'. Subsequent file deletion may fail. {ex.Message}");
+		}
 	}
 
 	private static string? TryGetSavePath(Subworld subworld)
@@ -543,28 +618,38 @@ public abstract class MappingWorld : Subworld
 
 	private static void DeleteSubworldFiles(string path)
 	{
-		DeleteSubworldFile(path);
-		DeleteSubworldFile(path + ".bak");
-		DeleteSubworldFile(path + ".bak2");
-		DeleteSubworldFile(Path.ChangeExtension(path, ".twld"));
-		DeleteSubworldFile(Path.ChangeExtension(path, ".twld") + ".bak");
-		DeleteSubworldFile(Path.ChangeExtension(path, ".twld") + ".bak2");
+		bool allOk = true;
+		allOk &= DeleteSubworldFile(path);
+		allOk &= DeleteSubworldFile(path + ".bak");
+		allOk &= DeleteSubworldFile(path + ".bak2");
+		allOk &= DeleteSubworldFile(Path.ChangeExtension(path, ".twld"));
+		allOk &= DeleteSubworldFile(Path.ChangeExtension(path, ".twld") + ".bak");
+		allOk &= DeleteSubworldFile(Path.ChangeExtension(path, ".twld") + ".bak2");
+
+		if (!allOk)
+		{
+			// Loud, single-line summary so a stuck subserver is obvious in logs instead of silently
+			// causing the next entry to load a stale world.
+			PoTMod.Instance.Logger.Error($"[DeleteSavedSubworld] One or more subworld files at '{path}' could not be deleted. Next entry will load stale world data.");
+		}
 	}
 
-	private static void DeleteSubworldFile(string path)
+	private static bool DeleteSubworldFile(string path)
 	{
 		if (!File.Exists(path))
 		{
-			return;
+			return true;
 		}
 
 		try
 		{
 			File.Delete(path);
+			return true;
 		}
-		catch
+		catch (Exception ex)
 		{
-			PoTMod.Instance.Logger.Error($"[DeleteSavedSubworld] Failed to delete saved subworld file at '{path}'.");
+			PoTMod.Instance.Logger.Error($"[DeleteSavedSubworld] Failed to delete '{path}': {ex.GetType().Name}: {ex.Message}");
+			return false;
 		}
 	}
 

--- a/Common/Subworlds/MappingWorld.cs
+++ b/Common/Subworlds/MappingWorld.cs
@@ -30,8 +30,10 @@ namespace PathOfTerraria.Common.Subworlds;
 /// but it is a class so it can be inherited to add arbitrary additional data.<br/><b>Most</b> of the code relating to this will not run on multiplayer clients,
 /// so be careful.
 /// </summary>
-public class PersistentData
+public class PersistentData : TagSerializable
 {
+	public static readonly Func<TagCompound, PersistentData> DESERIALIZER = Load;
+
 	public bool BossDowned = false;
 
 	/// <summary>
@@ -50,16 +52,20 @@ public class PersistentData
 		}
 	}
 
-	/// <summary> Persists this instance into the given tag. Subclasses should override and call base. </summary>
-	public virtual void Save(TagCompound tag)
+	public TagCompound SerializeData()
 	{
-		tag[nameof(BossDowned)] = BossDowned;
+		return new TagCompound
+		{
+			[nameof(BossDowned)] = BossDowned
+		};
 	}
 
-	/// <summary> Restores this instance from the given tag. Subclasses should override and call base. </summary>
-	public virtual void Load(TagCompound tag)
+	public static PersistentData Load(TagCompound tag)
 	{
-		BossDowned = tag.GetBool(nameof(BossDowned));
+		return new PersistentData
+		{
+			BossDowned = tag.GetBool(nameof(BossDowned))
+		};
 	}
 }
 
@@ -101,9 +107,7 @@ public abstract class MappingWorld : Subworld
 			// happens in ReadCopiedMainWorldData.
 			if (SubworldSystem.Current is { } current && PersistentDomainInfo.TryGetValue(current.FullName, out PersistentData? data))
 			{
-				TagCompound persistTag = [];
-				data.Save(persistTag);
-				tag.Add("persistentData", persistTag);
+				tag.Add("persistentData", data);
 			}
 		}
 
@@ -130,10 +134,8 @@ public abstract class MappingWorld : Subworld
 			// Subworld-side: restore this subworld's PersistentData from its .twld (must come before
 			// ReadCopiedMainWorldData runs, which is the case because LoadWorldData is part of the
 			// world load and ReadCopiedMainWorldData runs afterwards).
-			if (SubworldSystem.Current is { } current && tag.TryGet("persistentData", out TagCompound persistTag))
+			if (SubworldSystem.Current is { } current && tag.TryGet("persistentData", out PersistentData data))
 			{
-				PersistentData data = new();
-				data.Load(persistTag);
 				PersistentDomainInfo[current.FullName] = data;
 			}
 		}

--- a/Common/Subworlds/Tools/RoomDatabase.cs
+++ b/Common/Subworlds/Tools/RoomDatabase.cs
@@ -72,6 +72,14 @@ internal class RoomDatabase : ModSystem
 		AddGolemDatabase();
 	}
 
+	public override void OnWorldUnload()
+	{
+		// Timers are populated by the active subworld's worldgen and reference tile positions in that
+		// world. When the world unloads, drop any that haven't fired yet — otherwise they'll fire on
+		// the next subworld at stale coordinates and re-trigger pulled levers / spent traps.
+		_timers.Clear();
+	}
+
 	private void AddGolemDatabase()
 	{
 		DataByRoomIndex.Add(7, MakeRoom(true, 75, new Point(15, 0), 

--- a/Content/Swamp/SwampArea.cs
+++ b/Content/Swamp/SwampArea.cs
@@ -60,7 +60,6 @@ internal class SwampArea : MappingWorld, IExplorationWorld
 		Main.worldSurface = WaterY + 10;
 		Main.rockLayer = WaterY + 40;
 
-		setBossSpawn = false;
 		spawnedTemporaryContent = false;
 		EncounterLocations.Clear();
 		LeftSpawn = Random.NextBool(2);
@@ -789,6 +788,15 @@ internal class SwampArea : MappingWorld, IExplorationWorld
 		}
 
 		return yPerX;
+	}
+
+	public override void OnEnter()
+	{
+		base.OnEnter();
+
+		// Reset per-entry gate so a re-entered/loaded world re-evaluates the arena spawn override
+		// instead of inheriting whatever value the static held in this process.
+		setBossSpawn = false;
 	}
 
 	public override void Update()

--- a/Content/Swamp/SwampSystem.cs
+++ b/Content/Swamp/SwampSystem.cs
@@ -1,6 +1,7 @@
 ﻿using PathOfTerraria.Content.Swamp;
 using SubworldLibrary;
 using System.IO;
+using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Swamp;
 
@@ -12,6 +13,24 @@ internal class SwampSystem : ModSystem
 		{
 			tileColor = new Color(50, 70, 75);
 			backgroundColor = new Color(100, 130, 135);
+		}
+	}
+
+	public override void SaveWorldData(TagCompound tag)
+	{
+		// Persist LeftSpawn into the swamp's own .twld so ArenaMiddleX is correct after process
+		// restart (otherwise the static would default to false and arena geometry flips).
+		if (SubworldSystem.Current is SwampArea)
+		{
+			tag["LeftSpawn"] = SwampArea.LeftSpawn;
+		}
+	}
+
+	public override void LoadWorldData(TagCompound tag)
+	{
+		if (SubworldSystem.Current is SwampArea && tag.ContainsKey("LeftSpawn"))
+		{
+			SwampArea.LeftSpawn = tag.GetBool("LeftSpawn");
 		}
 	}
 


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work



<!-- pot-changelog-desc:start -->
### Bug Fixes

- Traps not being reset correctly on subworlds unloading
- various issues around swamp subworld loading and saving spawn point incorrectly
- Various fixes around persistening boss downed state to prevent abuse of killing boss over and over without additional maps being used
<!-- pot-changelog-desc:end -->
### Comments
* This is a Opus 4.7 Max effort pass against the existing map persistence bugs we were having. Hopefully diving deeper than before and trying to remove any of the lingering issues