### PR TITLE
fix: make shield block chance an inherent stat

### DIFF
--- a/Common/Systems/Affixes/ItemTypes/DefenseAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/DefenseAffixes.cs
@@ -59,6 +59,6 @@ internal class AddBlockAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<BlockPlayer>().AddBlockChance(1 + Value / 100f);
+		player.GetModPlayer<BlockPlayer>().AddBlockChance(Value / 100f);
 	}
 }

--- a/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
+++ b/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class BronzeKiteshield : Shield
 {
-	protected override float BlockChance => 0.1f;
+	internal override float BaseBlockChance => 0.20f;
+	protected override float ImplicitBlockChance => 0.1f;
 	protected override float SpeedReduction => 1.4f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
+++ b/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class BronzeKiteshield : Shield
 {
 	internal override float BaseBlockChance => 0.20f;
-	protected override float ImplicitBlockChance => 0.1f;
-	protected override float SpeedReduction => 1.4f;
+	protected override float SpeedReduction => 4f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class CorrodedTowerShield : Shield
 {
 	internal override float BaseBlockChance => 0.22f;
-	protected override float ImplicitBlockChance => 0.05f;
-	protected override float SpeedReduction => 1.5f;
+	protected override float SpeedReduction => 5f;
 
 	protected override void InternalDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class CorrodedTowerShield : Shield
 {
-	protected override float BlockChance => 0.05f;
+	internal override float BaseBlockChance => 0.22f;
+	protected override float ImplicitBlockChance => 0.05f;
 	protected override float SpeedReduction => 1.5f;
 
 	protected override void InternalDefaults()

--- a/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
+++ b/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class CrimsonBulwark : Shield
 {
 	internal override float BaseBlockChance => 0.23f;
-	protected override float ImplicitBlockChance => 0.18f;
-	protected override float SpeedReduction => 1.5f;
+	protected override float SpeedReduction => 5f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
+++ b/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class CrimsonBulwark : Shield
 {
-	protected override float BlockChance => 0.18f;
+	internal override float BaseBlockChance => 0.23f;
+	protected override float ImplicitBlockChance => 0.18f;
 	protected override float SpeedReduction => 1.5f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
+++ b/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
@@ -2,7 +2,8 @@
 
 internal class LeatherBuckler : Shield
 {
-	protected override float BlockChance => 0.08f;
+	internal override float BaseBlockChance => 0.18f;
+	protected override float ImplicitBlockChance => 0.08f;
 	protected override float SpeedReduction => 1.2f;
 
 	protected override void InternalDefaults()

--- a/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
+++ b/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
@@ -3,8 +3,7 @@
 internal class LeatherBuckler : Shield
 {
 	internal override float BaseBlockChance => 0.18f;
-	protected override float ImplicitBlockChance => 0.08f;
-	protected override float SpeedReduction => 1.2f;
+	protected override float SpeedReduction => 2f;
 
 	protected override void InternalDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
+++ b/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class ObsidianShell : Shield
 {
 	internal override float BaseBlockChance => 0.21f;
-	protected override float ImplicitBlockChance => 0.20f;
-	protected override float SpeedReduction => 2.5f;
+	protected override float SpeedReduction => 4f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
+++ b/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class ObsidianShell : Shield
 {
-	protected override float BlockChance => 0.20f;
+	internal override float BaseBlockChance => 0.21f;
+	protected override float ImplicitBlockChance => 0.20f;
 	protected override float SpeedReduction => 2.5f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/PlankShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/PlankShield.cs
@@ -2,7 +2,8 @@
 
 internal class PlankShield : Shield
 {
-	protected override float BlockChance => 0.02f;
+	internal override float BaseBlockChance => 0.22f;
+	protected override float ImplicitBlockChance => 0.02f;
 	protected override float SpeedReduction => 1.5f;
 
 	protected override void InternalDefaults()

--- a/Content/Items/Gear/Offhands/Shields/PlankShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/PlankShield.cs
@@ -3,8 +3,7 @@
 internal class PlankShield : Shield
 {
 	internal override float BaseBlockChance => 0.22f;
-	protected override float ImplicitBlockChance => 0.02f;
-	protected override float SpeedReduction => 1.5f;
+	protected override float SpeedReduction => 5f;
 
 	protected override void InternalDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
+++ b/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class ShadowBarrier : Shield
 {
-	protected override float BlockChance => 0.15f;
+	internal override float BaseBlockChance => 0.23f;
+	protected override float ImplicitBlockChance => 0.15f;
 	protected override float SpeedReduction => 1.2f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
+++ b/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class ShadowBarrier : Shield
 {
 	internal override float BaseBlockChance => 0.23f;
-	protected override float ImplicitBlockChance => 0.15f;
-	protected override float SpeedReduction => 1.2f;
+	protected override float SpeedReduction => 3f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/Shield.cs
+++ b/Content/Items/Gear/Offhands/Shields/Shield.cs
@@ -9,7 +9,6 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal abstract class Shield : Offhand
 {
 	internal abstract float BaseBlockChance { get; }
-	protected abstract float ImplicitBlockChance { get; }
 	protected abstract float SpeedReduction { get; }
 	protected override string GearLocalizationCategory => "Shield";
 
@@ -38,13 +37,21 @@ internal abstract class Shield : Offhand
 	{
 		player.GetModPlayer<BlockPlayer>().AddBlockChance(BaseBlockChance);
 	}
+
+	public override void PostRoll()
+	{
+		base.PostRoll();
+
+		PoTInstanceItemData data = Item.GetInstanceData();
+		int removedImplicits = data.Affixes.RemoveAll(affix => affix is AddBlockAffix && affix.IsImplicit);
+		data.ImplicitCount = Math.Max(0, data.ImplicitCount - removedImplicits);
+	}
 	
 	public override List<ItemAffix> GenerateImplicits()
 	{
 		return
 		[
 			(ItemAffix)Affix.CreateAffix<MovementSpeedAffix>(-SpeedReduction),
-			(ItemAffix)Affix.CreateAffix<AddBlockAffix>(ImplicitBlockChance * 100),
 		];
 	}
 }

--- a/Content/Items/Gear/Offhands/Shields/Shield.cs
+++ b/Content/Items/Gear/Offhands/Shields/Shield.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+using PathOfTerraria.Common.Systems.BlockSystem;
 
 namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal abstract class Shield : Offhand
 {
-	protected abstract float BlockChance { get; }
+	internal abstract float BaseBlockChance { get; }
+	protected abstract float ImplicitBlockChance { get; }
 	protected abstract float SpeedReduction { get; }
 	protected override string GearLocalizationCategory => "Shield";
 
@@ -31,13 +33,18 @@ internal abstract class Shield : Offhand
 	protected virtual void InternalDefaults()
 	{
 	}
+
+	public override void UpdateAccessory(Player player, bool hideVisual)
+	{
+		player.GetModPlayer<BlockPlayer>().AddBlockChance(BaseBlockChance);
+	}
 	
 	public override List<ItemAffix> GenerateImplicits()
 	{
 		return
 		[
 			(ItemAffix)Affix.CreateAffix<MovementSpeedAffix>(-SpeedReduction),
-			(ItemAffix)Affix.CreateAffix<AddBlockAffix>(BlockChance * 100),
+			(ItemAffix)Affix.CreateAffix<AddBlockAffix>(ImplicitBlockChance * 100),
 		];
 	}
 }

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -22,7 +22,6 @@ using Terraria.UI;
 using SubworldLibrary;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.ElementalDamage;
-using PathOfTerraria.Common.Systems.BlockSystem;
 using Terraria.ID;
 using Terraria.GameContent.RGB;
 using PathOfTerraria.Common.UI;
@@ -769,23 +768,17 @@ public sealed partial class ItemTooltips : GlobalItem
 
 	private static float GetModifiedBlockChance(Item item, Shield shield)
 	{
-		float blockChance = shield.BaseBlockChance;
 		float blockChanceMultiplier = 1f;
 
 		foreach (ItemAffix affix in item.GetInstanceData().Affixes)
 		{
-			switch (affix)
+			if (affix is IncreaseBlockAffix)
 			{
-				case AddBlockAffix:
-					blockChance = Math.Min(blockChance + affix.Value / 100f, BlockPlayer.DefaultMaxBlockChance);
-					break;
-				case IncreaseBlockAffix:
-					blockChanceMultiplier *= 1 + affix.Value / 100f;
-					break;
+				blockChanceMultiplier *= 1 + affix.Value / 100f;
 			}
 		}
 
-		return blockChance * blockChanceMultiplier;
+		return shield.BaseBlockChance * blockChanceMultiplier;
 	}
 
 	private static (int Minimum, int Maximum)? GetDefenseRollRange(Item item)

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -521,7 +521,7 @@ public sealed partial class ItemTooltips : GlobalItem
 		if (modifiedDefense > 0)
 		{
 			Color defenseNumberColor = modifiedDefense == item.defense ? Colors.DefaultNumber : Colors.ModifiedStat;
-			string defenseDetails = Main.keyState.PressingShift()
+			string defenseDetails = IsAltHeld()
 				? FormatBaseStatDetails(item.defense, modifiedDefense, GetDefenseRollRange(item))
 				: string.Empty;
 			var def = new TooltipLine(Mod, "Defense",
@@ -535,8 +535,7 @@ public sealed partial class ItemTooltips : GlobalItem
 			float modifiedBlockChance = GetModifiedBlockChance(item, shield) * 100f;
 			bool isModified = Math.Abs(modifiedBlockChance - baseBlockChance) > 0.001f;
 			Color blockChanceNumberColor = isModified ? Colors.ModifiedStat : Colors.DefaultNumber;
-			bool isAltHeld = Main.keyState.IsKeyDown(Keys.LeftAlt) || Main.keyState.IsKeyDown(Keys.RightAlt);
-			string blockChanceDetails = isModified && isAltHeld
+			string blockChanceDetails = isModified && IsAltHeld()
 				? FormatBaseStatDetails(baseBlockChance, modifiedBlockChance)
 				: string.Empty;
 			var blockChanceLine = new TooltipLine(Mod, "BlockChance",
@@ -827,6 +826,11 @@ public sealed partial class ItemTooltips : GlobalItem
 		float modifier = modifiedValue - baseValue;
 		Color modifierColor = modifier > 0 ? Colors.ModifiedStat : Colors.Negative;
 		return $" ({HighlightNumbers($"base {baseValue:0.##}")} {HighlightNumbers(FormatSignedNumber(modifier), modifierColor)})";
+	}
+
+	private static bool IsAltHeld()
+	{
+		return Main.keyState.IsKeyDown(Keys.LeftAlt) || Main.keyState.IsKeyDown(Keys.RightAlt);
 	}
 
 	private static string FormatSignedNumber(int value)

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -12,7 +12,9 @@ using PathOfTerraria.Content.Items.Consumables.Maps;
 using PathOfTerraria.Content.Items.Consumables.Maps.ExplorableMaps;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Gear;
+using PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 using PathOfTerraria.Utilities.Xna;
+using Microsoft.Xna.Framework.Input;
 using ReLogic.Content;
 using Terraria.Graphics.Effects;
 using Terraria.Localization;
@@ -20,6 +22,7 @@ using Terraria.UI;
 using SubworldLibrary;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.ElementalDamage;
+using PathOfTerraria.Common.Systems.BlockSystem;
 using Terraria.ID;
 using Terraria.GameContent.RGB;
 using PathOfTerraria.Common.UI;
@@ -527,6 +530,21 @@ public sealed partial class ItemTooltips : GlobalItem
 			AddNewTooltipLine(item, tooltips, def);
 		}
 
+		if (item.ModItem is Shield shield)
+		{
+			float baseBlockChance = shield.BaseBlockChance * 100f;
+			float modifiedBlockChance = GetModifiedBlockChance(item, shield) * 100f;
+			bool isModified = Math.Abs(modifiedBlockChance - baseBlockChance) > 0.001f;
+			Color blockChanceNumberColor = isModified ? Colors.ModifiedStat : Colors.DefaultNumber;
+			bool isAltHeld = Main.keyState.IsKeyDown(Keys.LeftAlt) || Main.keyState.IsKeyDown(Keys.RightAlt);
+			string blockChanceDetails = isModified && isAltHeld
+				? FormatBaseStatDetails(baseBlockChance, modifiedBlockChance)
+				: string.Empty;
+			var blockChanceLine = new TooltipLine(Mod, "BlockChance",
+				$"{ColoredDot(Colors.StatsAccent)} {HighlightNumbers($"{modifiedBlockChance:0.##}%", blockChanceNumberColor)} {Localize("BlockChance")}{blockChanceDetails}");
+			AddNewTooltipLine(item, tooltips, blockChanceLine);
+		}
+
 		if (item.ModItem is IEnergyShieldItem)
 		{
 			int baseEnergyShield = EnergyShieldItem.GetBaseEnergyShield(item);
@@ -749,6 +767,27 @@ public sealed partial class ItemTooltips : GlobalItem
 		return Math.Max(0, item.defense + (int)Math.Round(addedDefense));
 	}
 
+	private static float GetModifiedBlockChance(Item item, Shield shield)
+	{
+		float blockChance = shield.BaseBlockChance;
+		float blockChanceMultiplier = 1f;
+
+		foreach (ItemAffix affix in item.GetInstanceData().Affixes)
+		{
+			switch (affix)
+			{
+				case AddBlockAffix:
+					blockChance = Math.Min(blockChance + affix.Value / 100f, BlockPlayer.DefaultMaxBlockChance);
+					break;
+				case IncreaseBlockAffix:
+					blockChanceMultiplier *= 1 + affix.Value / 100f;
+					break;
+			}
+		}
+
+		return blockChance * blockChanceMultiplier;
+	}
+
 	private static (int Minimum, int Maximum)? GetDefenseRollRange(Item item)
 	{
 		if (item.ModItem is not IDefenseRangeItem rangeItem)
@@ -790,9 +829,21 @@ public sealed partial class ItemTooltips : GlobalItem
 		return details.Count == 0 ? string.Empty : $" ({string.Join("; ", details)})";
 	}
 
+	private static string FormatBaseStatDetails(float baseValue, float modifiedValue)
+	{
+		float modifier = modifiedValue - baseValue;
+		Color modifierColor = modifier > 0 ? Colors.ModifiedStat : Colors.Negative;
+		return $" ({HighlightNumbers($"base {baseValue:0.##}")} {HighlightNumbers(FormatSignedNumber(modifier), modifierColor)})";
+	}
+
 	private static string FormatSignedNumber(int value)
 	{
 		return value > 0 ? $"+{value}" : value.ToString();
+	}
+
+	private static string FormatSignedNumber(float value)
+	{
+		return value > 0 ? $"+{value:0.##}" : value.ToString("0.##");
 	}
 
 	public static string HighlightNumbers(string input, Color? numColor = null, Color? baseColor = null)

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	Tier: Tier:
 	Level: Item level:
 	Defense: Defense
+	BlockChance: Block Chance
 	EnergyShield: Energy Shield
 	Pickaxe: Pickaxe Power
 	Axe: Axe Power


### PR DESCRIPTION
## Summary

- Make block chance an inherent shield stat instead of a generated implicit affix.
- Align every shield's base block chance and movement penalty with the official shield stat table.
- Add a shield tooltip stat that is neutral at its base value, turns blue when increased-block affixes modify it, and shows the original calculation while Alt is held.
- Use Alt consistently for both Block Chance and Defense base/modifier breakdowns.
- Remove legacy flat-block implicits from existing shields during post-load/post-roll while preserving their remaining implicit count.

Leather Bucklers now have one inherent 18% block chance. They no longer combine an 18% base with a hidden `+8 block chance` implicit.

## Root cause

An earlier shield-to-implicit conversion replaced shields' inherent block chance with a generated flat-block implicit. That implicit also applied an erroneous extra 100%, forcing equipped shields to the 40% cap. Block chance is now owned by the shield base, while the normal `increased block chance` affix remains able to modify it.

## Consumer-facing patch notes

- Shields now use their intended inherent block chance instead of a separate block implicit.
- Updated shield block chances and movement penalties to match the official shield base stats.
- Shield tooltips now display total block chance. Base values use a neutral color, modified values appear blue, and holding Alt reveals the original value and modifier.
- Holding Alt over armor now reveals its base Defense, local modifiers, and base roll range when available.
- Existing shields automatically discard the obsolete block implicit.

## Validation

- `dotnet build PathOfTerraria.csproj` — succeeded with 0 errors (9 existing warnings)
- `git diff --check origin/develop...HEAD` — passed

Reference: https://wiki.pathofterraria.com/Gear/Shield
