### PR TITLE
feat: add in system for items to allow Flurry even if not (normally) …

### DIFF
--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -464,6 +464,7 @@ public class RavencrestSystem : ModSystem
 
 	public override void NetSend(BinaryWriter writer)
 	{
+		writer.Write(SpawnedScout);
 		writer.Write((short)HasOverworldNPC.Count);
 
 		foreach (string npc in HasOverworldNPC)
@@ -483,6 +484,7 @@ public class RavencrestSystem : ModSystem
 
 	public override void NetReceive(BinaryReader reader)
 	{
+		SpawnedScout = reader.ReadBoolean();
 		HasOverworldNPC.Clear();
 		short count = reader.ReadInt16();
 

--- a/Content/Items/Gear/Weapons/Bow/Bow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Bow.cs
@@ -1,5 +1,6 @@
-﻿using PathOfTerraria.Content.Projectiles.Ranged;
-using PathOfTerraria.Common.Systems;
+﻿using PathOfTerraria.Common.Systems;
+using PathOfTerraria.Content.Projectiles.Ranged;
+using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Core.Items;
 using ReLogic.Content;
 using System.Collections.Generic;
@@ -24,6 +25,19 @@ internal abstract class Bow : Gear
 
 	protected bool IsChanneling;
 
+	public static bool DefaultFlurryFunctionality(Player player, Item item, out int projToShoot, out float speed, out int damage, out float knockBack, out int usedAmmoItemId)
+	{
+		// Get overall info for the usage as if this is a normal bow
+		if (!player.PickAmmo(ContentSamples.ItemsByType[ItemID.WoodenBow], out projToShoot, out speed, out damage, out knockBack, out usedAmmoItemId, true))
+		{
+			return false;
+		}
+
+		// Then adjust to get the 'actual' info for the relevant stats
+		player.PickAmmo(item, out _, out _, out damage, out knockBack, out _, true);
+		return true;
+	}
+
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();
@@ -36,6 +50,8 @@ internal abstract class Bow : Gear
 		{
 			BowProjectileSpritesById.Add(Type, ModContent.Request<Texture2D>(Texture + "Animated"));
 		}
+
+		RainOfArrowsSets.CustomFunctionalities.Add(Type, DefaultFlurryFunctionality);
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Bow/WardensBow.cs
+++ b/Content/Items/Gear/Weapons/Bow/WardensBow.cs
@@ -3,6 +3,7 @@ using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Content.Buffs;
 using PathOfTerraria.Content.Projectiles.Ranged;
+using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Core.Items;
 using System.Collections.Generic;
 using Terraria.DataStructures;
@@ -20,6 +21,11 @@ internal class WardensBow : WoodenBow
 		staticData.DropChance = null;
 		staticData.IsUnique = true;
 		staticData.AltUseDescription = this.GetLocalization("AltUse");
+
+		RainOfArrowsSets.PostModify.Add(Type, new RainOfArrowsSets.PostModifyShootDelegate((player, item, projectile, who) =>
+		{
+			Main.projectile[who].GetGlobalProjectile<WardensBowProjectile>().WardenProj = true;
+		}));
 
 		BowAnimationProjectile.OverridenShootActionsByItemId[Type] = proj =>
 		{

--- a/Content/SkillSpecials/RainOfArrowsSpecials/PiercingPrecision.cs
+++ b/Content/SkillSpecials/RainOfArrowsSpecials/PiercingPrecision.cs
@@ -5,6 +5,7 @@ using PathOfTerraria.Content.SkillPassives.RainOfArrowsPassives;
 using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Content.SkillTrees;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Content.SkillSpecials.RainOfArrowsSpecials;
 
@@ -15,6 +16,7 @@ internal class PiercingPrecision(SkillTree tree) : SkillSpecial(tree)
 		public override string Texture => "Terraria/Images/NPC_0";
 
 		private int ProjToShoot => (int)Projectile.ai[0];
+		private int SpawnerItemType => (int)Projectile.ai[1];
 		private ref float Counter => ref Projectile.ai[2];
 
 		IEntitySource src = null;
@@ -52,6 +54,11 @@ internal class PiercingPrecision(SkillTree tree) : SkillSpecial(tree)
 
 					Projectile projectile = Main.projectile[proj];
 					projectile.GetGlobalProjectile<RainOfArrows.RainProjectile>().SetRainProjectile(Main.projectile[proj], Projectile.timeLeft == 8);
+
+					if (RainOfArrowsSets.PostModify.TryGetValue(SpawnerItemType, out RainOfArrowsSets.PostModifyShootDelegate hook))
+					{
+						hook.Invoke(player, ContentSamples.ItemsByType[SpawnerItemType], projectile, proj);
+					}
 				}
 
 				Counter++;

--- a/Content/Skills/Ranged/RainOfArrows.cs
+++ b/Content/Skills/Ranged/RainOfArrows.cs
@@ -20,6 +20,23 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Skills.Ranged;
 
+public class RainOfArrowsSets
+{
+	public delegate bool GetShootDataDelegate(Player player, Item item, out int projToShoot, out float speed, out int damage, out float knockBack, out int usedAmmoItemId);
+	public delegate void PostModifyShootDelegate(Player player, Item item, Projectile projectile, int projWhoAmI);
+
+	/// <summary>
+	/// Allows invalid or channeled items to have Flurry functionality with custom code.
+	/// </summary>
+	public static readonly Dictionary<int, GetShootDataDelegate> CustomFunctionalities = [];
+
+	/// <summary>
+	/// Allows items to modify the projectile(s) spawned by Flurry. 
+	/// The item passed in to this hook will not be from <see cref="ContentSamples"/> when using <see cref="PiercingPrecision"/>.
+	/// </summary>
+	public static readonly Dictionary<int, PostModifyShootDelegate> PostModify = [];
+}
+
 public class RainOfArrows : Skill
 {
 	private static readonly HashSet<int> WeaponBlacklist = [ItemID.Harpoon, ItemID.Flamethrower, ItemID.ElfMelter];
@@ -58,18 +75,33 @@ public class RainOfArrows : Skill
 
 	protected override void InternalUseSkill(Player player)
 	{
-		if (!player.PickAmmo(player.HeldItem, out int projToShoot, out float speed, out int damage, out float knockBack, out int ammo, true))
+		int projToShoot;
+		float speed;
+		int damage;
+		float knockBack;
+		int ammo;
+		bool hasCustom = false;
+
+		if (hasCustom = RainOfArrowsSets.CustomFunctionalities.TryGetValue(player.HeldItem.type, out RainOfArrowsSets.GetShootDataDelegate info))
+		{
+			if (!info.Invoke(player, player.HeldItem, out projToShoot, out speed, out damage, out knockBack, out ammo))
+			{
+				return;
+			}
+		}
+		else if (!player.PickAmmo(player.HeldItem, out projToShoot, out speed, out damage, out knockBack, out ammo, true))
 		{
 			return;
 		}
 
-		if (player.HeldItem.ModItem is not null)
+		if (!hasCustom && player.HeldItem.ModItem is not null)
 		{
 			Vector2 throwaway = Vector2.Zero;
 			ItemLoader.ModifyShootStats(player.HeldItem, player, ref throwaway, ref throwaway, ref projToShoot, ref damage, ref knockBack);
 		}
 
 		damage = GetTotalDamage(damage * (1 + Level * 0.15f));
+		_ = speed; // Throwaway to remove the warning, this isn't used but may be used in the future
 
 		if (projToShoot <= 0)
 		{
@@ -99,6 +131,11 @@ public class RainOfArrows : Skill
 				Projectile projectile = Main.projectile[proj];
 				projectile.GetGlobalProjectile<RainProjectile>().SetRainProjectile(Main.projectile[proj], i == 0);
 
+				if (RainOfArrowsSets.PostModify.TryGetValue(player.HeldItem.type, out RainOfArrowsSets.PostModifyShootDelegate hook))
+				{
+					hook.Invoke(player, player.HeldItem, projectile, proj);
+				}
+
 				if (shattering)
 				{
 					projectile.scale *= 0.5f;
@@ -108,7 +145,7 @@ public class RainOfArrows : Skill
 		else
 		{
 			int type = ModContent.ProjectileType<PiercingPrecision.PrecisionSpawnerProjectile>();
-			Projectile.NewProjectile(src, player.Center, Vector2.Zero, type, damage, knockBack, player.whoAmI, projToShoot);
+			Projectile.NewProjectile(src, player.Center, Vector2.Zero, type, damage, knockBack, player.whoAmI, projToShoot, player.HeldItem.type);
 		}
 	}
 
@@ -138,7 +175,7 @@ public class RainOfArrows : Skill
 			return false;
 		}
 
-		if (Main.LocalPlayer.HeldItem.channel)
+		if (Main.LocalPlayer.HeldItem.channel && !RainOfArrowsSets.CustomFunctionalities.ContainsKey(Main.LocalPlayer.HeldItem.type))
 		{
 			failReason = new SkillFailure(SkillFailReason.Other, "BadChanneled");
 			return false;

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	Name: Hollow Vessel
-	Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage. 
+	Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }


### PR DESCRIPTION
…able, add support for all PoT bows + Warden's Bow synergy

﻿### Description of Work

<!-- pot-changelog-desc:start -->
### Features

- add in system for items to allow Flurry even if not (normally) able, add support for all PoT bows + Warden's Bow synergy
<!-- pot-changelog-desc:end -->
See title & commit.
Also added sync for RavencrestSystem.SpawnedScout but I doubt that'll have an in-game effect.