### PR TITLE
Affix fixes and changes

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -252,6 +252,6 @@ public class AffixRegistry : ILoadable
 			map.Strength = tierData.Strength;
 		}
 
-		return affix.Round ? (float)Math.Round(randomValue) : randomValue;
+		return randomValue;
 	}
 }

--- a/Common/Data/Affixes/ArmorAffixes.json
+++ b/Common/Data/Affixes/ArmorAffixes.json
@@ -91,7 +91,7 @@
 	},
 	{
 		"affixType": "BaseLifeAffix",
-		"equipTypes": "Armor Shield",
+		"equipTypes": "Armor Shield Ring Amulet",
 		"tiers": [
 			{
 				"minValue": 1,
@@ -296,7 +296,7 @@
 	},
 	{
 		"affixType": "ManaAffix",
-		"equipTypes": "Armor Talisman",
+		"equipTypes": "Armor Talisman Ring Amulet",
 		"tiers": [
 			{
 				"minValue": 1,

--- a/Common/Data/Affixes/AttributesAffixes.json
+++ b/Common/Data/Affixes/AttributesAffixes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"affixType": "DexterityItemAffix",
-		"equipTypes": "Weapon Armor Jewel Quiver",
+		"equipTypes": "Weapon Armor Jewel Quiver Ring Amulet",
 		"round": true,
 		"tiers": [
 			{
@@ -44,7 +44,7 @@
 	},
 	{
 		"affixType": "StrengthItemAffix",
-		"equipTypes": "Weapon Armor Jewel Shield",
+		"equipTypes": "Weapon Armor Jewel Shield Ring Amulet",
 		"round": true,
 		"tiers": [
 			{
@@ -87,7 +87,7 @@
 	},
 	{
 		"affixType": "IntelligenceItemAffix",
-		"equipTypes": "Weapon Armor Jewel Talisman",
+		"equipTypes": "Weapon Armor Jewel Talisman Ring Amulet",
 		"round": true,
 		"tiers": [
 			{

--- a/Common/Data/Affixes/ElementalAffixes.json
+++ b/Common/Data/Affixes/ElementalAffixes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"affixType": "FireResistItemAffix",
-		"equipTypes": "Armor Quiver",
+		"equipTypes": "Armor Quiver Ring Amulet",
 		"tiers": [
 			{
 				"minValue": 4,
@@ -55,7 +55,7 @@
 	},
 	{
 		"affixType": "ColdResistItemAffix",
-		"equipTypes": "Armor Quiver",
+		"equipTypes": "Armor Quiver Ring Amulet",
 		"tiers": [
 			{
 				"minValue": 4,
@@ -109,7 +109,7 @@
 	},
 	{
 		"affixType": "LightningResistItemAffix",
-		"equipTypes": "Armor Quiver",
+		"equipTypes": "Armor Quiver Ring Amulet",
 		"tiers": [
 			{
 				"minValue": 4,
@@ -163,7 +163,7 @@
 	},
 	{
 		"affixType": "ChaosResistItemAffix",
-		"equipTypes": "Armor Quiver",
+		"equipTypes": "Armor Quiver Ring Amulet",
 		"tiers": [
 			{
 				"minValue": 1,

--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -23,8 +23,8 @@ public abstract class Affix : ILocalizedModType
 
 	public float Value
 	{
-		get => Round ? (float)Math.Round(_value) : _value;
-		set => _value = value;
+		get => _value;
+		set => _value = Round ? (float)Math.Round(value) : value;
 	}
 
 	public int Duration = 180; //3 Seconds by default

--- a/Common/Systems/Affixes/Affix.cs
+++ b/Common/Systems/Affixes/Affix.cs
@@ -19,7 +19,14 @@ public abstract class Affix : ILocalizedModType
 {
 	public float MinValue;
 	public float MaxValue = 1f;
-	public float Value = 0;
+	private float _value = 0;
+
+	public float Value
+	{
+		get => Round ? (float)Math.Round(_value) : _value;
+		set => _value = value;
+	}
+
 	public int Duration = 180; //3 Seconds by default
 	public bool IsCorruptedAffix = false;
 	public bool IsImplicit = false;
@@ -41,10 +48,6 @@ public abstract class Affix : ILocalizedModType
 		}
 
 		Value = Main.rand.NextFloat(MinValue, MaxValue);
-		if (Round)
-		{
-			Value = (float) Math.Round(Value);
-		}
 	}
 
 	/// <summary>
@@ -160,11 +163,12 @@ public abstract class Affix : ILocalizedModType
 	/// <returns>The new affix.</returns>
 	public static Affix CreateAffix(Type type, float value)
 	{
-		Affix instance = (Affix)Activator.CreateInstance(type) ?? throw new Exception($"Could not create affix of type {type.Name}");
+		Affix instance = (Affix)Activator.CreateInstance(type) ??
+		                 throw new Exception($"Could not create affix of type {type.Name}");
 		instance.Value = value;
 		return instance;
 	}
-	
+
 	/// <summary>
 	/// Creates an affix with a value between <paramref name="minValue"/> and <paramref name="maxValue"/>.
 	/// </summary>
@@ -186,7 +190,8 @@ public abstract class Affix : ILocalizedModType
 	/// <returns>The new affix.</returns>
 	public static Affix CreateAffix(Type type, float minValue = 0f, float maxValue = 1f)
 	{
-		Affix instance = (Affix)Activator.CreateInstance(type) ?? throw new Exception($"Could not create affix of type {type.Name}");
+		Affix instance = (Affix)Activator.CreateInstance(type) ??
+		                 throw new Exception($"Could not create affix of type {type.Name}");
 		instance.MinValue = minValue;
 		instance.MaxValue = maxValue;
 		instance.Roll();
@@ -314,7 +319,8 @@ internal class AffixHandler : ILoadable
 		return _itemAffixes
 			.Where(proto => proto.GetRequiredInfluence(item) == Influence.None ||
 			                proto.GetRequiredInfluence(item) == item.GetInstanceData().Influence)
-			.Where(proto => (item.GetInstanceData().ItemType & proto.GetPossibleTypes()) == item.GetInstanceData().ItemType)
+			.Where(proto =>
+				(item.GetInstanceData().ItemType & proto.GetPossibleTypes()) == item.GetInstanceData().ItemType)
 			.ToList();
 	}
 
@@ -327,6 +333,7 @@ internal class AffixHandler : ILoadable
 	{
 		return _itemAffixes[idx].GetType();
 	}
+
 	public static int IndexFromItemAffix(Affix affix)
 	{
 		ItemAffix a = _itemAffixes.First(a => affix.GetType() == a.GetType());
@@ -343,6 +350,7 @@ internal class AffixHandler : ILoadable
 	{
 		return _mobAffixesByName[name];
 	}
+
 	public static Type MobAffixTypeFromIndex(int idx)
 	{
 		if (idx < 0 || idx >= _mobAffixes.Count)
@@ -352,6 +360,7 @@ internal class AffixHandler : ILoadable
 
 		return _mobAffixes[idx].GetType();
 	}
+
 	public static int IndexFromMobAffix(MobAffix affix)
 	{
 		MobAffix a = _mobAffixes.FirstOrDefault(a => affix.GetType() == a.GetType());
@@ -368,7 +377,7 @@ internal class AffixHandler : ILoadable
 	public static WeightRand<MobAffix> GetMobAffixes(NPC npc, ItemRarity rarity)
 	{
 		var result = new WeightRand<MobAffix>(capacity: _mobAffixes.Count);
-	
+
 		foreach (MobAffix affix in _mobAffixes)
 		{
 			if (rarity >= affix.MinimumRarity && affix.CanApplyTo(npc))
@@ -405,7 +414,8 @@ internal class AffixHandler : ILoadable
 					_mobAffixes.Add(mobAffix);
 					_mobAffixesByName.Add(mobAffix.Name, mobAffix);
 
-					MobAffix.MobAffixIconsByAffixName[mobAffix.GetType().AssemblyQualifiedName] = ModContent.Request<Texture2D>(mobAffix.TexturePath);
+					MobAffix.MobAffixIconsByAffixName[mobAffix.GetType().AssemblyQualifiedName] =
+						ModContent.Request<Texture2D>(mobAffix.TexturePath);
 					break;
 			}
 		}
@@ -430,4 +440,3 @@ internal class AffixHandler : ILoadable
 		_mobAffixes.Clear();
 	}
 }
-

--- a/Common/Systems/Affixes/ItemTypes/AttributesAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/AttributesAffixes.cs
@@ -1,4 +1,4 @@
-﻿using PathOfTerraria.Common.Systems.ModPlayers;
+using PathOfTerraria.Common.Systems.ModPlayers;
 
 namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
@@ -14,12 +14,7 @@ internal class StrengthItemAffix : AttributeItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<AttributesPlayer>().Strength += (int)Math.Round(Value);
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
+		player.GetModPlayer<AttributesPlayer>().Strength += (int)Value;
 	}
 }
 
@@ -27,12 +22,7 @@ internal class DexterityItemAffix : AttributeItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<AttributesPlayer>().Dexterity += (int)Math.Round(Value);
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
+		player.GetModPlayer<AttributesPlayer>().Dexterity += (int)Value;
 	}
 }
 
@@ -40,11 +30,6 @@ internal class IntelligenceItemAffix : AttributeItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<AttributesPlayer>().Intelligence += (int)Math.Round(Value);
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
+		player.GetModPlayer<AttributesPlayer>().Intelligence += (int)Value;
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/AttributesAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/AttributesAffixes.cs
@@ -2,7 +2,15 @@
 
 namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
-internal class StrengthItemAffix : ItemAffix
+internal abstract class AttributeItemAffix : ItemAffix
+{
+	protected AttributeItemAffix()
+	{
+		Round = true;
+	}
+}
+
+internal class StrengthItemAffix : AttributeItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
@@ -15,7 +23,7 @@ internal class StrengthItemAffix : ItemAffix
 	}
 }
 
-internal class DexterityItemAffix : ItemAffix
+internal class DexterityItemAffix : AttributeItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
@@ -28,7 +36,7 @@ internal class DexterityItemAffix : ItemAffix
 	}
 }
 
-internal class IntelligenceItemAffix : ItemAffix
+internal class IntelligenceItemAffix : AttributeItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{

--- a/Common/Systems/Affixes/ItemTypes/ElementalAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ElementalAffixes.cs
@@ -9,20 +9,13 @@ internal abstract class ResistItemAffix : ItemAffix
 	{
 		Round = true;
 	}
-
-	protected float RoundedValue => (float)Math.Round(Value);
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
 }
 
 internal class FireResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Fire].Resistance += RoundedValue * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Fire].Resistance += Value * 0.01f;
 	}
 }
 
@@ -30,7 +23,7 @@ internal class ColdResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Cold].Resistance += RoundedValue * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Cold].Resistance += Value * 0.01f;
 	}
 }
 
@@ -38,7 +31,7 @@ internal class LightningResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Lightning].Resistance += RoundedValue * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Lightning].Resistance += Value * 0.01f;
 	}
 }
 
