### PR TITLE
fix: LifeRegenCountPassive applying doubled life regen

### DIFF
--- a/Content/Passives/Misc/LifeRegenPassives.cs
+++ b/Content/Passives/Misc/LifeRegenPassives.cs
@@ -21,7 +21,7 @@ internal class LifeRegenCountPassive : Passive
 {
 	public override void BuffPlayer(Player player)
 	{
-		player.lifeRegen += (int)(Value * 2 * Level);
+		player.lifeRegen += (int)(Value * Level);
 	}
 }
 


### PR DESCRIPTION
﻿### Link Issues
Resolves:

### Description of Work
Fixed an issue where LifeRegenCountPassive applied double the intended life regeneration value
The localization states `+{0} life regenerated per second`, for example +2, but the actual code multiplied the value by 2 again
As a result, a passive displaying +2 life regen was actually granting +4 life regen
### Comments
