### PR TITLE
Fix hardmode map drops

### DIFF
--- a/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
@@ -1,5 +1,4 @@
 ﻿using PathOfTerraria.Common.Items;
-using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 
@@ -9,18 +8,7 @@ internal abstract class BossMap(int tier, int level, Func<bool> defeatCondition,
 	public override int WorldLevel => level;
 	protected override bool RollsAdjacentTiers => false;
 
-	public override bool CanDrop
-	{
-		get
-		{
-			if (hardMode && PoTItemHelper.PickItemLevel() < WorldLevelBasedOnTier(tier))
-			{
-				return false;
-			}
-
-			return defeatCondition();
-		}
-	}
+	public override bool CanDrop => defeatCondition();
 
 	public override int GetMapTier(int _)
 	{

--- a/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
@@ -17,7 +17,6 @@ internal abstract class BossMap(int tier, int level, Func<bool> defeatCondition,
 			return 1;
 		}
 
-		// Hardmode boss maps can only drop with their own tier
 		return tier;
 	}
 


### PR DESCRIPTION
﻿### Description of Work

<!-- pot-changelog-desc:start -->
### Bug Fixes

- Hardmode map drops do not require area item level to drop
<!-- pot-changelog-desc:end -->
See fix commit.
