### PR TITLE
fix: issues with affixes rolling when they shouldn't and maps having …

### DIFF
--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -246,9 +246,11 @@ public class AffixRegistry : ILoadable
 			return null;
 		}
 
+		int itemLevel = GetItemLevel.Invoke(item);
 		IEnumerable<ItemAffixData> enumerable = AllItemData
 			.Where(affixData => (itemType & affixData.GetEquipTypes()) != ItemType.None)
-			.Where(affixData => CanApplyToItem(affixData, item));
+			.Where(affixData => CanApplyToItem(affixData, item))
+			.Where(affixData => affixData.CanRollAtLevel(itemLevel));
 
 		if (excludedAffixes != null)
 		{
@@ -265,6 +267,16 @@ public class AffixRegistry : ILoadable
 		int randomIndex = Main.rand.Next(0, filteredAffixData.Count);
 
 		return filteredAffixData[randomIndex];
+	}
+
+	public static bool HasEligibleAffix(Item item, int itemLevel)
+	{
+		ItemType itemType = item.ResolveToSingleType(item.GetInstanceData().ItemType);
+
+		return itemType != ItemType.None && AllItemData.Any(affixData =>
+			(itemType & affixData.GetEquipTypes()) != ItemType.None
+			&& CanApplyToItem(affixData, item)
+			&& affixData.CanRollAtLevel(itemLevel));
 	}
 
 	private static bool CanApplyToItem(ItemAffixData affixData, Item item)

--- a/Common/Data/Models/AffixData.cs
+++ b/Common/Data/Models/AffixData.cs
@@ -42,6 +42,11 @@ public class ItemAffixData
 		return (0, eligibleTiers.Count - 1);
 	}
 
+	public bool CanRollAtLevel(int level)
+	{
+		return Tiers.Any(tier => tier.MinimumLevel <= Math.Max(1, level));
+	}
+
 	public TierData GetAppropriateTierData(int level, out int tierIndex)
 	{
 		var eligibleTiers = Tiers.Where(t => t.MinimumLevel <= level).ToList();

--- a/Common/ItemDropping/DropTable.cs
+++ b/Common/ItemDropping/DropTable.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.Data;
 using PathOfTerraria.Content.Items.Consumables.Maps;
 using PathOfTerraria.Content.Items.Currency;
 using PathOfTerraria.Content.Items.Gear;
@@ -46,6 +47,7 @@ internal class DropTable
 	public static ItemDatabase.ItemRecord RollMobDrops(int itemLevel, float dropRarityModifier, DropCategoryWeights? categoryWeights = null, UnifiedRandom random = null,
 		ItemRarity forceRarity = ItemRarity.Invalid, float uniqueModifier = 1f, bool applyAreaLevelCategoryScaling = true)
 	{
+		itemLevel = itemLevel == 0 ? PoTItemHelper.PickItemLevel() : itemLevel;
 		random ??= Main.rand;
 		DropCategoryWeights weights = categoryWeights ?? DefaultCategoryWeights;
 		
@@ -58,7 +60,7 @@ internal class DropTable
 		float currencyRarityModifier = dropRarityModifier;
 		WeightedRandom<ItemDatabase.ItemRecord> gearPool = GetGearPool(itemLevel, ref gearRarityModifier, [.. ItemDatabase.GetItemByType<Gear>()], IsRecordValid, 0f, random, uniqueModifier);
 		WeightedRandom<ItemDatabase.ItemRecord> currencyPool = GetGearPool(itemLevel, ref currencyRarityModifier, [.. ItemDatabase.GetItemByType<CurrencyShard>()], IsRecordValid, 0f, random, uniqueModifier);
-		WeightedRandom<ItemDatabase.ItemRecord> mapPool = GetWeightedMapPool(random);
+		WeightedRandom<ItemDatabase.ItemRecord> mapPool = GetWeightedMapPool(itemLevel, random);
 
 		var chances = new WeightedRandom<WeightedRandom<ItemDatabase.ItemRecord>>(random);
 		AddPool(chances, gearPool, weights.Gear);
@@ -100,6 +102,7 @@ internal class DropTable
 		UnifiedRandom random = null, ItemRarity forceRarity = ItemRarity.Invalid, float itemRarityModifier = 0, float uniqueModifier = 1f, 
 		bool applyAreaLevelCategoryScaling = true)
 	{
+		itemLevel = itemLevel == 0 ? PoTItemHelper.PickItemLevel() : itemLevel;
 		random ??= Main.rand;
 		DropCategoryWeights weights = categoryWeights ?? DefaultCategoryWeights;
 		
@@ -113,7 +116,7 @@ internal class DropTable
 		var chances = new WeightedRandom<WeightedRandom<ItemDatabase.ItemRecord>>(random);
 		AddPool(chances, GetGearPool(itemLevel, ref gearRarityModifier, [.. ItemDatabase.GetItemByType<Gear>()], IsRecordValid, itemRarityModifier, random, uniqueModifier), weights.Gear);
 		AddPool(chances, GetGearPool(itemLevel, ref currencyRarityModifier, [.. ItemDatabase.GetItemByType<CurrencyShard>()], IsRecordValid, itemRarityModifier, random, uniqueModifier), weights.Currency);
-		AddPool(chances, GetWeightedMapPool(random), weights.Map);
+		AddPool(chances, GetWeightedMapPool(itemLevel, random), weights.Map);
 
 		List<ItemDatabase.ItemRecord> items = [];
 
@@ -138,48 +141,55 @@ internal class DropTable
 		}
 	}
 
