### PR TITLE
Quest glows

### DIFF
--- a/Common/Systems/DisableBuilding/StopCuttingProjectile.cs
+++ b/Common/Systems/DisableBuilding/StopCuttingProjectile.cs
@@ -54,7 +54,7 @@ internal class StopCuttingProjectile : GlobalProjectile
 
 	private bool CutCheck(On_DelegateMethods.orig_CutTiles orig, int x, int y)
 	{
-		if (CuttingProjectile is not null && (SubworldSystem.Current is (BossDomainSubworld or IExplorationWorld) and not MoonLordDomain) 
+		if (CuttingProjectile is not null && (SubworldSystem.Current is (BossDomainSubworld or IExplorationWorld) and not MoonLordDomain) && WorldGen.InWorld(x, y) 
 			&& Main.tile[x, y].HasTile && Main.tileCut[Main.tile[x, y].TileType])
 		{
 			return CanCutTile(CuttingProjectile, x, y) && orig(x, y);

--- a/Common/Systems/Visuals/SpecialObjectGlow.cs
+++ b/Common/Systems/Visuals/SpecialObjectGlow.cs
@@ -1,0 +1,112 @@
+using PathOfTerraria.Common.Subworlds;
+using PathOfTerraria.Common.Tiles;
+using SubworldLibrary;
+using Terraria.GameContent;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.Systems.Visuals;
+
+internal interface ISpecialGlowTile
+{
+	public Color GlowColor => new(255, 220, 120);
+}
+
+internal sealed class SpecialObjectGlowItem : GlobalItem
+{
+	private const float GlowOpacity = 0.28f;
+
+	public override void PostDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
+	{
+		if (!ShouldGlow(item))
+		{
+			return;
+		}
+
+		Texture2D texture = TextureAssets.Item[item.type].Value;
+		Rectangle frame = Main.itemAnimations[item.type]?.GetFrame(texture) ?? texture.Frame();
+		Vector2 origin = frame.Size() * 0.5f;
+		Vector2 position = item.Center - Main.screenPosition;
+		Color glowColor = GetItemGlowColor(item) * (GlowOpacity * Pulse(whoAmI));
+
+		DrawGlow(spriteBatch, texture, position, frame, glowColor, rotation, origin, scale);
+		Lighting.AddLight(item.Center, glowColor.ToVector3() * 0.35f);
+	}
+
+	private static bool ShouldGlow(Item item)
+	{
+		if (item.IsAir)
+		{
+			return false;
+		}
+
+		if (item.questItem || item.rare == ItemRarityID.Quest)
+		{
+			return true;
+		}
+
+		string itemNamespace = item.ModItem?.GetType().Namespace;
+		return itemNamespace is "PathOfTerraria.Content.Items.Quest" or "PathOfTerraria.Content.Items.BossDomain";
+	}
+
+	private static Color GetItemGlowColor(Item item)
+	{
+		string itemNamespace = item.ModItem?.GetType().Namespace;
+		return itemNamespace == "PathOfTerraria.Content.Items.BossDomain" ? new Color(255, 215, 120) : new Color(255, 235, 150);
+	}
+
+	internal static float Pulse(int offset)
+	{
+		return 0.75f + MathF.Sin(Main.GameUpdateCount * 0.055f + offset * 0.37f) * 0.25f;
+	}
+
+	internal static void DrawGlow(SpriteBatch spriteBatch, Texture2D texture, Vector2 position, Rectangle frame, Color color, float rotation, Vector2 origin, float scale)
+	{
+		for (int i = 0; i < 8; i++)
+		{
+			Vector2 offset = (MathHelper.TwoPi * i / 8f).ToRotationVector2() * 2.5f * scale;
+			spriteBatch.Draw(texture, position + offset, frame, color * 0.65f, rotation, origin, scale, SpriteEffects.None, 0f);
+		}
+
+		spriteBatch.Draw(texture, position, frame, color * 0.45f, rotation, origin, scale * 1.12f, SpriteEffects.None, 0f);
+	}
+}
+
+internal sealed class SpecialObjectGlowTile : GlobalTile
+{
+	private const float TileGlowOpacity = 0.32f;
+
+	public override void PostDraw(int i, int j, int type, SpriteBatch spriteBatch)
+	{
+		if (!TryGetGlowColor(type, out Color color))
+		{
+			return;
+		}
+
+		Tile tile = Main.tile[i, j];
+		Texture2D texture = TextureAssets.Tile[type].Value;
+		Rectangle frame = tile.BasicFrame();
+		Vector2 position = TileExtensions.DrawPosition(i, j);
+		float pulse = SpecialObjectGlowItem.Pulse(i + j * 3);
+		Color glowColor = color * (TileGlowOpacity * pulse);
+
+		SpecialObjectGlowItem.DrawGlow(spriteBatch, texture, position + new Vector2(8), frame, glowColor, 0f, new Vector2(8), 1f);
+	}
+
+	private static bool TryGetGlowColor(int type, out Color color)
+	{
+		if (ModContent.GetModTile(type) is ISpecialGlowTile specialGlowTile)
+		{
+			color = specialGlowTile.GlowColor;
+			return true;
+		}
+
+		if (type == TileID.Lever && SubworldSystem.Current is BossDomainSubworld)
+		{
+			color = new Color(255, 220, 120);
+			return true;
+		}
+
+		color = default;
+		return false;
+	}
+}

--- a/Content/Tiles/BossDomain/BabyBulb.cs
+++ b/Content/Tiles/BossDomain/BabyBulb.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using PathOfTerraria.Common.Systems.Visuals;
 using PathOfTerraria.Content.NPCs.BossDomain.PlantDomain;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -6,8 +7,10 @@ using Terraria.ObjectData;
 
 namespace PathOfTerraria.Content.Tiles.BossDomain;
 
-internal class BabyBulb : ModTile
+internal class BabyBulb : ModTile, ISpecialGlowTile
 {
+	public Color GlowColor => new(170, 255, 90);
+
 	public override void SetStaticDefaults()
 	{
 		Main.tileCut[Type] = true;

--- a/Content/Tiles/BossDomain/Mech/MechButton.cs
+++ b/Content/Tiles/BossDomain/Mech/MechButton.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Tiles;
+using PathOfTerraria.Common.Systems.Visuals;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
@@ -6,8 +7,10 @@ using Terraria.ObjectData;
 
 namespace PathOfTerraria.Content.Tiles.BossDomain.Mech;
 
-internal class MechButton : ModTile
+internal class MechButton : ModTile, ISpecialGlowTile
 {
+	public Color GlowColor => new(255, 90, 80);
+
 	public override void SetStaticDefaults()
 	{
 		Main.tileCut[Type] = true;

--- a/Content/Tiles/BossDomain/RoyalHoneyClumpTile.cs
+++ b/Content/Tiles/BossDomain/RoyalHoneyClumpTile.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Systems.DisableBuilding;
+using PathOfTerraria.Common.Systems.Visuals;
 using PathOfTerraria.Content.Items.BossDomain;
 using System.Collections.Generic;
 using Terraria.GameContent;
@@ -6,8 +7,10 @@ using Terraria.ID;
 
 namespace PathOfTerraria.Content.Tiles.BossDomain;
 
-internal class RoyalHoneyClumpTile : ModTile, ICanCutTile
+internal class RoyalHoneyClumpTile : ModTile, ICanCutTile, ISpecialGlowTile
 {
+	public Color GlowColor => new(255, 190, 70);
+
 	public override void SetStaticDefaults()
 	{
 		Main.tileCut[Type] = true;

--- a/Content/Tiles/BossDomain/RoyalHoneyClumpTile.cs
+++ b/Content/Tiles/BossDomain/RoyalHoneyClumpTile.cs
@@ -40,6 +40,11 @@ internal class RoyalHoneyClumpTile : ModTile, ICanCutTile
 		return Main.tile[i, j].TileFrameY > 0;
 	}
 
+	public override bool CanKillTile(int i, int j, ref bool blockDamaged)
+	{
+		return Main.tile[i, j].TileFrameY > 0;
+	}
+
 	public override IEnumerable<Item> GetItemDrops(int i, int j)
 	{
 		if (Main.tile[i, j].TileFrameY > 0)

--- a/Content/Tiles/BossDomain/TabletPieces.cs
+++ b/Content/Tiles/BossDomain/TabletPieces.cs
@@ -1,12 +1,15 @@
 ﻿using PathOfTerraria.Content.Items.BossDomain;
+using PathOfTerraria.Common.Systems.Visuals;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ObjectData;
 
 namespace PathOfTerraria.Content.Tiles.BossDomain;
 
-internal class TabletPieces : ModTile
+internal class TabletPieces : ModTile, ISpecialGlowTile
 {
+	public Color GlowColor => new(255, 210, 130);
+
 	public override void SetStaticDefaults()
 	{
 		Main.tileFrameImportant[Type] = true;


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- add glow around baby bulb, mech button, royal honey clump tile, and tablet pieces for better visual display of quest related items and tiles

### Bug Fixes

- royal honey clump tile being minnable before it would actually give the item
- Fixed out of bounds check when using a projectile that can cut tiles
<!-- pot-changelog-desc:end -->
### Comments
* Adds in namespace checks for various other item glows that should maybe catch everything we add assuming they are added in the correct space and namespace. Otherwise can always be added manually