### PR TITLE
feat(#2057): Add in tooltip to disabled boss items (like the Suspicio…

### DIFF
--- a/Common/Systems/VanillaModifications/BossItemRemovals/BossGlobalItemDisabler.cs
+++ b/Common/Systems/VanillaModifications/BossItemRemovals/BossGlobalItemDisabler.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using PathOfTerraria.Core.Items;
+using System.Collections.Generic;
 using Terraria.ID;
+using Terraria.Localization;
 
 namespace PathOfTerraria.Common.Systems.VanillaModifications.BossItemRemovals;
 
-internal class BossGlobalItemDisabler : GlobalItem
+internal class BossGlobalItemDisabler : GlobalItem, InsertAdditionalTooltipLines.IGlobal
 {
 	public static readonly HashSet<int> BossSpawners = [ItemID.SlimeCrown,
 		ItemID.SuspiciousLookingEye,
@@ -32,5 +34,13 @@ internal class BossGlobalItemDisabler : GlobalItem
 	public override bool CanUseItem(Item item, Player player)
 	{
 		return false;
+	}
+
+	void InsertAdditionalTooltipLines.IGlobal.InsertAdditionalTooltipLines(Item item, List<TooltipLine> tooltips)
+	{
+		if (AppliesToEntity(item, true))
+		{
+			tooltips.Add(new TooltipLine(Mod, "Disabled", Language.GetTextValue("Mods.PathOfTerraria.TooltipNotices.Disabled")) { OverrideColor = new Color(255, 160, 160) });
+		}
 	}
 }

--- a/Localization/de-DE/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@
 // TierXOfY: Tier {0} of {1}
 // AffixValueRange: Ranges {0} to {1}
 // Ephemeral: (Ephemeral)
+// Disabled: This item cannot be used - search for quests in Ravencrest instead

--- a/Localization/en-US/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@ NoDifferences: (No differences)
 TierXOfY: Tier {0} of {1}
 AffixValueRange: Ranges {0} to {1}
 Ephemeral: (Ephemeral)
+Disabled: This item cannot be used - search for quests in Ravencrest instead

--- a/Localization/es-ES/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@
 // TierXOfY: Tier {0} of {1}
 // AffixValueRange: Ranges {0} to {1}
 // Ephemeral: (Ephemeral)
+// Disabled: This item cannot be used - search for quests in Ravencrest instead

--- a/Localization/fr-FR/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@ Shift: (Maintenir shift pour comparer les statistiques)
 // TierXOfY: Tier {0} of {1}
 // AffixValueRange: Ranges {0} to {1}
 // Ephemeral: (Ephemeral)
+// Disabled: This item cannot be used - search for quests in Ravencrest instead

--- a/Localization/pl-PL/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@ Shift: (Przytrzymaj shift żeby porównać statystyki)
 // TierXOfY: Tier {0} of {1}
 // AffixValueRange: Ranges {0} to {1}
 // Ephemeral: (Ephemeral)
+// Disabled: This item cannot be used - search for quests in Ravencrest instead

--- a/Localization/pt-BR/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@
 // TierXOfY: Tier {0} of {1}
 // AffixValueRange: Ranges {0} to {1}
 // Ephemeral: (Ephemeral)
+// Disabled: This item cannot be used - search for quests in Ravencrest instead

--- a/Localization/ru-RU/Mods.PathOfTerraria.TooltipNotices.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.TooltipNotices.hjson
@@ -5,3 +5,4 @@ NoDifferences: (Нет отличий)
 // TierXOfY: Tier {0} of {1}
 AffixValueRange: В пределах от {0} до {1}
 // Ephemeral: (Ephemeral)
+// Disabled: This item cannot be used - search for quests in Ravencrest instead


### PR DESCRIPTION
…us Looking Eye) for clarity

﻿### Description of Work

<!-- pot-changelog-desc:start -->
### Features

- Add in tooltip to disabled boss items (like the Suspicious Looking Eye) for clarity
<!-- pot-changelog-desc:end -->
<img width="629" height="183" alt="image" src="https://github.com/user-attachments/assets/6589f059-2f86-4f87-b757-2199c37bd2c0" />


<!-- pot-changelog-closes:start -->
Closes #2057
<!-- pot-changelog-closes:end -->