@@ -46,7 +39,7 @@ internal class ChaosResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Chaos].Resistance += RoundedValue * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Chaos].Resistance += Value * 0.01f;
 	}
 }
 
@@ -203,12 +196,7 @@ internal class IgniteChanceAffix : ItemAffix
 
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<IgnitedPlayer>().AddedIgniteChance += (float)Math.Round(Value) / 100f;
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
+		player.GetModPlayer<IgnitedPlayer>().AddedIgniteChance += Value / 100f;
 	}
 }
 
@@ -229,17 +217,10 @@ internal class AllResistancesAffix : ItemAffix
 
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		float value = (float)Math.Round(Value);
-
 		foreach (ElementInstance element in player.GetModPlayer<ElementalPlayer>().Container)
 		{
-			element.Resistance += value / 100f;
+			element.Resistance += Value / 100f;
 		}
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 

--- a/Common/Systems/Affixes/ItemTypes/ElementalAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ElementalAffixes.cs
@@ -5,14 +5,24 @@ namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
 internal abstract class ResistItemAffix : ItemAffix
 {
-	
+	protected ResistItemAffix()
+	{
+		Round = true;
+	}
+
+	protected float RoundedValue => (float)Math.Round(Value);
+
+	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
+	{
+		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
+	}
 }
 
 internal class FireResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Fire].Resistance += Value * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Fire].Resistance += RoundedValue * 0.01f;
 	}
 }
 
