### PR TITLE
fix(#2037): Fixes a few annoying issues with the goblin surveyor spaw…

### DIFF
--- a/Common/Systems/Questing/Quests/MainPath/WizardStartQuest.cs
+++ b/Common/Systems/Questing/Quests/MainPath/WizardStartQuest.cs
@@ -16,6 +16,8 @@ namespace PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 
 internal class WizardStartQuest : Quest
 {
+	public const string SurveyorStepId = "KillSurveyor";
+
 	public override QuestTypes QuestType => QuestTypes.MainStoryQuestAct1;
 	public override int NPCQuestGiver => ModContent.NPCType<WizardNPC>();
 
@@ -57,7 +59,7 @@ internal class WizardStartQuest : Quest
 				RavencrestSystem.UpgradeBuilding("Library");
 				return true;
 			}),
-			new KillCount("KillSurveyor", ModContent.NPCType<TownScoutNPC>(), 1, this.GetLocalization("KillSurveyor")),
+			new KillCount(SurveyorStepId, ModContent.NPCType<TownScoutNPC>(), 1, this.GetLocalization(SurveyorStepId)),
 			new InteractWithNPC("End", ModContent.NPCType<WizardNPC>(), Language.GetText("Mods.PathOfTerraria.NPCs.WizardNPC.Dialogue.Quest"),
 			Language.GetText("Mods.PathOfTerraria.NPCs.WizardNPC.Dialogue.End")) { CountsAsCompletedOnMarker = true }, 
 		];

--- a/Content/NPCs/Town/TownScoutNPC.cs
+++ b/Content/NPCs/Town/TownScoutNPC.cs
@@ -13,6 +13,8 @@ namespace PathOfTerraria.Content.NPCs.Town;
 
 public sealed class TownScoutNPC : ModNPC
 {
+	private const string SurveyorQuestStep = "KillSurveyor";
+
 	private bool HasPlayerBeenNear
 	{
 		get => NPC.ai[0] == 1;
@@ -46,6 +48,18 @@ public sealed class TownScoutNPC : ModNPC
 
 	public override bool PreAI()
 	{
+		if (Main.netMode != NetmodeID.MultiplayerClient && !AnyPlayerCanEncounterSurveyor())
+		{
+			NPC.active = false;
+
+			if (Main.netMode == NetmodeID.Server)
+			{
+				NetMessage.SendData(MessageID.SyncNPC, number: NPC.whoAmI);
+			}
+
+			return false;
+		}
+
 		if (!HasPlayerBeenNear)
 		{
 			foreach (Player plr in Main.ActivePlayers)
@@ -113,39 +127,50 @@ public sealed class TownScoutNPC : ModNPC
 
 	public override float SpawnChance(NPCSpawnInfo spawnInfo)
 	{
-		bool anyHealthyPlayer = true;
-		bool forceQuestSpawn = false;
+		float questChance = GetQuestSpawnChance();
 
-		foreach (Player plr in Main.ActivePlayers)
-		{
-			QuestModPlayer questPlayer = plr.GetModPlayer<QuestModPlayer>();
-
-			if (questPlayer.QuestsByName.TryGetValue(ModContent.GetInstance<WizardStartQuest>().FullName, out Quest quest)
-				&& quest.Active
-				&& quest.ActiveStep.Id == "Start")
-			{
-				forceQuestSpawn = true;
-			}
-
-			if (plr.ConsumedLifeCrystals > 5)
-			{
-				anyHealthyPlayer = true;
-			}
-		}
-
-		if (!anyHealthyPlayer && !forceQuestSpawn)
+		if (questChance <= 0)
 		{
 			return 0;
 		}
 		
-		float chance = forceQuestSpawn ? 100f : (NPC.downedGoblins ? 0.1f : 5);
 		bool spawnedScout = ModContent.GetInstance<RavencrestSystem>().SpawnedScout;
 
-		return SubworldSystem.Current is RavencrestSubworld && spawnInfo.SpawnTileX < 180 && !spawnedScout ? chance : 0;
+		return SubworldSystem.Current is RavencrestSubworld && spawnInfo.SpawnTileX < 180 && !spawnedScout ? questChance : 0;
 	}
 
 	public override bool CheckActive()
 	{
 		return false;
+	}
+
+	private static bool AnyPlayerCanEncounterSurveyor()
+	{
+		return GetQuestSpawnChance() > 0;
+	}
+
+	private static float GetQuestSpawnChance()
+	{
+		string questName = ModContent.GetInstance<WizardStartQuest>().FullName;
+		bool questCompleted = false;
+
+		foreach (Player plr in Main.ActivePlayers)
+		{
+			QuestModPlayer questPlayer = plr.GetModPlayer<QuestModPlayer>();
+
+			if (!questPlayer.QuestsByName.TryGetValue(questName, out Quest quest))
+			{
+				continue;
+			}
+
+			if (quest.Active && quest.ActiveStep.Id == SurveyorQuestStep)
+			{
+				return 100f;
+			}
+
+			questCompleted |= quest.Completed;
+		}
+
+		return questCompleted ? (NPC.downedGoblins ? 0.1f : 5) : 0;
 	}
 }

--- a/Content/NPCs/Town/TownScoutNPC.cs
+++ b/Content/NPCs/Town/TownScoutNPC.cs
@@ -13,8 +13,6 @@ namespace PathOfTerraria.Content.NPCs.Town;
 
 public sealed class TownScoutNPC : ModNPC
 {
-	private const string SurveyorQuestStep = "KillSurveyor";
-
 	private bool HasPlayerBeenNear
 	{
 		get => NPC.ai[0] == 1;
@@ -163,7 +161,7 @@ public sealed class TownScoutNPC : ModNPC
 				continue;
 			}
 
-			if (quest.Active && quest.ActiveStep.Id == SurveyorQuestStep)
+			if (quest.Active && quest.ActiveStep.Id == WizardStartQuest.SurveyorStepId)
 			{
 				return 100f;
 			}


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Bug Fixes

- Fixes a few annoying issues with the goblin surveyor spawning and timing
<!-- pot-changelog-desc:end -->
### Comments
- It now only spawns when a player is actively on the KillSurveyor quest step.
- Removed the accidental early spawn paths: the "Start" step force-spawn and the always-true life crystal gate.
- Added server-side cleanup so any stale Surveyor that exists before the proper quest step despawns instead of hanging around.

<!-- pot-changelog-closes:start -->
Closes #2037
<!-- pot-changelog-closes:end -->