### PR TITLE
feat(#2020): Add item tooltip to map after map is opened to remember …

### DIFF
--- a/Common/UI/Elements/UIImageItemSlot.cs
+++ b/Common/UI/Elements/UIImageItemSlot.cs
@@ -278,6 +278,8 @@ public class UIImageItemSlot
 
 		if (IsLocked?.Invoke(this) == true)
 		{
+			UpdateHoverTooltip();
+			Main.LocalPlayer.mouseInterface = true;
 			return;
 		}
 
@@ -308,14 +310,21 @@ public class UIImageItemSlot
 			OnModifyItem?.Invoke(this, oldItem, item);
 		}
 
-		if (HoverText is { } hoverText)
-		{
-			Main.hoverItemName = hoverText.Arg0 != null ? Language.GetTextValue(hoverText.Key, hoverText.Arg0) : Language.GetTextValue(hoverText.Key);
-			Main.HoverItem = Item.Clone();
-			Main.HoverItem.tooltipContext = Context;
-		}
+		UpdateHoverTooltip();
 
 		Main.LocalPlayer.mouseInterface = true;
+	}
+
+	private void UpdateHoverTooltip()
+	{
+		if (HoverText is not { } hoverText)
+		{
+			return;
+		}
+
+		Main.hoverItemName = hoverText.Arg0 != null ? Language.GetTextValue(hoverText.Key, hoverText.Arg0) : Language.GetTextValue(hoverText.Key);
+		Main.HoverItem = Item.Clone();
+		Main.HoverItem.tooltipContext = Context;
 	}
 
 	// Because we can't access the texture being used by the UIImage.


### PR DESCRIPTION
…what was in there

﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- Add item tooltip to map after map is opened to remember what was in there
<!-- pot-changelog-desc:end -->
### Comments


<!-- pot-changelog-closes:start -->
Closes #2020
<!-- pot-changelog-closes:end -->