@@ -20,7 +30,7 @@ internal class ColdResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Cold].Resistance += Value * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Cold].Resistance += RoundedValue * 0.01f;
 	}
 }
 
@@ -28,7 +38,7 @@ internal class LightningResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Lightning].Resistance += Value * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Lightning].Resistance += RoundedValue * 0.01f;
 	}
 }
 
@@ -36,7 +46,7 @@ internal class ChaosResistItemAffix : ResistItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Chaos].Resistance += Value * 0.01f;
+		player.GetModPlayer<ElementalPlayer>().Container[ElementType.Chaos].Resistance += RoundedValue * 0.01f;
 	}
 }
 
@@ -186,9 +196,19 @@ internal class ExtraChaosDamage : ItemAffix
 
 internal class IgniteChanceAffix : ItemAffix
 {
+	public IgniteChanceAffix()
+	{
+		Round = true;
+	}
+
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<IgnitedPlayer>().AddedIgniteChance += Value / 100f;
+		player.GetModPlayer<IgnitedPlayer>().AddedIgniteChance += (float)Math.Round(Value) / 100f;
+	}
+
+	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
+	{
+		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 
@@ -202,12 +222,24 @@ internal class IncreasedIgniteEffectAffix : ItemAffix
 
 internal class AllResistancesAffix : ItemAffix
 {
+	public AllResistancesAffix()
+	{
+		Round = true;
+	}
+
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
+		float value = (float)Math.Round(Value);
+
 		foreach (ElementInstance element in player.GetModPlayer<ElementalPlayer>().Container)
 		{
-			element.Resistance += Value / 100f;
+			element.Resistance += value / 100f;
 		}
+	}
+
+	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
+	{
+		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 

--- a/Common/Systems/Affixes/ItemTypes/LifeAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/LifeAffixes.cs
@@ -1,72 +1,72 @@
-﻿namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
-internal class BaseLifeAffix : ItemAffix
+internal abstract class LifeAffix : ItemAffix
 {
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
-	{
-		modifier.MaximumLife.Base += Value;
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
-}
-
-internal class AddedLifeAffix : ItemAffix
-{
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
-	{
-		modifier.MaximumLife += Value / 100;
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
-}
-
-internal class LifeRegenAffix : ItemAffix
-{
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
-	{
-		modifier.LifeRegen.Base += Value;
-	}
-}
-
-internal class LifeRegenMultiplierAffix : ItemAffix
-{
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
-	{
-		modifier.LifeRegen += Value / 100;
-	}
-}
-
-internal class LifePotionPowerAffix : ItemAffix
-{
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
-	{
-		modifier.PotionHealPower.Base += Value;
-	}
-}
-
-internal class LifePotionCapAffix : ItemAffix
-{
-	public LifePotionCapAffix()
+	protected LifeAffix()
 	{
 		Round = true;
 	}
-	
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+
+	protected float RoundedValue => (float)Math.Round(Value);
+
+	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
 	{
-		modifier.MaxHealthPotions += Value;
+		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 
-internal class LifePotionCooldownAffix : ItemAffix
+internal class BaseLifeAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionHealDelay.Base -= Value;
+		modifier.MaximumLife.Base += RoundedValue;
+	}
+}
+
+internal class AddedLifeAffix : LifeAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.MaximumLife += RoundedValue / 100;
+	}
+}
+
+internal class LifeRegenAffix : LifeAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.LifeRegen.Base += RoundedValue;
+	}
+}
+
+internal class LifeRegenMultiplierAffix : LifeAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.LifeRegen += RoundedValue / 100;
+	}
+}
+
+internal class LifePotionPowerAffix : LifeAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.PotionHealPower.Base += RoundedValue;
+	}
+}
+
+internal class LifePotionCapAffix : LifeAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.MaxHealthPotions += RoundedValue;
+	}
+}
+
+internal class LifePotionCooldownAffix : LifeAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.PotionHealDelay.Base -= RoundedValue;
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/LifeAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/LifeAffixes.cs
@@ -6,20 +6,13 @@ internal abstract class LifeAffix : ItemAffix
 	{
 		Round = true;
 	}
