### PR TITLE
3.0.10

### DIFF
--- a/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
+++ b/Common/Subworlds/RavencrestContent/RavencrestSystem.cs
@@ -464,6 +464,7 @@ public class RavencrestSystem : ModSystem
 
 	public override void NetSend(BinaryWriter writer)
 	{
+		writer.Write(SpawnedScout);
 		writer.Write((short)HasOverworldNPC.Count);
 
 		foreach (string npc in HasOverworldNPC)
@@ -483,6 +484,7 @@ public class RavencrestSystem : ModSystem
 
 	public override void NetReceive(BinaryReader reader)
 	{
+		SpawnedScout = reader.ReadBoolean();
 		HasOverworldNPC.Clear();
 		short count = reader.ReadInt16();
 

--- a/Common/Systems/Affixes/ItemTypes/DefenseAffixes.cs
+++ b/Common/Systems/Affixes/ItemTypes/DefenseAffixes.cs
@@ -59,6 +59,6 @@ internal class AddBlockAffix : ItemAffix
 {
 	public override void ApplyAffix(Player player, EntityModifier modifier, Item item)
 	{
-		player.GetModPlayer<BlockPlayer>().AddBlockChance(1 + Value / 100f);
+		player.GetModPlayer<BlockPlayer>().AddBlockChance(Value / 100f);
 	}
 }

--- a/Common/Systems/ElementalDamage/ElementalContainer.cs
+++ b/Common/Systems/ElementalDamage/ElementalContainer.cs
@@ -110,6 +110,7 @@ public class ElementInstance(ElementType type, bool isGeneric)
 	{
 		Multiplier = 1;
 		Resistance = 0;
+		playerIsImmune = false;
 
 		if (resetModifiers)
 		{

--- a/Common/Systems/ElementalDamage/ElementalPlayer.cs
+++ b/Common/Systems/ElementalDamage/ElementalPlayer.cs
@@ -141,7 +141,7 @@ public class ElementalPlayer : ModPlayer
 		foreach (ElementInstance element in container)
 		{
 			float conversion = GetRawConversion(element, item) * conversionScale;
-			float resistanceMultiplier = element.GetDamageMultiplier();
+			float resistanceMultiplier = other[element.Type].GetDamageMultiplier();
 			elementalDamage += conversion * element.Multiplier * resistanceMultiplier;
 		}
 

--- a/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
@@ -1,5 +1,4 @@
 ﻿using PathOfTerraria.Common.Items;
-using PathOfTerraria.Core.Items;
 
 namespace PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 
@@ -9,18 +8,7 @@ internal abstract class BossMap(int tier, int level, Func<bool> defeatCondition,
 	public override int WorldLevel => level;
 	protected override bool RollsAdjacentTiers => false;
 
-	public override bool CanDrop
-	{
-		get
-		{
-			if (hardMode && PoTItemHelper.PickItemLevel() < WorldLevelBasedOnTier(tier))
-			{
-				return false;
-			}
-
-			return defeatCondition();
-		}
-	}
+	public override bool CanDrop => defeatCondition();
 
 	public override int GetMapTier(int _)
 	{

--- a/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
+++ b/Content/Items/Consumables/Maps/BossMaps/BossMap.cs
@@ -17,7 +17,6 @@ internal abstract class BossMap(int tier, int level, Func<bool> defeatCondition,
 			return 1;
 		}
 
-		// Hardmode boss maps can only drop with their own tier
 		return tier;
 	}
 

--- a/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
+++ b/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class BronzeKiteshield : Shield
 {
-	protected override float BlockChance => 0.1f;
+	internal override float BaseBlockChance => 0.20f;
+	protected override float ImplicitBlockChance => 0.1f;
 	protected override float SpeedReduction => 1.4f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
+++ b/Content/Items/Gear/Offhands/Shields/BronzeKiteshield.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class BronzeKiteshield : Shield
 {
 	internal override float BaseBlockChance => 0.20f;
-	protected override float ImplicitBlockChance => 0.1f;
-	protected override float SpeedReduction => 1.4f;
+	protected override float SpeedReduction => 4f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class CorrodedTowerShield : Shield
 {
 	internal override float BaseBlockChance => 0.22f;
-	protected override float ImplicitBlockChance => 0.05f;
-	protected override float SpeedReduction => 1.5f;
+	protected override float SpeedReduction => 5f;
 
 	protected override void InternalDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/CorrodedTowerShield.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class CorrodedTowerShield : Shield
 {
-	protected override float BlockChance => 0.05f;
+	internal override float BaseBlockChance => 0.22f;
+	protected override float ImplicitBlockChance => 0.05f;
 	protected override float SpeedReduction => 1.5f;
 
 	protected override void InternalDefaults()

--- a/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
+++ b/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class CrimsonBulwark : Shield
 {
 	internal override float BaseBlockChance => 0.23f;
-	protected override float ImplicitBlockChance => 0.18f;
-	protected override float SpeedReduction => 1.5f;
+	protected override float SpeedReduction => 5f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
+++ b/Content/Items/Gear/Offhands/Shields/CrimsonBulwark.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class CrimsonBulwark : Shield
 {
-	protected override float BlockChance => 0.18f;
+	internal override float BaseBlockChance => 0.23f;
+	protected override float ImplicitBlockChance => 0.18f;
 	protected override float SpeedReduction => 1.5f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
+++ b/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
@@ -2,7 +2,8 @@
 
 internal class LeatherBuckler : Shield
 {
-	protected override float BlockChance => 0.08f;
+	internal override float BaseBlockChance => 0.18f;
+	protected override float ImplicitBlockChance => 0.08f;
 	protected override float SpeedReduction => 1.2f;
 
 	protected override void InternalDefaults()

--- a/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
+++ b/Content/Items/Gear/Offhands/Shields/LeatherBuckler.cs
@@ -3,8 +3,7 @@
 internal class LeatherBuckler : Shield
 {
 	internal override float BaseBlockChance => 0.18f;
-	protected override float ImplicitBlockChance => 0.08f;
-	protected override float SpeedReduction => 1.2f;
+	protected override float SpeedReduction => 2f;
 
 	protected override void InternalDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
+++ b/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class ObsidianShell : Shield
 {
 	internal override float BaseBlockChance => 0.21f;
-	protected override float ImplicitBlockChance => 0.20f;
-	protected override float SpeedReduction => 2.5f;
+	protected override float SpeedReduction => 4f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
+++ b/Content/Items/Gear/Offhands/Shields/ObsidianShell.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class ObsidianShell : Shield
 {
-	protected override float BlockChance => 0.20f;
+	internal override float BaseBlockChance => 0.21f;
+	protected override float ImplicitBlockChance => 0.20f;
 	protected override float SpeedReduction => 2.5f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/PlankShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/PlankShield.cs
@@ -2,7 +2,8 @@
 
 internal class PlankShield : Shield
 {
-	protected override float BlockChance => 0.02f;
+	internal override float BaseBlockChance => 0.22f;
+	protected override float ImplicitBlockChance => 0.02f;
 	protected override float SpeedReduction => 1.5f;
 
 	protected override void InternalDefaults()

--- a/Content/Items/Gear/Offhands/Shields/PlankShield.cs
+++ b/Content/Items/Gear/Offhands/Shields/PlankShield.cs
@@ -3,8 +3,7 @@
 internal class PlankShield : Shield
 {
 	internal override float BaseBlockChance => 0.22f;
-	protected override float ImplicitBlockChance => 0.02f;
-	protected override float SpeedReduction => 1.5f;
+	protected override float SpeedReduction => 5f;
 
 	protected override void InternalDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
+++ b/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
@@ -4,7 +4,8 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal class ShadowBarrier : Shield
 {
-	protected override float BlockChance => 0.15f;
+	internal override float BaseBlockChance => 0.23f;
+	protected override float ImplicitBlockChance => 0.15f;
 	protected override float SpeedReduction => 1.2f;
 
 	public override void SetStaticDefaults()

--- a/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
+++ b/Content/Items/Gear/Offhands/Shields/ShadowBarrier.cs
@@ -5,8 +5,7 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal class ShadowBarrier : Shield
 {
 	internal override float BaseBlockChance => 0.23f;
-	protected override float ImplicitBlockChance => 0.15f;
-	protected override float SpeedReduction => 1.2f;
+	protected override float SpeedReduction => 3f;
 
 	public override void SetStaticDefaults()
 	{

--- a/Content/Items/Gear/Offhands/Shields/Shield.cs
+++ b/Content/Items/Gear/Offhands/Shields/Shield.cs
@@ -9,7 +9,6 @@ namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 internal abstract class Shield : Offhand
 {
 	internal abstract float BaseBlockChance { get; }
-	protected abstract float ImplicitBlockChance { get; }
 	protected abstract float SpeedReduction { get; }
 	protected override string GearLocalizationCategory => "Shield";
 
@@ -38,13 +37,21 @@ internal abstract class Shield : Offhand
 	{
 		player.GetModPlayer<BlockPlayer>().AddBlockChance(BaseBlockChance);
 	}
+
+	public override void PostRoll()
+	{
+		base.PostRoll();
+
+		PoTInstanceItemData data = Item.GetInstanceData();
+		int removedImplicits = data.Affixes.RemoveAll(affix => affix is AddBlockAffix && affix.IsImplicit);
+		data.ImplicitCount = Math.Max(0, data.ImplicitCount - removedImplicits);
+	}
 	
 	public override List<ItemAffix> GenerateImplicits()
 	{
 		return
 		[
 			(ItemAffix)Affix.CreateAffix<MovementSpeedAffix>(-SpeedReduction),
-			(ItemAffix)Affix.CreateAffix<AddBlockAffix>(ImplicitBlockChance * 100),
 		];
 	}
 }

--- a/Content/Items/Gear/Offhands/Shields/Shield.cs
+++ b/Content/Items/Gear/Offhands/Shields/Shield.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
+using PathOfTerraria.Common.Systems.BlockSystem;
 
 namespace PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 
 internal abstract class Shield : Offhand
 {
-	protected abstract float BlockChance { get; }
+	internal abstract float BaseBlockChance { get; }
+	protected abstract float ImplicitBlockChance { get; }
 	protected abstract float SpeedReduction { get; }
 	protected override string GearLocalizationCategory => "Shield";
 
@@ -31,13 +33,18 @@ internal abstract class Shield : Offhand
 	protected virtual void InternalDefaults()
 	{
 	}
+
+	public override void UpdateAccessory(Player player, bool hideVisual)
+	{
+		player.GetModPlayer<BlockPlayer>().AddBlockChance(BaseBlockChance);
+	}
 	
 	public override List<ItemAffix> GenerateImplicits()
 	{
 		return
 		[
 			(ItemAffix)Affix.CreateAffix<MovementSpeedAffix>(-SpeedReduction),
-			(ItemAffix)Affix.CreateAffix<AddBlockAffix>(BlockChance * 100),
+			(ItemAffix)Affix.CreateAffix<AddBlockAffix>(ImplicitBlockChance * 100),
 		];
 	}
 }

--- a/Content/Items/Gear/Weapons/Bow/Bow.cs
+++ b/Content/Items/Gear/Weapons/Bow/Bow.cs
@@ -1,5 +1,6 @@
-﻿using PathOfTerraria.Content.Projectiles.Ranged;
-using PathOfTerraria.Common.Systems;
+﻿using PathOfTerraria.Common.Systems;
+using PathOfTerraria.Content.Projectiles.Ranged;
+using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Core.Items;
 using ReLogic.Content;
 using System.Collections.Generic;
@@ -24,6 +25,19 @@ internal abstract class Bow : Gear
 
 	protected bool IsChanneling;
 
+	public static bool DefaultFlurryFunctionality(Player player, Item item, out int projToShoot, out float speed, out int damage, out float knockBack, out int usedAmmoItemId)
+	{
+		// Get overall info for the usage as if this is a normal bow
+		if (!player.PickAmmo(ContentSamples.ItemsByType[ItemID.WoodenBow], out projToShoot, out speed, out damage, out knockBack, out usedAmmoItemId, true))
+		{
+			return false;
+		}
+
+		// Then adjust to get the 'actual' info for the relevant stats
+		player.PickAmmo(item, out _, out _, out damage, out knockBack, out _, true);
+		return true;
+	}
+
 	public override void SetStaticDefaults()
 	{
 		base.SetStaticDefaults();
@@ -36,6 +50,8 @@ internal abstract class Bow : Gear
 		{
 			BowProjectileSpritesById.Add(Type, ModContent.Request<Texture2D>(Texture + "Animated"));
 		}
+
+		RainOfArrowsSets.CustomFunctionalities.Add(Type, DefaultFlurryFunctionality);
 	}
 
 	public override void SetDefaults()

--- a/Content/Items/Gear/Weapons/Bow/WardensBow.cs
+++ b/Content/Items/Gear/Weapons/Bow/WardensBow.cs
@@ -3,6 +3,7 @@ using PathOfTerraria.Common.Systems.Affixes;
 using PathOfTerraria.Common.Systems.Affixes.ItemTypes;
 using PathOfTerraria.Content.Buffs;
 using PathOfTerraria.Content.Projectiles.Ranged;
+using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Core.Items;
 using System.Collections.Generic;
 using Terraria.DataStructures;
@@ -20,6 +21,11 @@ internal class WardensBow : WoodenBow
 		staticData.DropChance = null;
 		staticData.IsUnique = true;
 		staticData.AltUseDescription = this.GetLocalization("AltUse");
+
+		RainOfArrowsSets.PostModify.Add(Type, new RainOfArrowsSets.PostModifyShootDelegate((player, item, projectile, who) =>
+		{
+			Main.projectile[who].GetGlobalProjectile<WardensBowProjectile>().WardenProj = true;
+		}));
 
 		BowAnimationProjectile.OverridenShootActionsByItemId[Type] = proj =>
 		{

--- a/Content/Passives/Magic/Keystones/HollowVesselKeystone.cs
+++ b/Content/Passives/Magic/Keystones/HollowVesselKeystone.cs
@@ -18,12 +18,12 @@ internal class HollowVesselKeystone : Passive
 				{
 					Player.statLife = 1;
 				}
-			}
-			
-			ElementInstance chaos = Player.GetModPlayer<ElementalPlayer>()
-				.Container[ElementType.Chaos];
 
-			chaos.playerIsImmune = true;
+				ElementInstance chaos = Player.GetModPlayer<ElementalPlayer>()
+					.Container[ElementType.Chaos];
+
+				chaos.playerIsImmune = true;
+			}
 		}
 	}
 }

--- a/Content/Passives/Summon/Masteries/RagingSpiritsMastery.cs
+++ b/Content/Passives/Summon/Masteries/RagingSpiritsMastery.cs
@@ -11,7 +11,9 @@ internal class RagingSpiritsMastery : Passive
 	{
 		public override void OnHitNPC(Projectile projectile, NPC target, NPC.HitInfo hit, int damageDone)
 		{
-			if (projectile.minion && projectile.TryGetOwner(out Player owner) &&
+			// Raging Spirits are minions, so exclude the proc projectile to prevent recursive summon chains.
+			if (projectile.minion && projectile.type != ModContent.ProjectileType<RagingSpirit>() &&
+			    projectile.TryGetOwner(out Player owner) &&
 			    owner.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<RagingSpiritsMastery>(out float value) &&
 			    Main.rand.NextFloat() < value / 100f)
 			{

--- a/Content/SkillSpecials/RainOfArrowsSpecials/PiercingPrecision.cs
+++ b/Content/SkillSpecials/RainOfArrowsSpecials/PiercingPrecision.cs
@@ -5,6 +5,7 @@ using PathOfTerraria.Content.SkillPassives.RainOfArrowsPassives;
 using PathOfTerraria.Content.Skills.Ranged;
 using PathOfTerraria.Content.SkillTrees;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Content.SkillSpecials.RainOfArrowsSpecials;
 
@@ -15,6 +16,7 @@ internal class PiercingPrecision(SkillTree tree) : SkillSpecial(tree)
 		public override string Texture => "Terraria/Images/NPC_0";
 
 		private int ProjToShoot => (int)Projectile.ai[0];
+		private int SpawnerItemType => (int)Projectile.ai[1];
 		private ref float Counter => ref Projectile.ai[2];
 
 		IEntitySource src = null;
@@ -52,6 +54,11 @@ internal class PiercingPrecision(SkillTree tree) : SkillSpecial(tree)
 
 					Projectile projectile = Main.projectile[proj];
 					projectile.GetGlobalProjectile<RainOfArrows.RainProjectile>().SetRainProjectile(Main.projectile[proj], Projectile.timeLeft == 8);
+
+					if (RainOfArrowsSets.PostModify.TryGetValue(SpawnerItemType, out RainOfArrowsSets.PostModifyShootDelegate hook))
+					{
+						hook.Invoke(player, ContentSamples.ItemsByType[SpawnerItemType], projectile, proj);
+					}
 				}
 
 				Counter++;

--- a/Content/Skills/Ranged/RainOfArrows.cs
+++ b/Content/Skills/Ranged/RainOfArrows.cs
@@ -20,6 +20,23 @@ using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Content.Skills.Ranged;
 
+public class RainOfArrowsSets
+{
+	public delegate bool GetShootDataDelegate(Player player, Item item, out int projToShoot, out float speed, out int damage, out float knockBack, out int usedAmmoItemId);
+	public delegate void PostModifyShootDelegate(Player player, Item item, Projectile projectile, int projWhoAmI);
+
+	/// <summary>
+	/// Allows invalid or channeled items to have Flurry functionality with custom code.
+	/// </summary>
+	public static readonly Dictionary<int, GetShootDataDelegate> CustomFunctionalities = [];
+
+	/// <summary>
+	/// Allows items to modify the projectile(s) spawned by Flurry. 
+	/// The item passed in to this hook will not be from <see cref="ContentSamples"/> when using <see cref="PiercingPrecision"/>.
+	/// </summary>
+	public static readonly Dictionary<int, PostModifyShootDelegate> PostModify = [];
+}
+
 public class RainOfArrows : Skill
 {
 	private static readonly HashSet<int> WeaponBlacklist = [ItemID.Harpoon, ItemID.Flamethrower, ItemID.ElfMelter];
@@ -58,18 +75,33 @@ public class RainOfArrows : Skill
 
 	protected override void InternalUseSkill(Player player)
 	{
-		if (!player.PickAmmo(player.HeldItem, out int projToShoot, out float speed, out int damage, out float knockBack, out int ammo, true))
+		int projToShoot;
+		float speed;
+		int damage;
+		float knockBack;
+		int ammo;
+		bool hasCustom = false;
+
+		if (hasCustom = RainOfArrowsSets.CustomFunctionalities.TryGetValue(player.HeldItem.type, out RainOfArrowsSets.GetShootDataDelegate info))
+		{
+			if (!info.Invoke(player, player.HeldItem, out projToShoot, out speed, out damage, out knockBack, out ammo))
+			{
+				return;
+			}
+		}
+		else if (!player.PickAmmo(player.HeldItem, out projToShoot, out speed, out damage, out knockBack, out ammo, true))
 		{
 			return;
 		}
 
-		if (player.HeldItem.ModItem is not null)
+		if (!hasCustom && player.HeldItem.ModItem is not null)
 		{
 			Vector2 throwaway = Vector2.Zero;
 			ItemLoader.ModifyShootStats(player.HeldItem, player, ref throwaway, ref throwaway, ref projToShoot, ref damage, ref knockBack);
 		}
 
 		damage = GetTotalDamage(damage * (1 + Level * 0.15f));
+		_ = speed; // Throwaway to remove the warning, this isn't used but may be used in the future
 
 		if (projToShoot <= 0)
 		{
@@ -99,6 +131,11 @@ public class RainOfArrows : Skill
 				Projectile projectile = Main.projectile[proj];
 				projectile.GetGlobalProjectile<RainProjectile>().SetRainProjectile(Main.projectile[proj], i == 0);
 
+				if (RainOfArrowsSets.PostModify.TryGetValue(player.HeldItem.type, out RainOfArrowsSets.PostModifyShootDelegate hook))
+				{
+					hook.Invoke(player, player.HeldItem, projectile, proj);
+				}
+
 				if (shattering)
 				{
 					projectile.scale *= 0.5f;
@@ -108,7 +145,7 @@ public class RainOfArrows : Skill
 		else
 		{
 			int type = ModContent.ProjectileType<PiercingPrecision.PrecisionSpawnerProjectile>();
-			Projectile.NewProjectile(src, player.Center, Vector2.Zero, type, damage, knockBack, player.whoAmI, projToShoot);
+			Projectile.NewProjectile(src, player.Center, Vector2.Zero, type, damage, knockBack, player.whoAmI, projToShoot, player.HeldItem.type);
 		}
 	}
 
@@ -138,7 +175,7 @@ public class RainOfArrows : Skill
 			return false;
 		}
 
-		if (Main.LocalPlayer.HeldItem.channel)
+		if (Main.LocalPlayer.HeldItem.channel && !RainOfArrowsSets.CustomFunctionalities.ContainsKey(Main.LocalPlayer.HeldItem.type))
 		{
 			failReason = new SkillFailure(SkillFailReason.Other, "BadChanneled");
 			return false;

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -22,7 +22,6 @@ using Terraria.UI;
 using SubworldLibrary;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.ElementalDamage;
-using PathOfTerraria.Common.Systems.BlockSystem;
 using Terraria.ID;
 using Terraria.GameContent.RGB;
 using PathOfTerraria.Common.UI;
@@ -769,23 +768,17 @@ public sealed partial class ItemTooltips : GlobalItem
 
 	private static float GetModifiedBlockChance(Item item, Shield shield)
 	{
-		float blockChance = shield.BaseBlockChance;
 		float blockChanceMultiplier = 1f;
 
 		foreach (ItemAffix affix in item.GetInstanceData().Affixes)
 		{
-			switch (affix)
+			if (affix is IncreaseBlockAffix)
 			{
-				case AddBlockAffix:
-					blockChance = Math.Min(blockChance + affix.Value / 100f, BlockPlayer.DefaultMaxBlockChance);
-					break;
-				case IncreaseBlockAffix:
-					blockChanceMultiplier *= 1 + affix.Value / 100f;
-					break;
+				blockChanceMultiplier *= 1 + affix.Value / 100f;
 			}
 		}
 
-		return blockChance * blockChanceMultiplier;
+		return shield.BaseBlockChance * blockChanceMultiplier;
 	}
 
 	private static (int Minimum, int Maximum)? GetDefenseRollRange(Item item)

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -521,7 +521,7 @@ public sealed partial class ItemTooltips : GlobalItem
 		if (modifiedDefense > 0)
 		{
 			Color defenseNumberColor = modifiedDefense == item.defense ? Colors.DefaultNumber : Colors.ModifiedStat;
-			string defenseDetails = Main.keyState.PressingShift()
+			string defenseDetails = IsAltHeld()
 				? FormatBaseStatDetails(item.defense, modifiedDefense, GetDefenseRollRange(item))
 				: string.Empty;
 			var def = new TooltipLine(Mod, "Defense",
@@ -535,8 +535,7 @@ public sealed partial class ItemTooltips : GlobalItem
 			float modifiedBlockChance = GetModifiedBlockChance(item, shield) * 100f;
 			bool isModified = Math.Abs(modifiedBlockChance - baseBlockChance) > 0.001f;
 			Color blockChanceNumberColor = isModified ? Colors.ModifiedStat : Colors.DefaultNumber;
-			bool isAltHeld = Main.keyState.IsKeyDown(Keys.LeftAlt) || Main.keyState.IsKeyDown(Keys.RightAlt);
-			string blockChanceDetails = isModified && isAltHeld
+			string blockChanceDetails = isModified && IsAltHeld()
 				? FormatBaseStatDetails(baseBlockChance, modifiedBlockChance)
 				: string.Empty;
 			var blockChanceLine = new TooltipLine(Mod, "BlockChance",
@@ -827,6 +826,11 @@ public sealed partial class ItemTooltips : GlobalItem
 		float modifier = modifiedValue - baseValue;
 		Color modifierColor = modifier > 0 ? Colors.ModifiedStat : Colors.Negative;
 		return $" ({HighlightNumbers($"base {baseValue:0.##}")} {HighlightNumbers(FormatSignedNumber(modifier), modifierColor)})";
+	}
+
+	private static bool IsAltHeld()
+	{
+		return Main.keyState.IsKeyDown(Keys.LeftAlt) || Main.keyState.IsKeyDown(Keys.RightAlt);
 	}
 
 	private static string FormatSignedNumber(int value)

--- a/Core/Items/ItemTooltips.cs
+++ b/Core/Items/ItemTooltips.cs
@@ -12,7 +12,9 @@ using PathOfTerraria.Content.Items.Consumables.Maps;
 using PathOfTerraria.Content.Items.Consumables.Maps.ExplorableMaps;
 using PathOfTerraria.Content.Items.Consumables.Maps.BossMaps;
 using PathOfTerraria.Content.Items.Gear;
+using PathOfTerraria.Content.Items.Gear.Offhands.Shields;
 using PathOfTerraria.Utilities.Xna;
+using Microsoft.Xna.Framework.Input;
 using ReLogic.Content;
 using Terraria.Graphics.Effects;
 using Terraria.Localization;
@@ -20,6 +22,7 @@ using Terraria.UI;
 using SubworldLibrary;
 using PathOfTerraria.Common.Subworlds;
 using PathOfTerraria.Common.Systems.ElementalDamage;
+using PathOfTerraria.Common.Systems.BlockSystem;
 using Terraria.ID;
 using Terraria.GameContent.RGB;
 using PathOfTerraria.Common.UI;
@@ -527,6 +530,21 @@ public sealed partial class ItemTooltips : GlobalItem
 			AddNewTooltipLine(item, tooltips, def);
 		}
 
+		if (item.ModItem is Shield shield)
+		{
+			float baseBlockChance = shield.BaseBlockChance * 100f;
+			float modifiedBlockChance = GetModifiedBlockChance(item, shield) * 100f;
+			bool isModified = Math.Abs(modifiedBlockChance - baseBlockChance) > 0.001f;
+			Color blockChanceNumberColor = isModified ? Colors.ModifiedStat : Colors.DefaultNumber;
+			bool isAltHeld = Main.keyState.IsKeyDown(Keys.LeftAlt) || Main.keyState.IsKeyDown(Keys.RightAlt);
+			string blockChanceDetails = isModified && isAltHeld
+				? FormatBaseStatDetails(baseBlockChance, modifiedBlockChance)
+				: string.Empty;
+			var blockChanceLine = new TooltipLine(Mod, "BlockChance",
+				$"{ColoredDot(Colors.StatsAccent)} {HighlightNumbers($"{modifiedBlockChance:0.##}%", blockChanceNumberColor)} {Localize("BlockChance")}{blockChanceDetails}");
+			AddNewTooltipLine(item, tooltips, blockChanceLine);
+		}
+
 		if (item.ModItem is IEnergyShieldItem)
 		{
 			int baseEnergyShield = EnergyShieldItem.GetBaseEnergyShield(item);
@@ -749,6 +767,27 @@ public sealed partial class ItemTooltips : GlobalItem
 		return Math.Max(0, item.defense + (int)Math.Round(addedDefense));
 	}
 
+	private static float GetModifiedBlockChance(Item item, Shield shield)
+	{
+		float blockChance = shield.BaseBlockChance;
+		float blockChanceMultiplier = 1f;
+
+		foreach (ItemAffix affix in item.GetInstanceData().Affixes)
+		{
+			switch (affix)
+			{
+				case AddBlockAffix:
+					blockChance = Math.Min(blockChance + affix.Value / 100f, BlockPlayer.DefaultMaxBlockChance);
+					break;
+				case IncreaseBlockAffix:
+					blockChanceMultiplier *= 1 + affix.Value / 100f;
+					break;
+			}
+		}
+
+		return blockChance * blockChanceMultiplier;
+	}
+
 	private static (int Minimum, int Maximum)? GetDefenseRollRange(Item item)
 	{
 		if (item.ModItem is not IDefenseRangeItem rangeItem)
@@ -790,9 +829,21 @@ public sealed partial class ItemTooltips : GlobalItem
 		return details.Count == 0 ? string.Empty : $" ({string.Join("; ", details)})";
 	}
 
+	private static string FormatBaseStatDetails(float baseValue, float modifiedValue)
+	{
+		float modifier = modifiedValue - baseValue;
+		Color modifierColor = modifier > 0 ? Colors.ModifiedStat : Colors.Negative;
+		return $" ({HighlightNumbers($"base {baseValue:0.##}")} {HighlightNumbers(FormatSignedNumber(modifier), modifierColor)})";
+	}
+
 	private static string FormatSignedNumber(int value)
 	{
 		return value > 0 ? $"+{value}" : value.ToString();
+	}
+
+	private static string FormatSignedNumber(float value)
+	{
+		return value > 0 ? $"+{value:0.##}" : value.ToString("0.##");
 	}
 
 	public static string HighlightNumbers(string input, Color? numColor = null, Color? baseColor = null)

--- a/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	Tier: Stufe
 	Level: Level
 	Defense: Verteidigung
+	// BlockChance: Block Chance
 	// EnergyShield: Energy Shield
 	Pickaxe: Spitzhacken Stärke
 	Axe: Axt Stärke

--- a/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/de-DE/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	Tier: Tier:
 	Level: Item level:
 	Defense: Defense
+	BlockChance: Block Chance
 	EnergyShield: Energy Shield
 	Pickaxe: Pickaxe Power
 	Axe: Axe Power

--- a/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/en-US/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	Name: Hollow Vessel
-	Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage. 
+	Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	// Tier: Tier:
 	// Level: Item level:
 	// Defense: Defense
+	// BlockChance: Block Chance
 	// EnergyShield: Energy Shield
 	// Pickaxe: Pickaxe Power
 	// Axe: Axe Power

--- a/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/es-ES/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	Tier: Rang :
 	Level: Niveau d'objet :
 	Defense: Défense
+	// BlockChance: Block Chance
 	// EnergyShield: Energy Shield
 	Pickaxe: Puissance de la Pioche
 	Axe: Puissance de la Hache

--- a/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/fr-FR/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	Tier: Poziom
 	Level: Poziom przedmiotu
 	Defense: Obrona
+	// BlockChance: Block Chance
 	// EnergyShield: Energy Shield
 	Pickaxe: Moc kilofa
 	Axe: Moc topora

--- a/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pl-PL/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	// Tier: Tier:
 	// Level: Item level:
 	// Defense: Defense
+	// BlockChance: Block Chance
 	// EnergyShield: Energy Shield
 	// Pickaxe: Pickaxe Power
 	// Axe: Axe Power

--- a/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/pt-BR/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Gear.hjson
@@ -11,6 +11,7 @@ Tooltips: {
 	Tier: Тир:
 	Level: Уровень предмета:
 	Defense: Защита
+	// BlockChance: Block Chance
 	// EnergyShield: Energy Shield
 	Pickaxe: Мощность кирки
 	Axe: Мощность топора

--- a/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
+++ b/Localization/ru-RU/Mods.PathOfTerraria.Passives.hjson
@@ -1191,5 +1191,5 @@ CinderBastionMastery: {
 
 HollowVesselKeystone: {
 	// Name: Hollow Vessel
-	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos damage.
+	// Tooltip: You are limited to 1 Maximum Life. Immune to Chaos Damage.
 }

--- a/build.txt
+++ b/build.txt
@@ -2,4 +2,4 @@ displayName = Path of Terraria (BETA)
 author = ScottieKnowz & GabeHasWon
 modReferences = SubworldLibrary, HousingAPI
 dllReferences = NPCUtils, StructureHelper, Wayfarer
-version = 0.3.9
+version = 0.3.10

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,7 @@
-v0.2.12
-- Fixed a critical issue where right clicking a non-equippable item could equip or even duplicate it.
-- Fixed a critical issue where right clicking an accessory could delete it forever.
-- Fixed an issue that could lead to crashes in accessory-adjacent code of other mods such as Calamity's Vanities.
-- Fixed hardmode accessory slots' unreachable items' effects being applied even in non-hardmode worlds.
-- Fixed accessories put in extra accessory slots not being visible.
-- Fixed right clicks not working on extra accessory slots.
-- Removes Desert explorable map spawn rate nerfs
-- Substantially boosts spawn rate in Forest map
-- Improves some Bestiary entries for PoT enemies
+v0.3.9
+- Added in system for items to allow Flurry even if not (normally) able, add support for all PoT bows + Warden's Bow synergy
+- Made hardmode map drops not require area item level to drop
+- Prevented recursive Raging Spirits procs
+- Corrected flat block chance calculation
+- Added a defense breakdown with Alt
+- Added a proper affix tooltip for modified shield block chance (i.e. +10 block chance)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
-v0.3.9
+v0.3.10
 - Added in system for items to allow Flurry even if not (normally) able, add support for all PoT bows + Warden's Bow synergy
 - Made hardmode map drops not require area item level to drop
 - Prevented recursive Raging Spirits procs
 - Corrected flat block chance calculation
 - Added a defense breakdown with Alt
 - Added a proper affix tooltip for modified shield block chance (i.e. +10 block chance)
+- Fixed player immunities not being reset properly for elemental damage types
+- Fixed an issue where the player's elemental immunity would count towards the amount of damage the player does with that element


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- add in system for items to allow Flurry even if not (normally) able, add support for all PoT bows + Warden's Bow synergy
- show modified shield block chance

### Bug Fixes

- Hardmode map drops do not require area item level to drop
- prevent recursive raging spirits
- correct flat block chance calculation
- show defense breakdown with alt
- calculate chaos damage against target defenses
<!-- pot-changelog-desc:end -->
### Comments
