### PR TITLE
Feat/1649

### DIFF
--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -34,12 +34,47 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 
 	/// <summary>Snapshot of lifeMax before rarity/map/area scaling, used for HP-scaled XP. -1 = not captured.</summary>
 	public int BaseLifeMax = -1;
+
 	public ItemRarity Rarity = ItemRarity.Normal;
 	public List<MobAffix> Affixes = [];
 
 	private readonly Player _lastPlayerHit = null;
 
 	private bool _synced = false;
+
+	public override void Load()
+	{
+		On_NPC.NPCLoot_DropItems += RerollVanillaDropsByRarity;
+	}
+
+	// Magic mobs get a 1.2x expected weighting on their vanilla drops, Rare mobs get 2x.
+	// Implemented as an extra full pool roll (20% chance for Magic, guaranteed for Rare).
+	private static void RerollVanillaDropsByRarity(On_NPC.orig_NPCLoot_DropItems orig, NPC self, Player closestPlayer)
+	{
+		orig(self, closestPlayer);
+
+		if (self.boss || self.SpawnedFromStatue || self.friendly || self.CountsAsACritter || self.lifeMax <= 5)
+		{
+			return;
+		}
+
+		if (!self.TryGetGlobalNPC(out ArpgNPC arpg))
+		{
+			return;
+		}
+
+		int extraRolls = arpg.Rarity switch
+		{
+			ItemRarity.Rare => 1,
+			ItemRarity.Magic => Main.rand.NextFloat() < 0.2f ? 1 : 0,
+			_ => 0
+		};
+
+		for (int i = 0; i < extraRolls; i++)
+		{
+			orig(self, closestPlayer);
+		}
+	}
 
 	// should somehow work together with magic find (that i assume we will have) to increase rarity / if its a unique
 	private float DropRarity
@@ -135,7 +170,8 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		Affixes.ForEach(a => a.OnKill(npc));
 
 		// Early exit conditions
-		if (DropModifierNPC.GetDropRate(npc) < Main.rand.NextFloat() || npc.lifeMax <= 5 || npc.SpawnedFromStatue || npc.boss || npc.friendly || npc.CountsAsACritter)
+		if (DropModifierNPC.GetDropRate(npc) < Main.rand.NextFloat() || npc.lifeMax <= 5 || npc.SpawnedFromStatue ||
+		    npc.boss || npc.friendly || npc.CountsAsACritter)
 		{
 			return;
 		}
@@ -178,13 +214,15 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		// Roll guaranteed rare/magic items first
 		if (Rarity is ItemRarity.Magic or ItemRarity.Rare)
 		{
-			drops.Add(DropTable.RollMobDrops(itemLevel, dropRarityModifier, forceRarity: Rarity, uniqueModifier: uniqueMod));
+			drops.Add(DropTable.RollMobDrops(itemLevel, dropRarityModifier, forceRarity: Rarity,
+				uniqueModifier: uniqueMod));
 		}
 
 		// Roll the remaining items normally
 		if (dropCount > 0)
 		{
-			drops.AddRange(DropTable.RollManyMobDrops(dropCount, itemLevel, dropRarityModifier, uniqueModifier: uniqueMod));
+			drops.AddRange(DropTable.RollManyMobDrops(dropCount, itemLevel, dropRarityModifier,
+				uniqueModifier: uniqueMod));
 		}
 
 		// Spawn all items
@@ -212,10 +250,12 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 	{
 		currentlyTransforming = true;
 	}
+
 	void INpcTransformCallbacks.PostTransform(NPC npc, int oldType)
 	{
 		currentlyTransforming = false;
 	}