-
-	protected float RoundedValue => (float)Math.Round(Value);
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
 }
 
 internal class BaseLifeAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaximumLife.Base += RoundedValue;
+		modifier.MaximumLife.Base += Value;
 	}
 }
 
@@ -27,7 +20,7 @@ internal class AddedLifeAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaximumLife += RoundedValue / 100;
+		modifier.MaximumLife += Value / 100;
 	}
 }
 
@@ -35,7 +28,7 @@ internal class LifeRegenAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.LifeRegen.Base += RoundedValue;
+		modifier.LifeRegen.Base += Value;
 	}
 }
 
@@ -43,7 +36,7 @@ internal class LifeRegenMultiplierAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.LifeRegen += RoundedValue / 100;
+		modifier.LifeRegen += Value / 100;
 	}
 }
 
@@ -51,7 +44,7 @@ internal class LifePotionPowerAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionHealPower.Base += RoundedValue;
+		modifier.PotionHealPower.Base += Value;
 	}
 }
 
@@ -59,7 +52,7 @@ internal class LifePotionCapAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaxHealthPotions += RoundedValue;
+		modifier.MaxHealthPotions += Value;
 	}
 }
 
@@ -67,6 +60,6 @@ internal class LifePotionCooldownAffix : LifeAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionHealDelay.Base -= RoundedValue;
+		modifier.PotionHealDelay.Base -= Value;
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/ManaAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ManaAffixes.cs
@@ -6,20 +6,13 @@ internal abstract class ManaItemAffix : ItemAffix
 	{
 		Round = true;
 	}
