### PR TITLE
fix: poison damage over time not synced in MP

### DIFF
--- a/Common/Buffs/DoTFunctionality.cs
+++ b/Common/Buffs/DoTFunctionality.cs
@@ -44,15 +44,14 @@ internal class DoTFunctionality
 			damage = npc.life;
 		}
 
-		if (!npc.dontTakeDamage && !npc.immortal)
+		if (Main.netMode != NetmodeID.MultiplayerClient && !npc.dontTakeDamage && !npc.immortal)
 		{
-			if (npc.realLife == -1)
+			NPC lifeTarget = npc.realLife == -1 ? npc : Main.npc[npc.realLife];
+			lifeTarget.life -= damage;
+
+			if (Main.netMode == NetmodeID.Server)
 			{
-				npc.life -= damage;
-			}
-			else
-			{
-				Main.npc[npc.realLife].life -= damage;
+				lifeTarget.netUpdate = true;
 			}
 		}
 

--- a/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
@@ -1,0 +1,39 @@
+﻿using PathOfTerraria.Content.Buffs.ElementalBuffs;
+using System.IO;
+
+namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
+
+/// <summary>
+/// Requests that the server add a stack of Poison to an NPC for the sending player.
+/// </summary>
+internal class PoisonStackHandler : Handler
+{
+	public static void Send(NPC npc, int time)
+	{
+		ModPacket packet = Networking.GetPacket<PoisonStackHandler>(7);
+		packet.Write((short)npc.whoAmI);
+		packet.Write(time);
+		packet.Send();
+	}
+
+	internal override void ServerReceive(BinaryReader reader, byte sender)
+	{
+		short npcWhoAmI = reader.ReadInt16();
+		int time = reader.ReadInt32();
+
+		if (sender >= Main.maxPlayers || npcWhoAmI < 0 || npcWhoAmI >= Main.maxNPCs || time <= 0)
+		{
+			return;
+		}
+
+		Player player = Main.player[sender];
+		NPC npc = Main.npc[npcWhoAmI];
+
+		if (!player.active || !npc.active)
+		{
+			return;
+		}
+
+		PoisonedDebuff.Apply(npc, time, player);
+	}
+}

--- a/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
@@ -3,16 +3,19 @@ using System.IO;
 
 namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
 
+#nullable enable
+
 /// <summary>
