### PR TITLE
fix: Currency shards now only reroll affixes, not implicits, as origi…

### DIFF
--- a/Content/Items/Currency/GlimmeringShard.cs
+++ b/Content/Items/Currency/GlimmeringShard.cs
@@ -33,6 +33,6 @@ public class GlimmeringShard : CurrencyShard
 
 	public override void ApplyToItem(Item slotItem)
 	{
-		PoTItemHelper.Roll(slotItem, slotItem.GetInstanceData().RealLevel);
+		PoTItemHelper.RerollAffixes(slotItem, slotItem.GetInstanceData().RealLevel);
 	}
 }

--- a/Content/Items/Currency/LimpidShard.cs
+++ b/Content/Items/Currency/LimpidShard.cs
@@ -42,7 +42,6 @@ public class LimpidShard : CurrencyShard
 	{
 		PoTInstanceItemData data = slotItem.GetInstanceData();
 		data.Rarity = ItemRarity.Normal;
-		data.Affixes = [];
-		PoTItemHelper.Roll(slotItem, data.RealLevel);
+		PoTItemHelper.RerollAffixes(slotItem, data.RealLevel);
 	}
 }

--- a/Content/Items/Currency/MysticShard.cs
+++ b/Content/Items/Currency/MysticShard.cs
@@ -44,7 +44,6 @@ public class MysticShard : CurrencyShard
 	{
 		PoTInstanceItemData data = slotItem.GetInstanceData();
 		data.Rarity = ItemRarity.Rare;
-		data.Affixes = [];
-		PoTItemHelper.Roll(slotItem, data.RealLevel);
+		PoTItemHelper.RerollAffixes(slotItem, data.RealLevel);
 	}
 }

--- a/Content/Items/Currency/SeveranceShard.cs
+++ b/Content/Items/Currency/SeveranceShard.cs
@@ -34,7 +34,7 @@ public class SeveranceShard : CurrencyShard
 			return false;
 		}
 
-		if (data.Affixes.Count == 0)
+		if (!PoTItemHelper.HasNonImplicitAffixes(slotItem))
 		{
 			failKey = "NoAffixes";
 			return false;
@@ -51,7 +51,6 @@ public class SeveranceShard : CurrencyShard
 
 	public override void ApplyToItem(Item slotItem)
 	{
-		PoTInstanceItemData data = slotItem.GetInstanceData();
-		data.Affixes.RemoveAt(Main.rand.Next(data.Affixes.Count));
+		PoTItemHelper.RemoveRandomNonImplicitAffix(slotItem);
 	}
 }

--- a/Content/Items/Currency/ShiftingShard.cs
+++ b/Content/Items/Currency/ShiftingShard.cs
@@ -44,7 +44,6 @@ public class ShiftingShard : CurrencyShard
 	public override void ApplyToItem(Item slotItem)
 	{
 		PoTInstanceItemData data = slotItem.GetInstanceData();
-		data.Affixes = [];
-		PoTItemHelper.Roll(slotItem, data.RealLevel);
+		PoTItemHelper.RerollAffixes(slotItem, data.RealLevel);
 	}
 }

--- a/Content/Items/Currency/UnfoldingShard.cs
+++ b/Content/Items/Currency/UnfoldingShard.cs
@@ -41,6 +41,6 @@ public class UnfoldingShard : CurrencyShard
 	{
 		PoTInstanceItemData data = slotItem.GetInstanceData();
 		data.Rarity = ItemRarity.Magic;
-		PoTItemHelper.Roll(slotItem, data.RealLevel);
+		PoTItemHelper.RerollAffixes(slotItem, data.RealLevel);
 	}
 }

--- a/Core/Items/PoTItemHelper.cs
+++ b/Core/Items/PoTItemHelper.cs
@@ -74,6 +74,17 @@ public static class PoTItemHelper
 		data.NameAffix = GenerateNameAffixes.Invoke(item);
 	}
 
+	public static void RerollAffixes(Item item, int itemLevel)
+	{
+		PoTInstanceItemData data = item.GetInstanceData();
+
+		SetItemLevel.Invoke(item, itemLevel);
+
+		RerollNonImplicitAffixes(item);
+		PostRoll.Invoke(item);
+		data.NameAffix = GenerateNameAffixes.Invoke(item);
+	}
+
 	private static void RollAffixes(Item item)
 	{
 		PoTInstanceItemData data = item.GetInstanceData();
@@ -82,6 +93,21 @@ public static class PoTItemHelper
 		data.Affixes.AddRange(GenerateImplicits.Invoke(item));
 		data.ImplicitCount = data.Affixes.Count;
 
+		RollNonImplicitAffixes(item, data);
+	}
+
+	private static void RerollNonImplicitAffixes(Item item)
+	{
+		PoTInstanceItemData data = item.GetInstanceData();
+
+		data.Affixes.RemoveAll(affix => !affix.IsImplicit);
+		data.ImplicitCount = data.Affixes.Count;
+
+		RollNonImplicitAffixes(item, data);
+	}
+
+	private static void RollNonImplicitAffixes(Item item, PoTInstanceItemData data)
+	{
 		int affixesToRoll = GetAffixCount(item);
 		for (int i = 0; i < affixesToRoll; i++)
 		{
@@ -96,6 +122,34 @@ public static class PoTItemHelper
 		}
 
 		data.Affixes.AddRange(uniqueItemAffixes);
+	}
+
+	public static bool RemoveRandomNonImplicitAffix(Item item)
+	{
+		PoTInstanceItemData data = item.GetInstanceData();
+		int nonImplicitAffixCount = data.Affixes.Count(affix => !affix.IsImplicit);
+
+		if (nonImplicitAffixCount == 0)
+		{
+			return false;
+		}
+
+		int selectedAffixIndex = Main.rand.Next(nonImplicitAffixCount);
+		for (int i = 0; i < data.Affixes.Count; i++)
+		{
+			if (data.Affixes[i].IsImplicit)
+			{
+				continue;
+			}
+
+			if (selectedAffixIndex-- == 0)
+			{
+				data.Affixes.RemoveAt(i);
+				return true;
+			}
+		}
+
+		return false;
 	}
 	
 	/// <summary>
@@ -200,6 +254,11 @@ public static class PoTItemHelper
 		PoTInstanceItemData data = item.GetInstanceData();
 		int nonImplicitAffixCount = data.Affixes.Count(affix => !affix.IsImplicit);
 		return nonImplicitAffixCount >= GetMaxAffixCounts(data.Rarity);
+	}
+
+	public static bool HasNonImplicitAffixes(Item item)
+	{
+		return item.GetInstanceData().Affixes.Any(affix => !affix.IsImplicit);
 	}
 
 	public static void SetMouseItemToHeldItem(Player player)


### PR DESCRIPTION
…nally intended

﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Bug Fixes

- Currency shards now only reroll affixes, not implicits, as originally intended
<!-- pot-changelog-desc:end -->
### Comments
* New function in item helper to assist with this for any future needs