-
-	protected float RoundedValue => (float)Math.Round(Value);
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
 }
 
 internal class ManaAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaximumMana.Base += RoundedValue;
+		modifier.MaximumMana.Base += Value;
 	}
 }
 
@@ -27,7 +20,7 @@ internal class ManaRegenAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.ManaRegen.Base += RoundedValue;
+		modifier.ManaRegen.Base += Value;
 	}
 }
 
@@ -35,7 +28,7 @@ internal class ManaPotionPowerAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionManaPower.Base += RoundedValue;
+		modifier.PotionManaPower.Base += Value;
 	}
 }
 
@@ -43,7 +36,7 @@ internal class ManaPotionCapAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaxManaPotions += RoundedValue;
+		modifier.MaxManaPotions += Value;
 	}
 }
 
@@ -51,6 +44,6 @@ internal class ManaPotionCooldownAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionManaDelay.Base -= RoundedValue;
+		modifier.PotionManaDelay.Base -= Value;
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/ManaAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ManaAffixes.cs
@@ -1,51 +1,56 @@
-﻿namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+namespace PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 
-internal class ManaAffix : ItemAffix
+internal abstract class ManaItemAffix : ItemAffix
 {
-	public ManaAffix()
+	protected ManaItemAffix()
 	{
 		Round = true;
 	}
-	
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+
+	protected float RoundedValue => (float)Math.Round(Value);
+
+	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
 	{
-		modifier.MaximumMana.Base += Value;
+		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 
-internal class ManaRegenAffix : ItemAffix
+internal class ManaAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.ManaRegen.Base += Value;
+		modifier.MaximumMana.Base += RoundedValue;
 	}
 }
 
-internal class ManaPotionPowerAffix : ItemAffix
+internal class ManaRegenAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionManaPower.Base += Value;
+		modifier.ManaRegen.Base += RoundedValue;
 	}
 }
 
-internal class ManaPotionCapAffix : ItemAffix
+internal class ManaPotionPowerAffix : ManaItemAffix
 {
-	public ManaPotionCapAffix()
-	{
-		Round = true;
-	}
-	
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.MaxManaPotions += Value;
+		modifier.PotionManaPower.Base += RoundedValue;
 	}
 }
 
-internal class ManaPotionCooldownAffix : ItemAffix
+internal class ManaPotionCapAffix : ManaItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.PotionManaDelay.Base -= Value;
+		modifier.MaxManaPotions += RoundedValue;
+	}
+}
+
+internal class ManaPotionCooldownAffix : ManaItemAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.PotionManaDelay.Base -= RoundedValue;
 	}
 }

--- a/Common/Systems/Affixes/ItemTypes/ModifyHitAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ModifyHitAffixes.cs
@@ -34,20 +34,13 @@ internal abstract class ChanceToApplyAffix : ItemAffix
 	{
 		Round = true;
 	}
-
-	protected float RoundedChance => (float)Math.Round(Value);
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
 }
 	
 internal class ChanceToApplyOnFireGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(BuffID.OnFire, Duration, RoundedChance * 0.01f);