+
 	void INpcTransformCallbacks.TransformTransfer(NPC npc, int oldType, INpcTransformCallbacks oldInstance)
 	{
 		if (oldInstance is ArpgNPC oldSelf)
@@ -237,8 +277,9 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		CaptureBaseLifeMax(npc);
 
 		// We only want to trigger these changes on hostile non-boss, mortal & damageable non-critter NPCs that aren't in NoAffixesSet
-		if (npc.IsABestiaryIconDummy || npc.friendly || npc.boss || Main.gameMenu || npc.immortal || npc.dontTakeDamage || NPCID.Sets.ProjectileNPC[npc.type]
-			|| npc.CountsAsACritter || npc.realLife != -1 || NoAffixesSet.Contains(npc.type))
+		if (npc.IsABestiaryIconDummy || npc.friendly || npc.boss || Main.gameMenu || npc.immortal ||
+		    npc.dontTakeDamage || NPCID.Sets.ProjectileNPC[npc.type]
+		    || npc.CountsAsACritter || npc.realLife != -1 || NoAffixesSet.Contains(npc.type))
 		{
 			return;
 		}
@@ -280,7 +321,7 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		if (!fromNet)
 		{
 			Affixes = [];
-			
+
 			if (MobRegistry.TryGetMobData(npc.type, out MobData mobData))
 			{
 				MobEntry entry = MobRegistry.SelectMobEntry(mobData.NetId);
@@ -339,14 +380,16 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 			case ItemRarity.Normal:
 				break;
 			case ItemRarity.Magic:
-				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(125, 125, 255), 0.5f);
+				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color,
+					new Color(125, 125, 255), 0.5f);
 				npc.lifeMax = (int)(npc.lifeMax * MathHelper.Lerp(1.35f, 2f, statScaling));
 				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
 				npc.damage = (int)(npc.damage * MathHelper.Lerp(1.04f, 1.1f, statScaling));
 				alwaysDisplayHealthbar = true;
 				break;
 			case ItemRarity.Rare:
-				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(255, 255, 0), 0.5f);
+				npc.color = Color.Lerp(npc.color == Color.Transparent ? Color.White : npc.color, new Color(255, 255, 0),
+					0.5f);
 				npc.lifeMax = (int)(npc.lifeMax * MathHelper.Lerp(1.75f, 3f, statScaling));
 				npc.life = currentlyTransforming ? npc.life : npc.lifeMax;
 				npc.damage = (int)(npc.damage * MathHelper.Lerp(1.08f, 1.2f, statScaling));
@@ -374,7 +417,8 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 	{
 		if (!string.IsNullOrEmpty(entry.Prefix))
 		{
-			npc.GivenName = $"{Language.GetTextValue($"Mods.{PoTMod.ModName}.EnemyPrefixes." + entry.Prefix)} {npc.GivenOrTypeName}";
+			npc.GivenName =
+				$"{Language.GetTextValue($"Mods.{PoTMod.ModName}.EnemyPrefixes." + entry.Prefix)} {npc.GivenOrTypeName}";
 		}
 
 		npc.scale *= entry.Scale ?? 1f;
@@ -398,7 +442,8 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 
 		npc.GivenName = Rarity switch
 		{
-			ItemRarity.Magic or ItemRarity.Rare => $"{Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.RarityNames." + Enum.GetName(Rarity))} {typeName}",
+			ItemRarity.Magic or ItemRarity.Rare =>
+				$"{Language.GetTextValue($"Mods.{PoTMod.ModName}.Misc.RarityNames." + Enum.GetName(Rarity))} {typeName}",
 			ItemRarity.Unique => "UNIQUE MOB",
 			_ => typeName
 		};

--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -152,7 +152,7 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 	private static float GetProgressionDropRateScale(int areaLevel)
 	{
 		float progress = MathHelper.Clamp((areaLevel - 1f) / PoTMobHelper.AreaLevelScalingCap, 0f, 1f);
-		return MathHelper.Lerp(0.2f, 0.15f, progress);
+		return MathHelper.Lerp(0.1f, 0.075f, progress);
 	}
 
 	// First caller wins so later SetDefaults modifiers (rarity, map affixes, area scaling) don't pollute the snapshot.
@@ -194,6 +194,14 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 		{
 			dropRarityModifier += DomainRarityBoost();
 		}
+
+		// Magic/Rare mobs bias their non-guaranteed drops toward higher rarities.
+		dropRarityModifier += Rarity switch
+		{
+			ItemRarity.Magic => 0.5f,
+			ItemRarity.Rare => 1.5f,
+			_ => 0f
+		};
 
 		// Determine drop count
 		float minDrop = (DropQuantity * MinDropChanceScale * 100f);


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- Add in extra vanilla drops for magic and rare mobs

### Balance

- Magic and rare mobs now have an inherit non-guaranteed drop rarity bias while bringing general gear drops reduced by about half
<!-- pot-changelog-desc:end -->
### Comments
* Hard to test the extra rolling stuff, but generally seemed fine? Could just be assuming it though

<!-- pot-changelog-closes:start -->
Closes #1649
<!-- pot-changelog-closes:end -->