### PR TITLE
fix(summoner): prevent recursive raging spirits

### DIFF
--- a/Content/Passives/Summon/Masteries/RagingSpiritsMastery.cs
+++ b/Content/Passives/Summon/Masteries/RagingSpiritsMastery.cs
@@ -11,7 +11,9 @@ internal class RagingSpiritsMastery : Passive
 	{
 		public override void OnHitNPC(Projectile projectile, NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (projectile.minion && projectile.TryGetOwner(out Player owner) &&
+			// Raging Spirits are minions, so exclude the proc projectile to prevent recursive summon chains.
+			if (projectile.minion && projectile.type != ModContent.ProjectileType<RagingSpirit>() &&
+			    projectile.TryGetOwner(out Player owner) &&
 			    owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<RagingSpiritsMastery>(out float value) &&
 			    Main.rand.NextFloat() < value / 100f)
 			{


### PR DESCRIPTION
## Summary

- prevent Raging Spirit projectiles from triggering the Raging Spirits mastery
- preserve existing minion classification and other summon interactions
- stop recursive spirit chains while retaining the intended proc from normal minion hits

## Root cause

The mastery accepted any projectile marked as a minion. Raging Spirit is itself marked as a minion, so its hits could pass the same proc check and summon additional Raging Spirits.

## Patch notes

- Fixed Raging Spirits being able to summon additional Raging Spirits on hit, preventing recursive summon chains and runaway damage.

## Validation

- `dotnet build PathOfTerraria.csproj -p:KBOEffectsIgnoreErrors=true` — succeeded with 0 warnings and 0 errors
- `git diff --check` — passed
- verified the trigger continues to accept normal minion projectiles while explicitly rejecting `RagingSpirit`

Closes #2145