+		modifier.Buffer.Add(BuffID.OnFire, Duration, Value * 0.01f);
 	}
 }
 	
@@ -55,7 +48,7 @@ internal class ChanceToApplyArmorShredGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<ArmorShredDebuff>(), Duration, RoundedChance * 0.01f);
+		modifier.Buffer.Add(ModContent.BuffType<ArmorShredDebuff>(), Duration, Value * 0.01f);
 	}
 }
 
@@ -63,7 +56,7 @@ internal class ChanceToApplyBloodclotItemAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<BloodclotDebuff>(), Duration, RoundedChance * 0.01f);
+		modifier.Buffer.Add(ModContent.BuffType<BloodclotDebuff>(), Duration, Value * 0.01f);
 	}
 }
 
@@ -71,7 +64,7 @@ internal class ChanceToApplyPoisonItemAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(BuffID.Poisoned, Duration, RoundedChance * 0.01f);
+		modifier.Buffer.Add(BuffID.Poisoned, Duration, Value * 0.01f);
 	}
 }
 
@@ -95,7 +88,7 @@ internal class ChanceToApplyShockGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<ShockDebuff>(), Duration, RoundedChance * 0.01f, 
+		modifier.Buffer.Add(ModContent.BuffType<ShockDebuff>(), Duration, Value * 0.01f, 
 			(Player player, NPC target, NPC.HitInfo info, int damageDone, int time) => ShockDebuff.Apply(player, target, damageDone));
 	}
 }
@@ -108,7 +101,7 @@ internal class ChanceToApplyRootedGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<RootedDebuff>(), Duration, RoundedChance * 0.01f);
+		modifier.Buffer.Add(ModContent.BuffType<RootedDebuff>(), Duration, Value * 0.01f);
 	}
 }
 
@@ -117,7 +110,7 @@ internal class ChanceToApplyBleedingItemAffix : ChanceToApplyAffix
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
 		// TODO: Needs duration modifier?
-		modifier.Buffer.Add(BuffID.Bleeding, 5 * 60, RoundedChance * 0.01f, (player, npc, _, damage, time) => BleedDebuff.Apply(player, npc, damage));
+		modifier.Buffer.Add(BuffID.Bleeding, 5 * 60, Value * 0.01f, (player, npc, _, damage, time) => BleedDebuff.Apply(player, npc, damage));
 	}
 }
 

--- a/Common/Systems/Affixes/ItemTypes/ModifyHitAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/ModifyHitAffixes.cs
@@ -28,40 +28,50 @@ internal class IncreasedKnockbackItemAffix : ItemAffix
 	}
 }
 	
-internal class ChanceToApplyOnFireGearAffix : ItemAffix
+internal abstract class ChanceToApplyAffix : ItemAffix
 {
-	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	protected ChanceToApplyAffix()
 	{
-		modifier.Buffer.Add(BuffID.OnFire, Duration, Value * 0.01f);
+		Round = true;
 	}
+
+	protected float RoundedChance => (float)Math.Round(Value);
 
 	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
 	{
-		return base.CreateDefaultTooltip(player, item) with { Value = MathF.Round(Value * 100f) };
+		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 	
-internal class ChanceToApplyArmorShredGearAffix : ItemAffix
+internal class ChanceToApplyOnFireGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<ArmorShredDebuff>(), Duration, Value * 0.01f);
+		modifier.Buffer.Add(BuffID.OnFire, Duration, RoundedChance * 0.01f);
+	}
+}
+	
+internal class ChanceToApplyArmorShredGearAffix : ChanceToApplyAffix
+{
+	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
+	{
+		modifier.Buffer.Add(ModContent.BuffType<ArmorShredDebuff>(), Duration, RoundedChance * 0.01f);
 	}
 }
 
-internal class ChanceToApplyBloodclotItemAffix : ItemAffix
+internal class ChanceToApplyBloodclotItemAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<BloodclotDebuff>(), Duration, Value * 0.01f);
+		modifier.Buffer.Add(ModContent.BuffType<BloodclotDebuff>(), Duration, RoundedChance * 0.01f);
 	}
 }
 
-internal class ChanceToApplyPoisonItemAffix : ItemAffix
+internal class ChanceToApplyPoisonItemAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(BuffID.Poisoned, Duration, Value * 0.01f);
+		modifier.Buffer.Add(BuffID.Poisoned, Duration, RoundedChance * 0.01f);
 	}
 }
 
