### PR TITLE
Moss Eel Fixes

### DIFF
--- a/Common/Systems/MobSystem/ArpgNPC.cs
+++ b/Common/Systems/MobSystem/ArpgNPC.cs
@@ -6,6 +6,7 @@ using PathOfTerraria.Common.Data.Models;
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Common.ItemDropping;
 using PathOfTerraria.Common.NPCs;
+using PathOfTerraria.Common.NPCs.Worms;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.ElementalDamage;
@@ -284,10 +285,11 @@ internal class ArpgNPC : GlobalNPC, INpcTransformCallbacks
 
 		CaptureBaseLifeMax(npc);
 
-		// We only want to trigger these changes on hostile non-boss, mortal & damageable non-critter NPCs that aren't in NoAffixesSet
+		// We only want to trigger these changes on hostile non-boss, mortal & damageable non-critter NPCs that aren't in NoAffixesSet.
+		// Worm segments are linked helper NPCs and should never roll independent rarity or affixes.
 		if (npc.IsABestiaryIconDummy || npc.friendly || npc.boss || Main.gameMenu || npc.immortal ||
 		    npc.dontTakeDamage || NPCID.Sets.ProjectileNPC[npc.type]
-		    || npc.CountsAsACritter || npc.realLife != -1 || NoAffixesSet.Contains(npc.type))
+		    || npc.CountsAsACritter || npc.realLife != -1 || npc.ModNPC is WormSegment || NoAffixesSet.Contains(npc.type))
 		{
 			return;
 		}

--- a/Content/Swamp/SwampArea.cs
+++ b/Content/Swamp/SwampArea.cs
@@ -803,9 +803,13 @@ internal class SwampArea : MappingWorld, IExplorationWorld
 	{
 		Liquid.UpdateLiquid();
 
-		if (Main.ActivePlayers.GetEnumerator().MoveNext() && NPC.CountNPCS(ModContent.NPCType<GiantEel>()) < Main.CurrentFrameFlags.ActivePlayersCount)
+		int activePlayerCount = Main.CurrentFrameFlags.ActivePlayersCount;
+		int eelsToSpawn = activePlayerCount - NPC.CountNPCS(ModContent.NPCType<GiantEel>());
+
+		for (int i = 0; i < eelsToSpawn; ++i)
 		{
-			int npc = NPC.NewNPC(new EntitySource_WorldGen(), Main.spawnTileX * 16, 120 * 16, ModContent.NPCType<GiantEel>(), 0, 0, 0, Main.CurrentFrameFlags.ActivePlayersCount - 1);
+			Vector2 spawnPosition = GetGiantEelSpawnPosition();
+			int npc = NPC.NewNPC(new EntitySource_WorldGen(), (int)spawnPosition.X, (int)spawnPosition.Y, ModContent.NPCType<GiantEel>(), 0, 0, 0, GetRandomActivePlayerIndex());
 			Main.npc[npc].netUpdate = true;
 		}
 
@@ -854,6 +858,58 @@ internal class SwampArea : MappingWorld, IExplorationWorld
 				}
 			}
 		}
+	}
+
+	private static Vector2 GetGiantEelSpawnPosition()
+	{
+		const int SpawnTileY = 120;
+		const int ArenaPadding = 80;
+		const int MinimumPlayerDistanceX = 220;
+		const int Attempts = 50;
+
+		int minX = SwampArenaGeneration.ArenaWidth + ArenaPadding;
+		int maxX = Main.maxTilesX - SwampArenaGeneration.ArenaWidth - ArenaPadding;
+		int fallbackX = Random.Next(minX, maxX);
+
+		for (int i = 0; i < Attempts; ++i)
+		{
+			int x = Random.Next(minX, maxX);
+
+			if (!IsNearAnyActivePlayerX(x, MinimumPlayerDistanceX))
+			{
+				return new Vector2(x * 16, SpawnTileY * 16);
+			}
+		}
+
+		return new Vector2(fallbackX * 16, SpawnTileY * 16);
+	}
+
+	private static bool IsNearAnyActivePlayerX(int tileX, int minimumDistance)
+	{
+		foreach (Player player in Main.ActivePlayers)
+		{
+			if (Math.Abs(player.Center.X / 16f - tileX) < minimumDistance)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static int GetRandomActivePlayerIndex()
+	{
+		int remaining = Random.Next(Main.CurrentFrameFlags.ActivePlayersCount);
+
+		foreach (Player player in Main.ActivePlayers)
+		{
+			if (remaining-- == 0)
+			{
+				return player.whoAmI;
+			}
+		}
+
+		return 0;
 	}
 
 	private static void SpawnArenaEntities()


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Balance

- Moss Eel in Swamp Map now spawns in random locations along the top to prevent over simple farming

### Bug Fixes

- Moss Eel no longer can roll mob rarity or random modifiers
<!-- pot-changelog-desc:end -->
### Comments
