### PR TITLE
fix: lunatic cultist and destroyer spawning not working in multiplayer

### DIFF
--- a/Common/Systems/Synchronization/Handlers/BossDomainSummonHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/BossDomainSummonHandler.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
+using SubworldLibrary;
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
+
+internal class BossDomainSummonHandler : Handler
+{
+	internal enum BossDomainSummon : byte
+	{
+		QueenBee,
+		Destroyer,
+		Cultist
+	}
+
+	public static bool TrySummon(BossDomainSummon summon, Player player)
+	{
+		if (!CanSummon(summon, player))
+		{
+			return false;
+		}
+
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			ModPacket packet = Networking.GetPacket<BossDomainSummonHandler>();
+			packet.Write((byte)summon);
+			packet.Send();
+		}
+		else
+		{
+			Spawn(summon, player.whoAmI);
+		}
+
+		return true;
+	}
+
+	internal override void ServerReceive(BinaryReader reader, byte sender)
+	{
+		BossDomainSummon summon = (BossDomainSummon)reader.ReadByte();
+
+		if (sender >= Main.maxPlayers)
+		{
+			return;
+		}
+
+		Player player = Main.player[sender];
+
+		if (!CanSummon(summon, player))
+		{
+			return;
+		}
+
+		Spawn(summon, sender);
+	}
+
+	private static bool CanSummon(BossDomainSummon summon, Player player)
+	{
+		if (player is null || !player.active || player.dead)
+		{
+			return false;
+		}
+
+		return summon switch
+		{
+			BossDomainSummon.QueenBee => SubworldSystem.Current is QueenBeeDomain && !NPC.AnyNPCs(NPCID.QueenBee),
+			BossDomainSummon.Destroyer => SubworldSystem.Current is DestroyerDomain && !AnyDestroyerSegment(),
+			BossDomainSummon.Cultist => SubworldSystem.Current is CultistDomain && !NPC.AnyNPCs(NPCID.CultistBoss),
+			_ => false
+		};
+	}
+
+	private static bool AnyDestroyerSegment()
+	{
+		return NPC.AnyNPCs(NPCID.TheDestroyer) || NPC.AnyNPCs(NPCID.TheDestroyerBody) || NPC.AnyNPCs(NPCID.TheDestroyerTail);
+	}
+
+	private static void Spawn(BossDomainSummon summon, int playerIndex)
+	{
+		Player player = Main.player[playerIndex];
+
+		switch (summon)
+		{
+			case BossDomainSummon.QueenBee:
+				NPC.SpawnOnPlayer(playerIndex, NPCID.QueenBee);
+				break;
+
+			case BossDomainSummon.Destroyer:
+				NPC.SpawnOnPlayer(playerIndex, NPCID.TheDestroyer);
+				break;
+
+			case BossDomainSummon.Cultist:
+				NPC.SpawnBoss((int)player.Center.X, (int)player.Center.Y - 120, NPCID.CultistBoss, playerIndex);
+				break;
+		}
+	}
+}

--- a/Common/Systems/Synchronization/Handlers/BossDomainSummonHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/BossDomainSummonHandler.cs
@@ -40,11 +40,6 @@ internal class BossDomainSummonHandler : Handler
 	{
 		BossDomainSummon summon = (BossDomainSummon)reader.ReadByte();
 
-		if (sender >= Main.maxPlayers)
-		{
-			return;
-		}
-
 		Player player = Main.player[sender];
 
 		if (!CanSummon(summon, player))

--- a/Content/Items/BossDomain/AncientTablet.cs
+++ b/Content/Items/BossDomain/AncientTablet.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using SubworldLibrary;
 using Terraria.ID;
 
@@ -15,12 +16,9 @@ internal class AncientTablet : ModItem
 
 	public override bool? UseItem(Player player)
 	{
-		if (Main.netMode != NetmodeID.MultiplayerClient)
-		{
-			NPC.SpawnBoss((int)player.Center.X, (int)player.Center.Y - 120, NPCID.CultistBoss, player.whoAmI);
-		}
-
-		return true;
+		return BossDomainSummonHandler.TrySummon(
+			BossDomainSummonHandler.BossDomainSummon.Cultist,
+			player);
 	}
 
 	public override void UpdateInventory(Player player)

--- a/Content/Items/BossDomain/MechChip.cs
+++ b/Content/Items/BossDomain/MechChip.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using SubworldLibrary;
 using Terraria.ID;
 
@@ -14,8 +15,9 @@ internal class MechChip : ModItem
 
 	public override bool? UseItem(Player player)
 	{
-		NPC.SpawnOnPlayer(player.whoAmI, NPCID.TheDestroyer);
-		return true;
+		return BossDomainSummonHandler.TrySummon(
+			BossDomainSummonHandler.BossDomainSummon.Destroyer,
+			player);
 	}
 
 	public override void UpdateInventory(Player player)

--- a/Content/Items/BossDomain/RoyalJelly.cs
+++ b/Content/Items/BossDomain/RoyalJelly.cs
@@ -1,5 +1,4 @@
-﻿using PathOfTerraria.Common.Subworlds.BossDomains.Hardmode;
-using Terraria.DataStructures;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.BossDomain;
@@ -14,8 +13,9 @@ internal class RoyalJelly : ModItem
 
 	public override bool? UseItem(Player player)
 	{
-		NPC.SpawnOnPlayer(player.whoAmI, NPCID.QueenBee);
-		return true;
+		return BossDomainSummonHandler.TrySummon(
+			BossDomainSummonHandler.BossDomainSummon.QueenBee,
+			player);
 	}
 
 	public override void AddRecipes()


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Bug Fixes

- lunatic cultist and destroyer spawning not working in multiplayer
<!-- pot-changelog-desc:end -->
### Comments
* This adds a new handler for boss summons that can be called for making in-domain summons a bit more centralized and easy