-	private static WeightedRandom<ItemDatabase.ItemRecord> GetWeightedMapPool(UnifiedRandom random)
+	private static WeightedRandom<ItemDatabase.ItemRecord> GetWeightedMapPool(int itemLevel, UnifiedRandom random)
 	{
 		WeightedRandom<ItemDatabase.ItemRecord> items = new(random);
+		ItemDatabase.ItemRecord[] droppableMaps =
+		[
+			.. ItemDatabase.GetItemByType<Map>()
+				.Where(record => ((Map)record.Item.ModItem).CanDrop)
+		];
+		bool canRollMapAffixes = droppableMaps.Length > 0
+			&& AffixRegistry.HasEligibleAffix(droppableMaps[0].Item, itemLevel);
+		ItemDatabase.ItemRecord[] availableMaps =
+		[
+			.. droppableMaps.Where(record => record.Rarity == ItemRarity.Normal || canRollMapAffixes)
+		];
 
 		if (Main.hardMode)
 		{
-			ItemDatabase.ItemRecord[] allMaps = [.. ItemDatabase.GetItemByType<Map>().Where(x => ((Map)x.Item.ModItem).CanDrop)];
-			ItemDatabase.ItemRecord[] explorableMaps = [.. allMaps.Where(x => x.Item.ModItem is Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
-			ItemDatabase.ItemRecord[] bossMaps = [.. allMaps.Where(x => x.Item.ModItem is not Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
+			ItemDatabase.ItemRecord[] explorableMaps = [.. availableMaps.Where(x => x.Item.ModItem is Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
+			ItemDatabase.ItemRecord[] bossMaps = [.. availableMaps.Where(x => x.Item.ModItem is not Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
 
 			// Normalize per-category so explorable maps sum to 70% and boss maps sum to 30%, regardless of how many maps are in each category.
-			if (explorableMaps.Length > 0)
-			{
-				float weightPer = 0.7f / explorableMaps.Length;
-
-				foreach (ItemDatabase.ItemRecord record in explorableMaps)
-				{
-					items.Add(record, weightPer);
-				}
-			}
-
-			if (bossMaps.Length > 0)
-			{
-				float weightPer = 0.3f / bossMaps.Length;
-
-				foreach (ItemDatabase.ItemRecord record in bossMaps)
-				{
-					items.Add(record, weightPer);
-				}
-			}
+			AddNormalizedMapCategory(items, explorableMaps, 0.7f);
+			AddNormalizedMapCategory(items, bossMaps, 0.3f);
 		}
 		else
 		{
-			IEnumerable<ItemDatabase.ItemRecord> list = ItemDatabase.GetItemByType<Map>().Where(x => (x.Item.ModItem as Map).CanDrop);
-
-			foreach (ItemDatabase.ItemRecord record in list)
+			foreach (ItemDatabase.ItemRecord record in availableMaps)
 			{
-				items.Add(record);
+				items.Add(record, record.DropChance);
 			}
 		}
 
 		return items;
+	}
+
+	private static void AddNormalizedMapCategory(WeightedRandom<ItemDatabase.ItemRecord> destination,
+		ItemDatabase.ItemRecord[] records, float categoryWeight)
+	{
+		float totalWeight = records.Sum(record => record.DropChance);
+
+		if (totalWeight <= 0f)
+		{
+			return;
+		}
+
+		foreach (ItemDatabase.ItemRecord record in records)
+		{
+			destination.Add(record, categoryWeight * record.DropChance / totalWeight);
+		}
 	}
 
 	private static ItemDatabase.ItemRecord RollList(int itemLevel, float rarityMod, List<ItemDatabase.ItemRecord> filteredGear, UnifiedRandom random = null, float uniqueModifier = 1f)

--- a/Common/ItemDropping/ItemSpawner.cs
+++ b/Common/ItemDropping/ItemSpawner.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Core.Items;
+using PathOfTerraria.Content.Items.Consumables.Maps;
 using System.Collections.Generic;
 using System.Linq;
 using PathOfTerraria.Common.Enums;
@@ -170,8 +171,9 @@ internal class ItemSpawner
 	/// <param name="pos"></param>
 	public static void SpawnMap(Vector2 pos, int tier)
 	{
-		int type = DropTable.RollMobDrops(tier, 0, new DropTable.DropCategoryWeights(0, 0, 1)).Item.type;
+		int itemLevel = Map.WorldLevelBasedOnTier(tier);
+		int type = DropTable.RollMobDrops(itemLevel, 0, new DropTable.DropCategoryWeights(0, 0, 1)).Item.type;
 
-		SpawnItem(type, pos, tier);
+		SpawnItem(type, pos, itemLevel);
 	}
 }

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -48,10 +48,21 @@ public abstract class ItemAffix : Affix
 			};
 		}
 
-		// PoTInstanceItemData itemData = item.GetInstanceData();
-		ItemAffixData.TierData tierData = data.Tiers[Tier];
-
 		(int tierMin, int tierMax) = data.GetPossibleTierRange(itemLevel);
+		if (tierMax < 0 || Tier < tierMin || Tier > tierMax || Tier >= data.Tiers.Count)
+		{
+			return new AffixTooltipLine
+			{
+				Text = this.GetLocalization("Description"),
+				Value = Value,
+				Tier = null,
+				ValueRollRange = null,
+				Corrupt = IsCorruptedAffix,
+				Implicit = IsImplicit,
+			};
+		}
+
+		ItemAffixData.TierData tierData = data.Tiers[Tier];
 
 		return new AffixTooltipLine
 		{

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -22,7 +22,7 @@ namespace PathOfTerraria.Content.Items.Consumables.Maps;
 #nullable enable
 
 public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.IItem, GenerateImplicits.IItem,
-	IPoTGlobalItem, GetItemLevel.IItem, SetItemLevel.IItem
+	IPoTGlobalItem, SetItemLevel.IItem
 {
 	protected sealed override bool CloneNewInstances => true;
 
@@ -198,11 +198,6 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 	public List<ItemAffix> GenerateAffixes()
 	{
 		return [];
-	}
-
-	int GetItemLevel.IItem.GetItemLevel(int realLevel)
-	{
-		return realLevel;
 	}
 
 	void SetItemLevel.IItem.SetItemLevel(int level, ref int realLevel)

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -32,13 +32,11 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 	protected virtual bool RollsAdjacentTiers => true;
 
 	internal int Tier = 1;
-	internal int ItemLevel = 1;
 
 	public override ModItem Clone(Item newEntity)
 	{
 		var map = base.Clone(newEntity) as Map;
 		map!.Tier = Tier;
-		map.ItemLevel = ItemLevel;
 		return map;
 	}
 
@@ -131,7 +129,7 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 	public override void LoadData(TagCompound tag)
 	{
-		Tier = tag.GetShort("tier");
+		Tier = Math.Clamp((int)tag.GetShort("tier"), 1, MaxMapTier);
 	}
 
 	public override void NetSend(BinaryWriter writer)
@@ -141,7 +139,7 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 	public override void NetReceive(BinaryReader reader)
 	{
-		Tier = reader.ReadInt16();
+		Tier = Math.Clamp((int)reader.ReadInt16(), 1, MaxMapTier);
 	}
 
 	public abstract string GenerateName(string defaultName);
@@ -204,19 +202,18 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 	int GetItemLevel.IItem.GetItemLevel(int realLevel)
 	{
-		return ItemLevel;
+		return realLevel;
 	}
 
 	void SetItemLevel.IItem.SetItemLevel(int level, ref int realLevel)
 	{
-		if (RollsAdjacentTiers && level > MaxOverworldLevel)
+		if (RollsAdjacentTiers && level >= MaxOverworldLevel)
 		{
 			level = RollAdjacentMapLevel(level);
 		}
 
 		realLevel = level;
-		ItemLevel = realLevel;
-		Tier = GetMapTier(ItemLevel);
+		Tier = GetMapTier(realLevel);
 	}
 
 	private static int RollAdjacentMapLevel(int level)

--- a/Core/Items/PoTGlobalItem.IO.cs
+++ b/Core/Items/PoTGlobalItem.IO.cs
@@ -68,6 +68,7 @@ partial class PoTGlobalItem : GlobalItem
 			}
 		}
 
+		RemoveInvalidZeroValueAffixes(item, data);
 		PostRoll.Invoke(item);
 	}
 
@@ -116,7 +117,16 @@ partial class PoTGlobalItem : GlobalItem
 			data.Affixes.Add(Affix.FromBReader(reader));
 		}
 
+		RemoveInvalidZeroValueAffixes(item, data);
 		PostRoll.Invoke(item);
+	}
+
+	private static void RemoveInvalidZeroValueAffixes(Item item, PoTInstanceItemData data)
+	{
+		int itemLevel = GetItemLevel.Invoke(item);
+		data.Affixes.RemoveAll(affix => affix is { IsImplicit: false, Value: 0f }
+			&& affix.TryGetData(item) is { } affixData
+			&& !affixData.CanRollAtLevel(itemLevel));
 	}
 
 	private static ItemType NormalizeLoadedItemType(Item item, ItemType itemType)


### PR DESCRIPTION
…issues with tiers

﻿### Description of Work

What was fixed
* Affixes that have no eligible tier at the item’s level can no longer be selected.
* Previously saved zero-value affixes caused by this bug are removed when loaded.
* Invalid or manually created affixes no longer display impossible tier ranges.
* Low-level maps remain Normal until map affixes become available at level 45.
* Map rarity now respects the configured 67% Normal, 30% Magic, and 3% Rare weighting instead of weighting all three equally.
* Explorable maps generated at overworld level 70 now correctly become level 71/tier 1.
* Map item level now uses the normal saved/networked item-level field instead of a duplicate unsaved field.
* The /spawnmap testing command now converts map tier into the proper item level.



<!-- pot-changelog-desc:start -->
### Bug Fixes

- issues with affixes rolling when they shouldn't and maps having issues with tiers
<!-- pot-changelog-desc:end -->
### Comments