@@ -81,11 +91,11 @@ internal class BuffPoisonedHitsAffix : ItemAffix
 	}
 }
 
-internal class ChanceToApplyShockGearAffix : ItemAffix
+internal class ChanceToApplyShockGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<ShockDebuff>(), Duration, Value * 0.01f, 
+		modifier.Buffer.Add(ModContent.BuffType<ShockDebuff>(), Duration, RoundedChance * 0.01f, 
 			(Player player, NPC target, NPC.HitInfo info, int damageDone, int time) => ShockDebuff.Apply(player, target, damageDone));
 	}
 }
@@ -94,20 +104,20 @@ internal class BuffShockedEffectAffix : ItemAffix
 {
 }
 
-internal class ChanceToApplyRootedGearAffix : ItemAffix
+internal class ChanceToApplyRootedGearAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		modifier.Buffer.Add(ModContent.BuffType<RootedDebuff>(), Duration, Value * 0.01f);
+		modifier.Buffer.Add(ModContent.BuffType<RootedDebuff>(), Duration, RoundedChance * 0.01f);
 	}
 }
 
-internal class ChanceToApplyBleedingItemAffix : ItemAffix
+internal class ChanceToApplyBleedingItemAffix : ChanceToApplyAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
 		// TODO: Needs duration modifier?
-		modifier.Buffer.Add(BuffID.Bleeding, 5 * 60, Value * 0.01f, (player, npc, _, damage, time) => BleedDebuff.Apply(player, npc, damage));
+		modifier.Buffer.Add(BuffID.Bleeding, 5 * 60, RoundedChance * 0.01f, (player, npc, _, damage, time) => BleedDebuff.Apply(player, npc, damage));
 	}
 }
 

--- a/Common/Systems/Affixes/ItemTypes/OnKillAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/OnKillAffixes.cs
@@ -53,13 +53,8 @@ internal class LifeOnKillAffix : ItemAffix
 				return;
 			}
 
-			player.Heal((int)Math.Round(totalLifeOnKill));
+			player.Heal((int)totalLifeOnKill);
 		}
-	}
-
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
 	}
 }
 
@@ -89,7 +84,7 @@ internal class ManaOnKillAffix : ItemAffix
 				return;
 			}
 
-			int manaToRestore = (int)Math.Round(totalManaOnKill);
+			int manaToRestore = (int)totalManaOnKill;
 			player.statMana = Math.Min(player.statMana + manaToRestore, player.statManaMax2);
 			
 			//Add combat text for mana restoration value
@@ -97,9 +92,5 @@ internal class ManaOnKillAffix : ItemAffix
 		}
 	}
 
-	protected override AffixTooltipLine CreateDefaultTooltip(Player player, Item item)
-	{
-		return base.CreateDefaultTooltip(player, item) with { Value = (int)Math.Round(Value) };
-	}
 }
 

--- a/Common/Systems/Affixes/ItemTypes/OnKillAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/OnKillAffixes.cs
@@ -29,6 +29,11 @@ internal class HealOnKillingBurningEnemiesAffix : ItemAffix
 
 internal class LifeOnKillAffix : ItemAffix
 {
+	public LifeOnKillAffix()
+	{
+		Round = true;
+	}
+
 	private sealed class LifeOnKillGlobalNPC : GlobalNPC
 	{
 		public override void OnKill(NPC npc)
@@ -60,6 +65,11 @@ internal class LifeOnKillAffix : ItemAffix
 
 internal class ManaOnKillAffix : ItemAffix
 {
+	public ManaOnKillAffix()
+	{
+		Round = true;
+	}
+
 	private sealed class ManaOnKillGlobalNPC : GlobalNPC
 	{
 		public override void OnKill(NPC npc)


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- Adds rounding to several affixes just for simplicity sake

### Bug Fixes

- missing affixes after the accessory update
<!-- pot-changelog-desc:end -->
### Comments
This also fixes a regression in the affixes when we did the accessory rewrite
## Cleaner Affix Values
- Attribute rolls now use whole numbers.
- Life and mana rolls now use whole numbers.
- Resistance rolls now use whole numbers.
- Chance-to-apply effects now use whole-number percentages.