-/// Requests that the server add a stack of Poison to an NPC for the sending player.
+/// Requests that the server add a stack of Poison to an NPC, preserving whether the sending player was its source.
 /// </summary>
 internal class PoisonStackHandler : Handler
 {
-	public static void Send(NPC npc, int time)
+	public static void Send(NPC npc, int time, Player? player)
 	{
-		ModPacket packet = Networking.GetPacket<PoisonStackHandler>(7);
+		ModPacket packet = Networking.GetPacket<PoisonStackHandler>(8);
 		packet.Write((short)npc.whoAmI);
 		packet.Write(time);
+		packet.Write(player is not null);
 		packet.Send();
 	}
 
@@ -20,16 +23,17 @@ internal class PoisonStackHandler : Handler
 	{
 		short npcWhoAmI = reader.ReadInt16();
 		int time = reader.ReadInt32();
+		bool hasPlayerSource = reader.ReadBoolean();
 
 		if (sender >= Main.maxPlayers || npcWhoAmI < 0 || npcWhoAmI >= Main.maxNPCs || time <= 0)
 		{
 			return;
 		}
 
-		Player player = Main.player[sender];
+		Player? player = hasPlayerSource ? Main.player[sender] : null;
 		NPC npc = Main.npc[npcWhoAmI];
 
-		if (!player.active || !npc.active)
+		if (player is { active: false } || !npc.active)
 		{
 			return;
 		}

--- a/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
+++ b/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
@@ -52,7 +52,7 @@ internal class PoisonedDebuff : ModBuff
 		{
 			if (player is null || player.whoAmI == Main.myPlayer)
 			{
-				PoisonStackHandler.Send(npc, time);
+				PoisonStackHandler.Send(npc, time, player);
 			}
 
 			return;
@@ -184,6 +184,14 @@ internal class PoisonNPC : GlobalNPC
 
 	public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
 	{
+		bool hasStacks = _stacks.Count > 0;
+		bitWriter.WriteBit(hasStacks);
+
+		if (!hasStacks)
+		{
+			return;
+		}
+
 		binaryWriter.Write((ushort)_stacks.Count);
 
 		foreach (PoisonStack stack in _stacks)
@@ -200,6 +208,15 @@ internal class PoisonNPC : GlobalNPC
 	public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
 	{
 		_stacks.Clear();
+
+		if (!bitReader.ReadBit())
+		{
+			ElapsedDoT = 0;
+			LastTickRate = 60;
+			_timer = 0;
+			return;
+		}
+
 		ushort count = binaryReader.ReadUInt16();
 
 		for (int i = 0; i < count; i++)

--- a/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
+++ b/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
@@ -1,10 +1,13 @@
 ﻿using PathOfTerraria.Common.Buffs;
 using PathOfTerraria.Common.Systems.MobSystem;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using ReLogic.Content;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using Terraria.GameContent;
 using Terraria.ID;
+using Terraria.ModLoader.IO;
 using Terraria.UI.Chat;
 
 namespace PathOfTerraria.Content.Buffs.ElementalBuffs;
@@ -45,6 +48,16 @@ internal class PoisonedDebuff : ModBuff
 
 	public static void Apply(NPC npc, int time, Player? player = null)
 	{
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			if (player is null || player.whoAmI == Main.myPlayer)
+			{
+				PoisonStackHandler.Send(npc, time);
+			}
+
+			return;
+		}
+
 		float damage = 4f;
 		float tickRate = 60;
 
@@ -62,6 +75,7 @@ internal class PoisonedDebuff : ModBuff
 
 		ref float tick = ref npc.GetGlobalNPC<PoisonNPC>().LastTickRate;
 		tick = MathF.Min(tickRate, tick);
+		npc.netUpdate = true;
 	}
 
 	public override void SetStaticDefaults()
@@ -129,6 +143,8 @@ internal class PoisonNPC : GlobalNPC
 
 	public override bool PreAI(NPC npc)
 	{
+		int previousStackCount = _stacks.Count;
+
 		for (int i = 0; i < _stacks.Count; i++)
 		{
 			PoisonStack stack = _stacks[i];
@@ -138,6 +154,12 @@ internal class PoisonNPC : GlobalNPC
 		}
 
 		_stacks.RemoveAll(x => x.Time <= 0);
+
+		if (Main.netMode == NetmodeID.Server && _stacks.Count != previousStackCount)
+		{
+			npc.netUpdate = true;
+		}
+
 		_timer++;
 
 		if (_timer > LastTickRate && _stacks.Count > 0 && ElapsedDoT >= 1)
@@ -158,6 +180,36 @@ internal class PoisonNPC : GlobalNPC
 		}
 
 		return true;
+	}
+
+	public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
+	{
+		binaryWriter.Write((ushort)_stacks.Count);
+
+		foreach (PoisonStack stack in _stacks)
+		{
+			binaryWriter.Write(stack.Time);
+			binaryWriter.Write(stack.DamagePerTick);
+		}
+
+		binaryWriter.Write(ElapsedDoT);
+		binaryWriter.Write(LastTickRate);
+		binaryWriter.Write(_timer);
+	}
+
+	public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
+	{
+		_stacks.Clear();
+		ushort count = binaryReader.ReadUInt16();
+
+		for (int i = 0; i < count; i++)
+		{
+			_stacks.Add(new PoisonStack(binaryReader.ReadInt32(), binaryReader.ReadSingle()));
+		}
+
+		ElapsedDoT = binaryReader.ReadSingle();
+		LastTickRate = binaryReader.ReadSingle();
+		_timer = binaryReader.ReadSingle();
 	}
 
 	public override Color? GetAlpha(NPC npc, Color drawColor)


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Bug Fixes

- poison damage over time not synced in MP
<!-- pot-changelog-desc:end -->
### Comments
