### PR TITLE
feat: make level 1-10 faster progression

### DIFF
--- a/Common/Systems/ModPlayers/ExpModPlayer.cs
+++ b/Common/Systems/ModPlayers/ExpModPlayer.cs
@@ -14,7 +14,27 @@ public class ExpModPlayer : ModPlayer
 
 	public int Exp;
 
-	public int NextLevel => Level == 100 ? 1 : Level * 250 + (int)(80 * Math.Pow(2, 1 + Level * 0.2f));
+	public int NextLevel
+	{
+		get
+		{
+			if (Level == 100)
+			{
+				return 1;
+			}
+
+			int baseXp = Level * 250 + (int)(80 * Math.Pow(2, 1 + Level * 0.2f));
+
+			if (Level <= 10)
+			{
+				float progress = (Level - 1) / 9f;
+				float multiplier = MathHelper.Lerp(0.6f, 0.95f, progress);
+				return (int)(baseXp * multiplier);
+			}
+
+			return baseXp;
+		}
+	}
 
 	public override void PreUpdate()
 	{


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- make level 1-10 faster progression
<!-- pot-changelog-desc:end -->
### Comments
Levels 1-10 now use the same base XP formula with a tapering multiplier from 60% at level 1 to 95% at level 10. Level 11+ is unchanged. Examples:
Level 1: 434 -> 260 XP
Level 5: 1570 -> 1186 XP
Level 10: 3140 -> 2983 XP
Level 11+: unchanged