### PR TITLE
v3.0.11

### DIFF
--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -49,11 +49,21 @@ jobs:
             };
             const closes = new Set();
 
-            // type(scope)?: subject — only the first line of each commit message
+            // type(scope)?: subject
             const re = /^(feat|balance|fix)(?:\(([^)]*)\))?!?:\s*(.+)$/i;
+            const trailerRe = /^(?:co-authored-by|signed-off-by|reviewed-by|acked-by|tested-by):/i;
+
+            const getBodyBullets = message => message
+              .split(/\r?\n/)
+              .slice(1)
+              .map(line => line.trim())
+              .filter(line => line && !trailerRe.test(line))
+              .map(line => line.replace(/^(?:[-*+]|\d+[.)])\s+/, '').trim())
+              .filter(Boolean);
 
             for (const c of commits) {
-              const firstLine = (c.commit.message || '').split(/\r?\n/)[0].trim();
+              const message = c.commit.message || '';
+              const firstLine = message.split(/\r?\n/)[0].trim();
               const m = firstLine.match(re);
               if (!m) continue;
 
@@ -64,8 +74,10 @@ jobs:
               const scopeIssues = [...scope.matchAll(/#(\d+)/g)].map(x => Number(x[1]));
               for (const n of scopeIssues) closes.add(n);
 
-              // Plain-text bullet — no commit hash, no issue links — so it copy-pastes cleanly into wiki articles.
-              groups[type].entries.push(`- ${subject}`);
+              // Plain-text bullets — no commit hash or issue links — so they copy-paste cleanly into wiki articles.
+              const bodyBullets = getBodyBullets(message);
+              const entry = [`- ${subject}`, ...bodyBullets.map(line => `  - ${line}`)].join('\n');
+              groups[type].entries.push(entry);
             }
 
             const sections = [];

--- a/Common/Buffs/DoTFunctionality.cs
+++ b/Common/Buffs/DoTFunctionality.cs
@@ -44,15 +44,14 @@ internal class DoTFunctionality
 			damage = npc.life;
 		}
 
-		if (!npc.dontTakeDamage && !npc.immortal)
+		if (Main.netMode != NetmodeID.MultiplayerClient && !npc.dontTakeDamage && !npc.immortal)
 		{
-			if (npc.realLife == -1)
+			NPC lifeTarget = npc.realLife == -1 ? npc : Main.npc[npc.realLife];
+			lifeTarget.life -= damage;
+
+			if (Main.netMode == NetmodeID.Server)
 			{
-				npc.life -= damage;
-			}
-			else
-			{
-				Main.npc[npc.realLife].life -= damage;
+				lifeTarget.netUpdate = true;
 			}
 		}
 

--- a/Common/Data/AffixRegistry.cs
+++ b/Common/Data/AffixRegistry.cs
@@ -246,9 +246,11 @@ public class AffixRegistry : ILoadable
 			return null;
 		}
 
+		int itemLevel = GetItemLevel.Invoke(item);
 		IEnumerable<ItemAffixData> enumerable = AllItemData
 			.Where(affixData => (itemType & affixData.GetEquipTypes()) != ItemType.None)
-			.Where(affixData => CanApplyToItem(affixData, item));
+			.Where(affixData => CanApplyToItem(affixData, item))
+			.Where(affixData => affixData.CanRollAtLevel(itemLevel));
 
 		if (excludedAffixes != null)
 		{
@@ -265,6 +267,16 @@ public class AffixRegistry : ILoadable
 		int randomIndex = Main.rand.Next(0, filteredAffixData.Count);
 
 		return filteredAffixData[randomIndex];
+	}
+
+	public static bool HasEligibleAffix(Item item, int itemLevel)
+	{
+		ItemType itemType = item.ResolveToSingleType(item.GetInstanceData().ItemType);
+
+		return itemType != ItemType.None && AllItemData.Any(affixData =>
+			(itemType & affixData.GetEquipTypes()) != ItemType.None
+			&& CanApplyToItem(affixData, item)
+			&& affixData.CanRollAtLevel(itemLevel));
 	}
 
 	private static bool CanApplyToItem(ItemAffixData affixData, Item item)

--- a/Common/Data/Models/AffixData.cs
+++ b/Common/Data/Models/AffixData.cs
@@ -42,6 +42,11 @@ public class ItemAffixData
 		return (0, eligibleTiers.Count - 1);
 	}
 
+	public bool CanRollAtLevel(int level)
+	{
+		return Tiers.Any(tier => tier.MinimumLevel <= Math.Max(1, level));
+	}
+
 	public TierData GetAppropriateTierData(int level, out int tierIndex)
 	{
 		var eligibleTiers = Tiers.Where(t => t.MinimumLevel <= level).ToList();

--- a/Common/ItemDropping/DropTable.cs
+++ b/Common/ItemDropping/DropTable.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Common.Enums;
+using PathOfTerraria.Common.Data;
 using PathOfTerraria.Content.Items.Consumables.Maps;
 using PathOfTerraria.Content.Items.Currency;
 using PathOfTerraria.Content.Items.Gear;
@@ -46,6 +47,7 @@ internal class DropTable
 	public static ItemDatabase.ItemRecord RollMobDrops(int itemLevel, float dropRarityModifier, DropCategoryWeights? categoryWeights = null, UnifiedRandom random = null,
 		ItemRarity forceRarity = ItemRarity.Invalid, float uniqueModifier = 1f, bool applyAreaLevelCategoryScaling = true)
 	{
+		itemLevel = itemLevel == 0 ? PoTItemHelper.PickItemLevel() : itemLevel;
 		random ??= Main.rand;
 		DropCategoryWeights weights = categoryWeights ?? DefaultCategoryWeights;
 		
@@ -58,7 +60,7 @@ internal class DropTable
 		float currencyRarityModifier = dropRarityModifier;
 		WeightedRandom<ItemDatabase.ItemRecord> gearPool = GetGearPool(itemLevel, ref gearRarityModifier, [.. ItemDatabase.GetItemByType<Gear>()], IsRecordValid, 0f, random, uniqueModifier);
 		WeightedRandom<ItemDatabase.ItemRecord> currencyPool = GetGearPool(itemLevel, ref currencyRarityModifier, [.. ItemDatabase.GetItemByType<CurrencyShard>()], IsRecordValid, 0f, random, uniqueModifier);
-		WeightedRandom<ItemDatabase.ItemRecord> mapPool = GetWeightedMapPool(random);
+		WeightedRandom<ItemDatabase.ItemRecord> mapPool = GetWeightedMapPool(itemLevel, random);
 
 		var chances = new WeightedRandom<WeightedRandom<ItemDatabase.ItemRecord>>(random);
 		AddPool(chances, gearPool, weights.Gear);
@@ -100,6 +102,7 @@ internal class DropTable
 		UnifiedRandom random = null, ItemRarity forceRarity = ItemRarity.Invalid, float itemRarityModifier = 0, float uniqueModifier = 1f, 
 		bool applyAreaLevelCategoryScaling = true)
 	{
+		itemLevel = itemLevel == 0 ? PoTItemHelper.PickItemLevel() : itemLevel;
 		random ??= Main.rand;
 		DropCategoryWeights weights = categoryWeights ?? DefaultCategoryWeights;
 		
@@ -113,7 +116,7 @@ internal class DropTable
 		var chances = new WeightedRandom<WeightedRandom<ItemDatabase.ItemRecord>>(random);
 		AddPool(chances, GetGearPool(itemLevel, ref gearRarityModifier, [.. ItemDatabase.GetItemByType<Gear>()], IsRecordValid, itemRarityModifier, random, uniqueModifier), weights.Gear);
 		AddPool(chances, GetGearPool(itemLevel, ref currencyRarityModifier, [.. ItemDatabase.GetItemByType<CurrencyShard>()], IsRecordValid, itemRarityModifier, random, uniqueModifier), weights.Currency);
-		AddPool(chances, GetWeightedMapPool(random), weights.Map);
+		AddPool(chances, GetWeightedMapPool(itemLevel, random), weights.Map);
 
 		List<ItemDatabase.ItemRecord> items = [];
 
@@ -138,48 +141,55 @@ internal class DropTable
 		}
 	}
 
-	private static WeightedRandom<ItemDatabase.ItemRecord> GetWeightedMapPool(UnifiedRandom random)
+	private static WeightedRandom<ItemDatabase.ItemRecord> GetWeightedMapPool(int itemLevel, UnifiedRandom random)
 	{
 		WeightedRandom<ItemDatabase.ItemRecord> items = new(random);
+		ItemDatabase.ItemRecord[] droppableMaps =
+		[
+			.. ItemDatabase.GetItemByType<Map>()
+				.Where(record => ((Map)record.Item.ModItem).CanDrop)
+		];
+		bool canRollMapAffixes = droppableMaps.Length > 0
+			&& AffixRegistry.HasEligibleAffix(droppableMaps[0].Item, itemLevel);
+		ItemDatabase.ItemRecord[] availableMaps =
+		[
+			.. droppableMaps.Where(record => record.Rarity == ItemRarity.Normal || canRollMapAffixes)
+		];
 
 		if (Main.hardMode)
 		{
-			ItemDatabase.ItemRecord[] allMaps = [.. ItemDatabase.GetItemByType<Map>().Where(x => ((Map)x.Item.ModItem).CanDrop)];
-			ItemDatabase.ItemRecord[] explorableMaps = [.. allMaps.Where(x => x.Item.ModItem is Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
-			ItemDatabase.ItemRecord[] bossMaps = [.. allMaps.Where(x => x.Item.ModItem is not Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
+			ItemDatabase.ItemRecord[] explorableMaps = [.. availableMaps.Where(x => x.Item.ModItem is Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
+			ItemDatabase.ItemRecord[] bossMaps = [.. availableMaps.Where(x => x.Item.ModItem is not Content.Items.Consumables.Maps.ExplorableMaps.ExplorableMap)];
 
 			// Normalize per-category so explorable maps sum to 70% and boss maps sum to 30%, regardless of how many maps are in each category.
-			if (explorableMaps.Length > 0)
-			{
-				float weightPer = 0.7f / explorableMaps.Length;
-
-				foreach (ItemDatabase.ItemRecord record in explorableMaps)
-				{
-					items.Add(record, weightPer);
-				}
-			}
-
-			if (bossMaps.Length > 0)
-			{
-				float weightPer = 0.3f / bossMaps.Length;
-
-				foreach (ItemDatabase.ItemRecord record in bossMaps)
-				{
-					items.Add(record, weightPer);
-				}
-			}
+			AddNormalizedMapCategory(items, explorableMaps, 0.7f);
+			AddNormalizedMapCategory(items, bossMaps, 0.3f);
 		}
 		else
 		{
-			IEnumerable<ItemDatabase.ItemRecord> list = ItemDatabase.GetItemByType<Map>().Where(x => (x.Item.ModItem as Map).CanDrop);
-
-			foreach (ItemDatabase.ItemRecord record in list)
+			foreach (ItemDatabase.ItemRecord record in availableMaps)
 			{
-				items.Add(record);
+				items.Add(record, record.DropChance);
 			}
 		}
 
 		return items;
+	}
+
+	private static void AddNormalizedMapCategory(WeightedRandom<ItemDatabase.ItemRecord> destination,
+		ItemDatabase.ItemRecord[] records, float categoryWeight)
+	{
+		float totalWeight = records.Sum(record => record.DropChance);
+
+		if (totalWeight <= 0f)
+		{
+			return;
+		}
+
+		foreach (ItemDatabase.ItemRecord record in records)
+		{
+			destination.Add(record, categoryWeight * record.DropChance / totalWeight);
+		}
 	}
 
 	private static ItemDatabase.ItemRecord RollList(int itemLevel, float rarityMod, List<ItemDatabase.ItemRecord> filteredGear, UnifiedRandom random = null, float uniqueModifier = 1f)

--- a/Common/ItemDropping/InstancedItemDrop.cs
+++ b/Common/ItemDropping/InstancedItemDrop.cs
@@ -1,0 +1,60 @@
+using Terraria.ID;
+
+namespace PathOfTerraria.Common.ItemDropping;
+
+internal static class InstancedItemDrop
+{
+	/// <summary>
+	/// Drops an item locally for each player accepted by <paramref name="canDrop"/>.
+	/// In multiplayer, each accepted player receives a client-only item which other players cannot see or pick up.
+	/// </summary>
+	public static void DropForEachEligiblePlayer(NPC npc, int itemType, Func<Player, bool> canDrop, int stack = 1,
+		bool interactionRequired = true)
+	{
+		if (Main.netMode == NetmodeID.MultiplayerClient || itemType <= ItemID.None
+			|| itemType >= ItemLoader.ItemCount || stack <= 0)
+		{
+			return;
+		}
+
+		bool IsEligible(Player player)
+		{
+			return player.active
+				&& (!interactionRequired || npc.playerInteraction[player.whoAmI])
+				&& canDrop(player);
+		}
+
+		if (Main.netMode == NetmodeID.SinglePlayer)
+		{
+			if (IsEligible(Main.LocalPlayer))
+			{
+				Item.NewItem(npc.GetSource_Death(), npc.Hitbox, itemType, stack);
+			}
+
+			return;
+		}
+
+		int itemIndex = -1;
+
+		foreach (Player player in Main.ActivePlayers)
+		{
+			if (!IsEligible(player))
+			{
+				continue;
+			}
+
+			if (itemIndex == -1)
+			{
+				itemIndex = Item.NewItem(npc.GetSource_Death(), npc.Hitbox, itemType, stack, noBroadcast: true);
+				Main.timeItemSlotCannotBeReusedFor[itemIndex] = 54000;
+			}
+
+			NetMessage.SendData(MessageID.InstancedItem, player.whoAmI, -1, null, itemIndex);
+		}
+
+		if (itemIndex != -1)
+		{
+			Main.item[itemIndex].active = false;
+		}
+	}
+}

--- a/Common/ItemDropping/ItemSpawner.cs
+++ b/Common/ItemDropping/ItemSpawner.cs
@@ -1,4 +1,5 @@
 ﻿using PathOfTerraria.Core.Items;
+using PathOfTerraria.Content.Items.Consumables.Maps;
 using System.Collections.Generic;
 using System.Linq;
 using PathOfTerraria.Common.Enums;
@@ -170,8 +171,9 @@ internal class ItemSpawner
 	/// <param name="pos"></param>
 	public static void SpawnMap(Vector2 pos, int tier)
 	{
-		int type = DropTable.RollMobDrops(tier, 0, new DropTable.DropCategoryWeights(0, 0, 1)).Item.type;
+		int itemLevel = Map.WorldLevelBasedOnTier(tier);
+		int type = DropTable.RollMobDrops(itemLevel, 0, new DropTable.DropCategoryWeights(0, 0, 1)).Item.type;
 
-		SpawnItem(type, pos, tier);
+		SpawnItem(type, pos, itemLevel);
 	}
 }

--- a/Common/Mapping/MapDeviceInterface.cs
+++ b/Common/Mapping/MapDeviceInterface.cs
@@ -201,7 +201,8 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 
 	internal static void MoveItemIntoStorage(ref Item originalItem)
 	{
-		Item[] storage = MapDeviceInterface.Entity!.Storage;
+		MapDeviceEntity device = MapDeviceInterface.Entity!;
+		Item[] storage = device.Storage;
 
 		for (int i = 0; i < MapDeviceEntity.StorageSize; i++)
 		{
@@ -212,6 +213,12 @@ internal class MapDeviceShiftClickPlayer : ModPlayer
 			originalItem.TurnToAir();
 			item = invItem;
 			SoundEngine.PlaySound(SoundID.Grab);
+
+			if (Main.netMode == NetmodeID.MultiplayerClient)
+			{
+				MapDeviceSync.Send(device.ID, MapDeviceSync.Flags.Storage, [i]);
+			}
+
 			break;
 		}
 	}

--- a/Common/Projectiles/IRightClickableProjectile.cs
+++ b/Common/Projectiles/IRightClickableProjectile.cs
@@ -39,14 +39,7 @@ internal static class RightClickableProjectileExtensions
 			return 0;
 		}
 
-		// Due to a quirk in how projectiles drawn using behindProjectiles are implemented,
-		// we need to do some math to calculate the correct world position of the mouse instead of using Main.MouseWorld directly.
-		var matrix = Matrix.Invert(Main.GameViewMatrix.ZoomMatrix);
-		Vector2 position = Main.ReverseGravitySupport(Main.MouseScreen);
-		Vector2.Transform(Main.screenPosition, matrix);
-		Vector2 realMouseWorld = Vector2.Transform(position, matrix) + Main.screenPosition;
-
-		bool mouseDirectlyOver = projectile.Hitbox.Contains(realMouseWorld.ToPoint());
+		bool mouseDirectlyOver = projectile.Hitbox.Contains(Main.MouseWorld.ToPoint());
 		bool interactingWithThisProjectile = mouseDirectlyOver || Main.SmartInteractProj == projectile.whoAmI;
 
 		if (!interactingWithThisProjectile || localPlayer.lastMouseInterface)

--- a/Common/Subworlds/BossDomains/Hardmode/QueenDomain/QueenDomainCoreDrop.cs
+++ b/Common/Subworlds/BossDomains/Hardmode/QueenDomain/QueenDomainCoreDrop.cs
@@ -1,20 +1,24 @@
-﻿using PathOfTerraria.Common.NPCs.DropRules;
+using PathOfTerraria.Common.ItemDropping;
+using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath.HardmodeQuesting;
 using PathOfTerraria.Content.Items.Quest;
-using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
 
 namespace PathOfTerraria.Common.Subworlds.BossDomains.Hardmode.QueenDomain;
 
 internal class QueenDomainCoreDrop : GlobalNPC
 {
-	public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
+	public override void OnKill(NPC npc)
 	{
 		if (npc.type == NPCID.QueenSlimeBoss)
 		{
-			LeadingConditionRule rule = new(new HasQuest(ModContent.GetInstance<QueenSlimeQuest>().FullName));
-			rule.OnSuccess(ItemDropRule.Common(ModContent.ItemType<RoyalJellyCore>()));
-			npcLoot.Add(rule);
+			string questName = ModContent.GetInstance<QueenSlimeQuest>().FullName;
+			int itemType = ModContent.ItemType<RoyalJellyCore>();
+
+			// BossTracker advances this quest for every active quest owner, not only players recorded as interacting.
+			InstancedItemDrop.DropForEachEligiblePlayer(npc, itemType,
+				player => Quest.PlayerHasQuest(player.whoAmI, questName) && !player.HasItem(itemType),
+				interactionRequired: false);
 		}
 	}
 }

--- a/Common/Subworlds/BossDomains/Prehardmode/DeerclopsDomain.cs
+++ b/Common/Subworlds/BossDomains/Prehardmode/DeerclopsDomain.cs
@@ -20,6 +20,8 @@ namespace PathOfTerraria.Common.Subworlds.BossDomains.Prehardmode;
 public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 {
 	public const int Surface = 200;
+	private const int MaxStructurePlacementAttempts = 20000;
+	private const int TunnelStructurePadding = 8;
 
 	internal static Asset<Texture2D> LightGlow = null;
 
@@ -220,7 +222,7 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 
 		if (!skipPonds)
 		{
-			FindPondLocation(points);
+			FindPondLocation(points, chasmPoints);
 		}
 
 		FindWalls(points, 2, chasmPoints);
@@ -231,9 +233,9 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 	{
 		for (int i = 0; i < wallCount; i++)
 		{
-			while (true)
+			for (int tries = 0; tries < MaxStructurePlacementAttempts; tries++)
 			{
-				Vector2 pos = Main.rand.Next(points);
+				Vector2 pos = WorldGen.genRand.Next(points);
 				int x = (int)pos.X;
 				int y = (int)pos.Y;
 
@@ -254,7 +256,7 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 				int dist = Math.Abs(y - y2);
 				var checkingRect = new Rectangle(x, y - (int)(size.Y * 0.5f), size.X, size.Y);
 
-				if (chasmPoints.Any(x => checkingRect.Contains(x.ToPoint())))
+				if (IntersectsTunnel(checkingRect, chasmPoints))
 				{
 					continue;
 				}
@@ -269,21 +271,14 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 		}
 	}
 
-	private static void FindPondLocation(Vector2[] points)
+	private static void FindPondLocation(Vector2[] points, Vector2[] chasmPoints)
 	{
-		int tries = 0;
-
-		while (true)
+		// Ponds are placed after the incoming tunnel is dug. Keep their large footprint away from that
+		// connector so the structure cannot overwrite the only route into the horizontal tunnel.
+		for (int tries = 0; tries < MaxStructurePlacementAttempts; tries++)
 		{
-			tries++;
-
-			if (tries > 20000)
-			{
-				break;
-			}
-
 			int pond = WorldGen.genRand.Next(3);
-			Vector2 pos = Main.rand.Next(points);
+			Vector2 pos = WorldGen.genRand.Next(points);
 			int x = (int)pos.X;
 			int y = (int)pos.Y;
 
@@ -301,10 +296,12 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 				y2++;
 			}
 
-			if (Math.Abs(y2 - y) < 3 && GenVars.structures.CanPlace(new Rectangle(x, y, size.X, size.Y)))
+			var checkingRect = new Rectangle(x, y, size.X, size.Y);
+
+			if (Math.Abs(y2 - y) < 3 && CanPlaceWithoutBlockingTunnel(checkingRect, chasmPoints))
 			{
 				StructureTools.PlaceByOrigin(structure, new Point16(x, y), new Vector2(0));
-				GenVars.structures.AddProtectedStructure(new Rectangle(x, y, size.X, size.Y));
+				GenVars.structures.AddProtectedStructure(checkingRect);
 				break;
 			}
 			else
@@ -316,14 +313,27 @@ public class DeerclopsDomain : BossDomainSubworld, IOverrideBiome
 					y2++;
 				}
 
-				if (Math.Abs(y2 - y) < 3 && GenVars.structures.CanPlace(new Rectangle(x - size.X, y, size.X, size.Y)))
+				checkingRect = new Rectangle(x - size.X, y, size.X, size.Y);
+
+				if (Math.Abs(y2 - y) < 3 && CanPlaceWithoutBlockingTunnel(checkingRect, chasmPoints))
 				{
 					StructureTools.PlaceByOrigin(structure, new Point16(x, y), new Vector2(1, 0));
-					GenVars.structures.AddProtectedStructure(new Rectangle(x - size.X, y, size.X, size.Y));
+					GenVars.structures.AddProtectedStructure(checkingRect);
 					break;
 				}
 			}
 		}
+	}
+
+	private static bool CanPlaceWithoutBlockingTunnel(Rectangle structureArea, Vector2[] tunnelPoints)
+	{
+		return !IntersectsTunnel(structureArea, tunnelPoints) && GenVars.structures.CanPlace(structureArea);
+	}
+
+	private static bool IntersectsTunnel(Rectangle structureArea, Vector2[] tunnelPoints)
+	{
+		structureArea.Inflate(TunnelStructurePadding, TunnelStructurePadding);
+		return tunnelPoints.Any(point => structureArea.Contains(point.ToPoint()));
 	}
 
 	private void StartTunnel(FastNoiseLite noise, int firstTunnelXStart, out Vector2 last)

--- a/Common/Systems/Affixes/ItemAffix.cs
+++ b/Common/Systems/Affixes/ItemAffix.cs
@@ -48,10 +48,21 @@ public abstract class ItemAffix : Affix
 			};
 		}
 
-		// PoTInstanceItemData itemData = item.GetInstanceData();
-		ItemAffixData.TierData tierData = data.Tiers[Tier];
-
 		(int tierMin, int tierMax) = data.GetPossibleTierRange(itemLevel);
+		if (tierMax < 0 || Tier < tierMin || Tier > tierMax || Tier >= data.Tiers.Count)
+		{
+			return new AffixTooltipLine
+			{
+				Text = this.GetLocalization("Description"),
+				Value = Value,
+				Tier = null,
+				ValueRollRange = null,
+				Corrupt = IsCorruptedAffix,
+				Implicit = IsImplicit,
+			};
+		}
+
+		ItemAffixData.TierData tierData = data.Tiers[Tier];
 
 		return new AffixTooltipLine
 		{

--- a/Common/Systems/PersistentMinionsPlayer.cs
+++ b/Common/Systems/PersistentMinionsPlayer.cs
@@ -9,6 +9,30 @@ namespace PathOfTerraria.Common.Systems;
 
 internal class PersistentMinionsPlayer : ModPlayer, IPreDomainRespawnPlayer
 {
+	private static readonly HashSet<int> MinionBuffTypes = [];
+
+	private sealed class MinionBuffCacheSystem : ModSystem
+	{
+		public override void PostSetupContent()
+		{
+			MinionBuffTypes.Clear();
+
+			foreach (Item item in ContentSamples.ItemsByType.Values)
+			{
+				if (item.buffType > 0 && item.shoot > ProjectileID.None
+					&& ContentSamples.ProjectilesByType.TryGetValue(item.shoot, out Projectile projectile) && projectile.minion)
+				{
+					MinionBuffTypes.Add(item.buffType);
+				}
+			}
+		}
+
+		public override void Unload()
+		{
+			MinionBuffTypes.Clear();
+		}
+	}
+
 	private class PersistentMinionProjectile : GlobalProjectile
 	{
 		public override bool InstancePerEntity => true;
@@ -157,26 +181,11 @@ internal class PersistentMinionsPlayer : ModPlayer, IPreDomainRespawnPlayer
 		{
 			int type = Player.buffType[i];
 
-			if (type > 0 && IsMinionBuff(type))
+			if (MinionBuffTypes.Contains(type))
 			{
 				destination.Add(new SavedBuff(type, Player.buffTime[i]));
 			}
 		}
-	}
-
-	private static bool IsMinionBuff(int buffType)
-	{
-		// Terraria has no dedicated minion-buff set, so derive the relationship from summon items.
-		foreach (Item item in ContentSamples.ItemsByType.Values)
-		{
-			if (item.buffType == buffType && item.shoot > ProjectileID.None
-				&& ContentSamples.ProjectilesByType.TryGetValue(item.shoot, out Projectile projectile) && projectile.minion)
-			{
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private void CaptureStationBuffs(List<SavedBuff> destination)

--- a/Common/Systems/PersistentMinionsPlayer.cs
+++ b/Common/Systems/PersistentMinionsPlayer.cs
@@ -1,11 +1,13 @@
 ﻿using PathOfTerraria.Common.Projectiles;
+using PathOfTerraria.Common.Systems.ModPlayers.LivesSystem;
 using System.Collections.Generic;
 using Terraria.DataStructures;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace PathOfTerraria.Common.Systems;
 
-internal class PersistentMinionsPlayer : ModPlayer
+internal class PersistentMinionsPlayer : ModPlayer, IPreDomainRespawnPlayer
 {
 	private class PersistentMinionProjectile : GlobalProjectile
 	{
@@ -25,76 +27,297 @@ internal class PersistentMinionsPlayer : ModPlayer
 	}
 
 	private readonly record struct SavedProjectile(int type, int time, int damage, float knockBack);
+	private readonly record struct SavedBuff(int type, int time);
 
 	private readonly List<SavedProjectile> _savedProjectiles = [];
+	private readonly List<SavedBuff> _savedMinionBuffs = [];
+	private readonly List<SavedBuff> _savedStationBuffs = [];
+	private readonly List<SavedProjectile> _respawnProjectiles = [];
+	private readonly List<SavedBuff> _respawnMinionBuffs = [];
+
+	private int _domainRespawnRestoreDelay;
 
 	public override void SaveData(TagCompound tag)
 	{
-		TagCompound projectiles = [];
-		int count = 0;
-
 		if (Main.gameMenu) // Skip this on the main menu, as it can't run properly
 		{
 			return;
 		}
 
-		foreach (Projectile projectile in Main.ActiveProjectiles)
-		{
-			if (projectile.owner == Player.whoAmI && projectile.TryGetGlobalProjectile(out PersistentMinionProjectile persist))
-			{
-				int damage = persist.OriginalDamage;
-
-				projectiles.Add("projType_" + count, projectile.type);
-				projectiles.Add("projTime_" + count, projectile.timeLeft);
-				projectiles.Add("projDamage_" + count, damage);
-				projectiles.Add("projKnockback_" + count, projectile.knockBack);
-				count++;
-
-				// Store the projectile so this works in singleplayer, as while players ARE saved between subworlds,
-				// they are NOT loaded
-				_savedProjectiles.Add(new SavedProjectile(projectile.type, projectile.timeLeft, damage, projectile.knockBack));
-			}
-		}
-		
-		if (count > 0)
-		{
-			projectiles.Add("count", count);
-			tag.Add("savedProjectiles", projectiles);
-		}
+		CaptureProjectiles(_savedProjectiles);
+		CaptureMinionBuffs(_savedMinionBuffs, _savedProjectiles.Count > 0);
+		CaptureStationBuffs(_savedStationBuffs);
+		SaveProjectiles(tag, "savedProjectiles", _savedProjectiles);
+		SaveBuffs(tag, "savedMinionBuffs", _savedMinionBuffs);
+		SaveBuffs(tag, "savedStationBuffs", _savedStationBuffs);
 	}
 
 	public override void LoadData(TagCompound tag)
 	{
-		if (tag.TryGet("savedProjectiles", out TagCompound projectiles))
-		{
-			int count = projectiles.GetInt("count");
-
-			for (int i = 0; i < count; ++i)
-			{
-				int type = projectiles.GetInt("projType_" + i);
-				int time = projectiles.GetInt("projTime_" + i);
-				int damage = projectiles.GetInt("projDamage_" + i);
-				float knockBack = projectiles.GetFloat("projKnockback_" + i);
-
-				_savedProjectiles.Add(new SavedProjectile(type, time, damage, knockBack));
-			}
-		}
+		LoadProjectiles(tag, "savedProjectiles", _savedProjectiles);
+		LoadBuffs(tag, "savedMinionBuffs", _savedMinionBuffs);
+		LoadBuffs(tag, "savedStationBuffs", _savedStationBuffs);
 	}
 
 	public override void OnEnterWorld()
 	{
-		Vector2 pos = Player.Center - new Vector2(0, 10);
-
-		foreach (SavedProjectile item in _savedProjectiles)
-		{
-			int proj = Projectile.NewProjectile(Player.GetSource_FromThis(), pos, Vector2.Zero, item.type, item.damage, item.knockBack, Player.whoAmI);
-			Main.projectile[proj].timeLeft = item.time;
-			Main.projectile[proj].netUpdate = true;
-			Main.projectile[proj].damage = item.damage;
-			Main.projectile[proj].originalDamage = item.damage;
-		}
+		RestoreBuffs(_savedMinionBuffs);
+		RestoreBuffs(_savedStationBuffs);
+		RestoreProjectiles(_savedProjectiles);
 
 		_savedProjectiles.Clear();
+		_savedMinionBuffs.Clear();
+		_savedStationBuffs.Clear();
+	}
+
+	public override bool PreKill(double damage, int hitDirection, bool pvp, ref bool playSound, ref bool genDust, ref PlayerDeathReason damageSource)
+	{
+		if (Player.whoAmI == Main.myPlayer)
+		{
+			CaptureRespawnState();
+		}
+
+		return true;
+	}
+
+	public override void OnRespawn()
+	{
+		if (Player.whoAmI != Main.myPlayer)
+		{
+			return;
+		}
+
+		_domainRespawnRestoreDelay = 0;
+		RestoreRespawnState();
+	}
+
+	public void OnDomainRespawn()
+	{
+		if (Player.whoAmI != Main.myPlayer)
+		{
+			return;
+		}
+
+		CaptureRespawnState();
+
+		// Boss-domain lives cancel normal death from inside PreKill. Wait until the following update
+		// so any vanilla death cleanup has finished before restoring the minions.
+		_domainRespawnRestoreDelay = 2;
+	}
+
+	public override void PostUpdate()
+	{
+		if (Player.whoAmI != Main.myPlayer || _domainRespawnRestoreDelay <= 0 || --_domainRespawnRestoreDelay > 0)
+		{
+			return;
+		}
+
+		RestoreRespawnState();
+	}
+
+	private void CaptureRespawnState()
+	{
+		CaptureProjectiles(_respawnProjectiles);
+		CaptureMinionBuffs(_respawnMinionBuffs, _respawnProjectiles.Count > 0);
+	}
+
+	private void RestoreRespawnState()
+	{
+		RestoreBuffs(_respawnMinionBuffs);
+		RestoreProjectiles(_respawnProjectiles);
+		_respawnProjectiles.Clear();
+		_respawnMinionBuffs.Clear();
+	}
+
+	private void CaptureProjectiles(List<SavedProjectile> destination)
+	{
+		destination.Clear();
+
+		foreach (Projectile projectile in Main.ActiveProjectiles)
+		{
+			if (projectile.owner != Player.whoAmI || !projectile.TryGetGlobalProjectile(out PersistentMinionProjectile persist))
+			{
+				continue;
+			}
+
+			destination.Add(new SavedProjectile(projectile.type, projectile.timeLeft, persist.OriginalDamage, projectile.knockBack));
+		}
+	}
+
+	private void CaptureMinionBuffs(List<SavedBuff> destination, bool hasMinions)
+	{
+		destination.Clear();
+
+		if (!hasMinions)
+		{
+			return;
+		}
+
+		for (int i = 0; i < Player.buffType.Length; ++i)
+		{
+			int type = Player.buffType[i];
+
+			if (type > 0 && IsMinionBuff(type))
+			{
+				destination.Add(new SavedBuff(type, Player.buffTime[i]));
+			}
+		}
+	}
+
+	private static bool IsMinionBuff(int buffType)
+	{
+		// Terraria has no dedicated minion-buff set, so derive the relationship from summon items.
+		foreach (Item item in ContentSamples.ItemsByType.Values)
+		{
+			if (item.buffType == buffType && item.shoot > ProjectileID.None
+				&& ContentSamples.ProjectilesByType.TryGetValue(item.shoot, out Projectile projectile) && projectile.minion)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private void CaptureStationBuffs(List<SavedBuff> destination)
+	{
+		destination.Clear();
+
+		int[] stationBuffTypes = [BuffID.Bewitched, BuffID.WarTable];
+
+		foreach (int type in stationBuffTypes)
+		{
+			int index = Player.FindBuffIndex(type);
+
+			if (index >= 0)
+			{
+				destination.Add(new SavedBuff(type, Player.buffTime[index]));
+			}
+		}
+	}
+
+	private void RestoreProjectiles(List<SavedProjectile> projectiles)
+	{
+		Dictionary<int, int> activeCounts = [];
+
+		foreach (Projectile projectile in Main.ActiveProjectiles)
+		{
+			if (projectile.owner == Player.whoAmI && projectile.TryGetGlobalProjectile(out PersistentMinionProjectile _))
+			{
+				activeCounts.TryGetValue(projectile.type, out int count);
+				activeCounts[projectile.type] = count + 1;
+			}
+		}
+
+		Vector2 position = Player.Center - new Vector2(0, 10);
+
+		foreach (SavedProjectile item in projectiles)
+		{
+			if (activeCounts.TryGetValue(item.type, out int count) && count > 0)
+			{
+				activeCounts[item.type] = count - 1;
+				continue;
+			}
+
+			int index = Projectile.NewProjectile(Player.GetSource_FromThis(), position, Vector2.Zero, item.type, item.damage, item.knockBack, Player.whoAmI);
+
+			if (index >= Main.maxProjectiles)
+			{
+				continue;
+			}
+
+			Projectile projectile = Main.projectile[index];
+			projectile.timeLeft = item.time;
+			projectile.netUpdate = true;
+			projectile.damage = item.damage;
+			projectile.originalDamage = item.damage;
+		}
+	}
+
+	private void RestoreBuffs(List<SavedBuff> buffs)
+	{
+		foreach (SavedBuff buff in buffs)
+		{
+			Player.AddBuff(buff.type, buff.time, quiet: false);
+		}
+	}
+
+	private static void SaveProjectiles(TagCompound tag, string key, List<SavedProjectile> projectiles)
+	{
+		if (projectiles.Count == 0)
+		{
+			return;
+		}
+
+		TagCompound saved = [];
+		saved.Add("count", projectiles.Count);
+
+		for (int i = 0; i < projectiles.Count; ++i)
+		{
+			SavedProjectile projectile = projectiles[i];
+			saved.Add("projType_" + i, projectile.type);
+			saved.Add("projTime_" + i, projectile.time);
+			saved.Add("projDamage_" + i, projectile.damage);
+			saved.Add("projKnockback_" + i, projectile.knockBack);
+		}
+
+		tag.Add(key, saved);
+	}
+
+	private static void LoadProjectiles(TagCompound tag, string key, List<SavedProjectile> destination)
+	{
+		destination.Clear();
+
+		if (!tag.TryGet(key, out TagCompound projectiles))
+		{
+			return;
+		}
+
+		int count = projectiles.GetInt("count");
+
+		for (int i = 0; i < count; ++i)
+		{
+			destination.Add(new SavedProjectile(
+				projectiles.GetInt("projType_" + i),
+				projectiles.GetInt("projTime_" + i),
+				projectiles.GetInt("projDamage_" + i),
+				projectiles.GetFloat("projKnockback_" + i)));
+		}
+	}
+
+	private static void SaveBuffs(TagCompound tag, string key, List<SavedBuff> buffs)
+	{
+		if (buffs.Count == 0)
+		{
+			return;
+		}
+
+		TagCompound saved = [];
+		saved.Add("count", buffs.Count);
+
+		for (int i = 0; i < buffs.Count; ++i)
+		{
+			saved.Add("buffType_" + i, buffs[i].type);
+			saved.Add("buffTime_" + i, buffs[i].time);
+		}
+
+		tag.Add(key, saved);
+	}
+
+	private static void LoadBuffs(TagCompound tag, string key, List<SavedBuff> destination)
+	{
+		destination.Clear();
+
+		if (!tag.TryGet(key, out TagCompound buffs))
+		{
+			return;
+		}
+
+		int count = buffs.GetInt("count");
+
+		for (int i = 0; i < count; ++i)
+		{
+			destination.Add(new SavedBuff(buffs.GetInt("buffType_" + i), buffs.GetInt("buffTime_" + i)));
+		}
 	}
 }
-

--- a/Common/Systems/Questing/Quest.cs
+++ b/Common/Systems/Questing/Quest.cs
@@ -192,11 +192,11 @@ public abstract class Quest : ModType, ILocalizedModType
 		OnCompleted();
 
 		QuestModPlayer quester = player.GetModPlayer<QuestModPlayer>();
-		quester.EnabledQuestsByName.Remove(FullName);
+		quester.SetSyncedQuestState(FullName, false, string.Empty, true);
 
 		if (player.whoAmI == Main.myPlayer && Main.netMode == NetmodeID.MultiplayerClient)
 		{
-			SyncPlayerQuestActive.Send(FullName, false);
+			SyncPlayerQuestActive.Send(FullName, false, string.Empty, true);
 		}
 	}
 
@@ -228,6 +228,17 @@ public abstract class Quest : ModType, ILocalizedModType
 				{
 					break;
 				}
+			}
+		}
+
+		if (Active)
+		{
+			QuestModPlayer quester = player.GetModPlayer<QuestModPlayer>();
+			quester.SetSyncedQuestState(FullName, true, ActiveStep.Id, false);
+
+			if (player.whoAmI == Main.myPlayer && Main.netMode == NetmodeID.MultiplayerClient)
+			{
+				SyncPlayerQuestActive.Send(FullName, true, ActiveStep.Id, false);
 			}
 		}
 	}
@@ -324,7 +335,7 @@ public abstract class Quest : ModType, ILocalizedModType
 		QuestSteps = SetSteps();
 
 		QuestModPlayer quester = player.GetModPlayer<QuestModPlayer>();
-		quester.EnabledQuestsByName.Remove(FullName);
+		quester.SetSyncedQuestState(FullName, false, string.Empty, false);
 	}
 
 	/// <summary>

--- a/Common/Systems/Questing/QuestModPlayer.cs
+++ b/Common/Systems/Questing/QuestModPlayer.cs
@@ -33,6 +33,16 @@ public class QuestModPlayer : ModPlayer
 	/// </summary>
 	public readonly HashSet<string> EnabledQuestsByName = [];
 
+	/// <summary>
+	/// A fully synced lookup of active quest names to their current step IDs.
+	/// </summary>
+	public readonly Dictionary<string, string> ActiveQuestStepsByName = [];
+
+	/// <summary>
+	/// A fully synced list of the quests this player has completed.
+	/// </summary>
+	public readonly HashSet<string> CompletedQuestsByName = [];
+
 	internal bool FirstQuest = true;
 	/// <summary> The full name of this player's pinned quest. </summary>
 	public string PinnedQuest;
@@ -52,12 +62,17 @@ public class QuestModPlayer : ModPlayer
 	/// <param name="fromLoad">Skips the quest popups &amp; sound effects if true.</param>
 	public void StartQuest(string name, int step = -1, bool fromLoad = false)
 	{
-		QuestsByName[name].Start(Player, step == -1 ? 0 : step);
-		EnabledQuestsByName.Add(name);
+		Quest quest = QuestsByName[name];
+		quest.Start(Player, step == -1 ? 0 : step);
+
+		if (quest.Active)
+		{
+			SetSyncedQuestState(name, true, quest.ActiveStep.Id, false);
+		}
 
 		if (Main.myPlayer == Player.whoAmI && !fromLoad)
 		{
-			UIQuestPopupState.NewQuest = new UIQuestPopupState.PopupText(QuestsByName[name].DisplayName, 300, 1f, 1.2f);
+			UIQuestPopupState.NewQuest = new UIQuestPopupState.PopupText(quest.DisplayName, 300, 1f, 1.2f);
 			SoundEngine.PlaySound(new SoundStyle($"{PoTMod.ModName}/Assets/Sounds/QuestStart") { Volume = 0.5f });
 
 			if (FirstQuest) // Only display first quest popup on first quest (wow!)
@@ -67,26 +82,62 @@ public class QuestModPlayer : ModPlayer
 				FirstQuest = false;
 			}
 
-			if (Main.netMode != NetmodeID.SinglePlayer)
+			if (Main.netMode != NetmodeID.SinglePlayer && quest.Active)
 			{
-				SyncPlayerQuestActive.Send(name, true);
+				SyncPlayerQuestActive.Send(name, true, quest.ActiveStep.Id, false);
 			}
 		}
 	}
 
 	public override void OnEnterWorld()
 	{
+		EnabledQuestsByName.Clear();
+		ActiveQuestStepsByName.Clear();
+		CompletedQuestsByName.Clear();
+
 		foreach (Quest quest in QuestsByName.Values)
 		{
 			if (quest.Active)
 			{
-				EnabledQuestsByName.Add(quest.FullName);
+				SetSyncedQuestState(quest.FullName, true, quest.ActiveStep.Id, false);
 
-				if (Main.netMode != NetmodeID.SinglePlayer)
+				if (Player.whoAmI == Main.myPlayer && Main.netMode == NetmodeID.MultiplayerClient)
 				{
-					SyncPlayerQuestActive.Send(quest.FullName, true);
+					SyncPlayerQuestActive.Send(quest.FullName, true, quest.ActiveStep.Id, false);
 				}
 			}
+			else if (quest.Completed)
+			{
+				SetSyncedQuestState(quest.FullName, false, string.Empty, true);
+
+				if (Player.whoAmI == Main.myPlayer && Main.netMode == NetmodeID.MultiplayerClient)
+				{
+					SyncPlayerQuestActive.Send(quest.FullName, false, string.Empty, true);
+				}
+			}
+		}
+	}
+
+	internal void SetSyncedQuestState(string questName, bool active, string activeStep, bool completed)
+	{
+		if (active)
+		{
+			EnabledQuestsByName.Add(questName);
+			ActiveQuestStepsByName[questName] = activeStep;
+			CompletedQuestsByName.Remove(questName);
+			return;
+		}
+
+		EnabledQuestsByName.Remove(questName);
+		ActiveQuestStepsByName.Remove(questName);
+
+		if (completed)
+		{
+			CompletedQuestsByName.Add(questName);
+		}
+		else
+		{
+			CompletedQuestsByName.Remove(questName);
 		}
 	}
 

--- a/Common/Systems/Questing/QuestModPlayer.cs
+++ b/Common/Systems/Questing/QuestModPlayer.cs
@@ -116,6 +116,11 @@ public class QuestModPlayer : ModPlayer
 				}
 			}
 		}
+
+		if (Player.whoAmI == Main.myPlayer && Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			RequestOtherQuestStatesHandler.Send();
+		}
 	}
 
 	internal void SetSyncedQuestState(string questName, bool active, string activeStep, bool completed)

--- a/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
@@ -1,0 +1,39 @@
+﻿using PathOfTerraria.Content.Buffs.ElementalBuffs;
+using System.IO;
+
+namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
+
+/// <summary>
+/// Requests that the server add a stack of Poison to an NPC for the sending player.
+/// </summary>
+internal class PoisonStackHandler : Handler
+{
+	public static void Send(NPC npc, int time)
+	{
+		ModPacket packet = Networking.GetPacket<PoisonStackHandler>(7);
+		packet.Write((short)npc.whoAmI);
+		packet.Write(time);
+		packet.Send();
+	}
+
+	internal override void ServerReceive(BinaryReader reader, byte sender)
+	{
+		short npcWhoAmI = reader.ReadInt16();
+		int time = reader.ReadInt32();
+
+		if (sender >= Main.maxPlayers || npcWhoAmI < 0 || npcWhoAmI >= Main.maxNPCs || time <= 0)
+		{
+			return;
+		}
+
+		Player player = Main.player[sender];
+		NPC npc = Main.npc[npcWhoAmI];
+
+		if (!player.active || !npc.active)
+		{
+			return;
+		}
+
+		PoisonedDebuff.Apply(npc, time, player);
+	}
+}

--- a/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/PoisonStackHandler.cs
@@ -3,16 +3,19 @@ using System.IO;
 
 namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
 
+#nullable enable
+
 /// <summary>
-/// Requests that the server add a stack of Poison to an NPC for the sending player.
+/// Requests that the server add a stack of Poison to an NPC, preserving whether the sending player was its source.
 /// </summary>
 internal class PoisonStackHandler : Handler
 {
-	public static void Send(NPC npc, int time)
+	public static void Send(NPC npc, int time, Player? player)
 	{
-		ModPacket packet = Networking.GetPacket<PoisonStackHandler>(7);
+		ModPacket packet = Networking.GetPacket<PoisonStackHandler>(8);
 		packet.Write((short)npc.whoAmI);
 		packet.Write(time);
+		packet.Write(player is not null);
 		packet.Send();
 	}
 
@@ -20,16 +23,17 @@ internal class PoisonStackHandler : Handler
 	{
 		short npcWhoAmI = reader.ReadInt16();
 		int time = reader.ReadInt32();
+		bool hasPlayerSource = reader.ReadBoolean();
 
 		if (sender >= Main.maxPlayers || npcWhoAmI < 0 || npcWhoAmI >= Main.maxNPCs || time <= 0)
 		{
 			return;
 		}
 
-		Player player = Main.player[sender];
+		Player? player = hasPlayerSource ? Main.player[sender] : null;
 		NPC npc = Main.npc[npcWhoAmI];
 
-		if (!player.active || !npc.active)
+		if (player is { active: false } || !npc.active)
 		{
 			return;
 		}

--- a/Common/Systems/Synchronization/Handlers/RequestOtherQuestStatesHandler.cs
+++ b/Common/Systems/Synchronization/Handlers/RequestOtherQuestStatesHandler.cs
@@ -1,0 +1,83 @@
+﻿using PathOfTerraria.Common.Systems.Questing;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
+
+/// <summary>
+/// Requests the cached quest state of every other active player from the server.
+/// </summary>
+internal class RequestOtherQuestStatesHandler : Handler
+{
+	public static void Send()
+	{
+		Networking.GetPacket<RequestOtherQuestStatesHandler>().Send();
+	}
+
+	internal override void ServerReceive(BinaryReader reader, byte sender)
+	{
+		if (sender >= Main.maxPlayers || !Main.player[sender].active)
+		{
+			return;
+		}
+
+		foreach (Player player in Main.ActivePlayers)
+		{
+			if (player.whoAmI == sender)
+			{
+				continue;
+			}
+
+			QuestModPlayer questPlayer = player.GetModPlayer<QuestModPlayer>();
+			ModPacket packet = Networking.GetPacket(Id);
+			packet.Write((byte)player.whoAmI);
+			packet.Write((ushort)questPlayer.ActiveQuestStepsByName.Count);
+
+			foreach (KeyValuePair<string, string> quest in questPlayer.ActiveQuestStepsByName)
+			{
+				packet.Write(quest.Key);
+				packet.Write(quest.Value);
+			}
+
+			packet.Write((ushort)questPlayer.CompletedQuestsByName.Count);
+
+			foreach (string questName in questPlayer.CompletedQuestsByName)
+			{
+				packet.Write(questName);
+			}
+
+			packet.Send(sender);
+		}
+	}
+
+	internal override void ClientReceive(BinaryReader reader, byte sender)
+	{
+		byte playerWhoAmI = reader.ReadByte();
+
+		if (playerWhoAmI >= Main.maxPlayers)
+		{
+			return;
+		}
+
+		QuestModPlayer questPlayer = Main.player[playerWhoAmI].GetModPlayer<QuestModPlayer>();
+		questPlayer.EnabledQuestsByName.Clear();
+		questPlayer.ActiveQuestStepsByName.Clear();
+		questPlayer.CompletedQuestsByName.Clear();
+
+		ushort activeCount = reader.ReadUInt16();
+
+		for (int i = 0; i < activeCount; i++)
+		{
+			string questName = reader.ReadString();
+			string activeStep = reader.ReadString();
+			questPlayer.SetSyncedQuestState(questName, true, activeStep, false);
+		}
+
+		ushort completedCount = reader.ReadUInt16();
+
+		for (int i = 0; i < completedCount; i++)
+		{
+			questPlayer.SetSyncedQuestState(reader.ReadString(), false, string.Empty, true);
+		}
+	}
+}

--- a/Common/Systems/Synchronization/Handlers/SyncPlayerQuestActive.cs
+++ b/Common/Systems/Synchronization/Handlers/SyncPlayerQuestActive.cs
@@ -4,35 +4,48 @@ using System.IO;
 namespace PathOfTerraria.Common.Systems.Synchronization.Handlers;
 
 /// <summary>
-/// Syncs that a player has enabled a given quest. This is used for things like quests.
+/// Syncs a player's active/completed quest state and current active step.
 /// </summary>
 internal class SyncPlayerQuestActive : Handler
 {
-	public static void Send(string quest, bool enabled, int toClient = -1, int ignoreClient = -1)
+	public static void Send(string quest, bool active, string activeStep, bool completed, int toClient = -1, int ignoreClient = -1)
 	{
 		ModPacket packet = Networking.GetPacket<SyncPlayerQuestActive>();
-		packet.Write(quest);
-		packet.Write(enabled);
+		WriteState(packet, quest, active, activeStep, completed);
 		packet.Send(toClient, ignoreClient);
 	}
 
-	internal override void Receive(BinaryReader reader, byte sender)
+	internal override void ServerReceive(BinaryReader reader, byte sender)
 	{
-		string questName = reader.ReadString();
-		bool enabled = reader.ReadBoolean();
+		ReadState(reader, out string questName, out bool active, out string activeStep, out bool completed);
+		Main.player[sender].GetModPlayer<QuestModPlayer>().SetSyncedQuestState(questName, active, activeStep, completed);
 
-		if (enabled)
-		{
-			Main.player[sender].GetModPlayer<QuestModPlayer>().EnabledQuestsByName.Add(questName);
-		}
-		else
-		{
-			Main.player[sender].GetModPlayer<QuestModPlayer>().EnabledQuestsByName.Remove(questName);
-		}
+		ModPacket packet = Networking.GetPacket(Id);
+		packet.Write(sender);
+		WriteState(packet, questName, active, activeStep, completed);
+		packet.Send(-1, sender);
+	}
 
-		if (Main.dedServ)
-		{
-			Send(questName, enabled, -1, sender);
-		}
+	internal override void ClientReceive(BinaryReader reader, byte sender)
+	{
+		byte playerWhoAmI = reader.ReadByte();
+		ReadState(reader, out string questName, out bool active, out string activeStep, out bool completed);
+		Main.player[playerWhoAmI].GetModPlayer<QuestModPlayer>().SetSyncedQuestState(questName, active, activeStep, completed);
+	}
+
+	private static void WriteState(BinaryWriter writer, string questName, bool active, string activeStep, bool completed)
+	{
+		writer.Write(questName);
+		writer.Write(active);
+		writer.Write(activeStep);
+		writer.Write(completed);
+	}
+
+	private static void ReadState(BinaryReader reader, out string questName, out bool active, out string activeStep, out bool completed)
+	{
+		questName = reader.ReadString();
+		active = reader.ReadBoolean();
+		activeStep = reader.ReadString();
+		completed = reader.ReadBoolean();
 	}
 }

--- a/Common/Systems/VanillaModifications/AddValidShieldParryItems.cs
+++ b/Common/Systems/VanillaModifications/AddValidShieldParryItems.cs
@@ -94,6 +94,8 @@ internal class AddValidShieldParryItems : ModSystem
 			return;
 		}
 
+		self.hasRaisableShield = true;
+
 		bool canRaiseShield = true;
 		IParryItem parryItem = null;
 
@@ -103,7 +105,7 @@ internal class AddValidShieldParryItems : ModSystem
 			canRaiseShield = parryItem.CanRaiseShield(self);
 		}
 
-		if (canRaiseShield && theGeneralCheck && self.hasRaisableShield && !self.mount.Active && (self.itemAnimation == 0 || mouseRight))
+		if (canRaiseShield && theGeneralCheck && !self.mount.Active && (self.itemAnimation == 0 || mouseRight))
 		{
 			shouldGuard = true;
 			parryItem?.OnRaiseShield(self);

--- a/Common/Systems/VanillaModifications/ManaRegenRework.cs
+++ b/Common/Systems/VanillaModifications/ManaRegenRework.cs
@@ -6,6 +6,7 @@ namespace PathOfTerraria.Common.Systems.VanillaModifications;
 internal sealed class ManaRegenRework : ModSystem
 {
 	private const float BaseManaRegenMultiplier = 0.05f;
+	private const float NaturalManaRegenMultiplier = 1f / 3f;
 	private const int MinimumBaseManaRegen = 1;
 	private const int TicksPerSecond = 60;
 	private const int VanillaManaRegenCountPerMana = 120;
@@ -16,7 +17,8 @@ internal sealed class ManaRegenRework : ModSystem
 	internal sealed class ManaRegenPlayer : ModPlayer
 	{
 		public StatModifier ManaRegen = StatModifier.Default;
-		public int LastManaRegen { get; internal set; }
+		public float LastManaRegen { get; internal set; }
+		internal float ManaRegenRemainder;
 
 		public override void ResetEffects()
 		{
@@ -92,25 +94,39 @@ internal sealed class ManaRegenRework : ModSystem
 	private static int GetBaseManaRegenPenalty(Player player)
 	{
 		int baseManaRegen = player.statManaMax2 / 7 + 1;
-		int reducedBaseManaRegen = Math.Max(MinimumBaseManaRegen, (int)(baseManaRegen * BaseManaRegenMultiplier));
+		int reducedBaseManaRegen = GetReducedBaseManaRegen(baseManaRegen);
 		return baseManaRegen - reducedBaseManaRegen;
+	}
+
+	private static int GetReducedBaseManaRegen(int baseManaRegen)
+	{
+		return Math.Max(MinimumBaseManaRegen, (int)(baseManaRegen * BaseManaRegenMultiplier));
 	}
 
 	private static void ApplyManaRegenModifier(Player player, int statMana, int manaRegenCount)
 	{
 		ManaRegenPlayer regenPlayer = player.GetModPlayer<ManaRegenPlayer>();
-		int modifiedManaRegen = Math.Max(0, (int)regenPlayer.ManaRegen.ApplyTo(player.manaRegen));
-
-		if (modifiedManaRegen == player.manaRegen)
-		{
-			regenPlayer.LastManaRegen = player.manaRegen;
-			return;
-		}
+		int baseManaRegen = player.statManaMax2 / 7 + 1;
+		int naturalManaRegen = GetReducedBaseManaRegen(baseManaRegen);
+		float adjustedManaRegen = player.manaRegen - naturalManaRegen + naturalManaRegen * NaturalManaRegenMultiplier;
+		float modifiedManaRegen = Math.Max(0, regenPlayer.ManaRegen.ApplyTo(adjustedManaRegen));
 
 		int vanillaManaRestored = CountManaRestored(statMana, manaRegenCount, player.manaRegen, player.statManaMax2);
 		player.statMana = Math.Clamp(player.statMana - vanillaManaRestored, 0, player.statManaMax2);
-		player.manaRegen = modifiedManaRegen;
-		player.manaRegenCount = manaRegenCount + modifiedManaRegen;
+		player.manaRegen = (int)modifiedManaRegen;
+
+		if (statMana >= player.statManaMax2)
+		{
+			regenPlayer.ManaRegenRemainder = 0f;
+			player.manaRegenCount = 0;
+		}
+		else
+		{
+			regenPlayer.ManaRegenRemainder += modifiedManaRegen;
+			int manaRegenThisTick = (int)regenPlayer.ManaRegenRemainder;
+			regenPlayer.ManaRegenRemainder -= manaRegenThisTick;
+			player.manaRegenCount = manaRegenCount + manaRegenThisTick;
+		}
 
 		while (player.manaRegenCount >= VanillaManaRegenCountPerMana && player.statMana < player.statManaMax2)
 		{
@@ -118,7 +134,7 @@ internal sealed class ManaRegenRework : ModSystem
 			player.statMana++;
 		}
 
-		regenPlayer.LastManaRegen = player.manaRegen;
+		regenPlayer.LastManaRegen = modifiedManaRegen;
 	}
 
 	private static int CountManaRestored(int statMana, int manaRegenCount, int manaRegen, int statManaMax)

--- a/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
+++ b/Common/UI/PlayerStats/PlayerStatInnerPanel.cs
@@ -164,7 +164,7 @@ internal class PlayerStatInnerPanel : SmartUiElement
 			float manaPercent = player.statMana / player.statManaMax * 100;
 			return $"{player.statMana}/{player.statManaMax2} ({manaPercent:#0.##}%)";
 		}));
-		list.Add(new PlayerStatUI(Localize("ManaRegen"), player => $"{player.GetModPlayer<ManaRegenRework.ManaRegenPlayer>().LastManaRegen}"));
+		list.Add(new PlayerStatUI(Localize("ManaRegen"), player => $"{player.GetModPlayer<ManaRegenRework.ManaRegenPlayer>().LastManaRegen:#0.##}"));
 		list.Add(new PlayerStatUI(Localize("DamageReduction"), player => $"{player.endurance * 100:#0.##}%"));
 		list.Add(new PlayerStatUI(Localize("BlockChance"), player => $"{player.GetModPlayer<BlockPlayer>().ActualBlockChance * 100:#0.##}%"));
 		list.Add(new PlayerStatUI(Localize("MaxBlock"), player => $"{player.GetModPlayer<BlockPlayer>().MaxBlockChance * 100:#0.##}%"));

--- a/Common/UI/SkillsTree/AugmentSlotElement.cs
+++ b/Common/UI/SkillsTree/AugmentSlotElement.cs
@@ -189,9 +189,9 @@ internal class AugmentSlotElement : SmartUiElement, IConnectedAllocatableNode
 			SkillCombatPlayer global = Main.LocalPlayer.GetModPlayer<SkillCombatPlayer>();
 			Type parent = SkillTree.Current.ParentSkill;
 
-			if (global.HotbarSkills.FirstOrDefault(x => x.GetType() == parent) is Skill skill)
+			if (global.HotbarSkills.FirstOrDefault(x => x?.GetType() == parent) is Skill skill)
 			{
-				return skill != default && augment.CanBeApplied(skill);
+				return augment.CanBeApplied(skill);
 			}
 
 			return false;

--- a/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
+++ b/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
@@ -52,7 +52,7 @@ internal class PoisonedDebuff : ModBuff
 		{
 			if (player is null || player.whoAmI == Main.myPlayer)
 			{
-				PoisonStackHandler.Send(npc, time);
+				PoisonStackHandler.Send(npc, time, player);
 			}
 
 			return;
@@ -184,6 +184,14 @@ internal class PoisonNPC : GlobalNPC
 
 	public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
 	{
+		bool hasStacks = _stacks.Count > 0;
+		bitWriter.WriteBit(hasStacks);
+
+		if (!hasStacks)
+		{
+			return;
+		}
+
 		binaryWriter.Write((ushort)_stacks.Count);
 
 		foreach (PoisonStack stack in _stacks)
@@ -200,6 +208,15 @@ internal class PoisonNPC : GlobalNPC
 	public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
 	{
 		_stacks.Clear();
+
+		if (!bitReader.ReadBit())
+		{
+			ElapsedDoT = 0;
+			LastTickRate = 60;
+			_timer = 0;
+			return;
+		}
+
 		ushort count = binaryReader.ReadUInt16();
 
 		for (int i = 0; i < count; i++)

--- a/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
+++ b/Content/Buffs/ElementalBuffs/PoisonedDebuff.cs
@@ -1,10 +1,13 @@
 ﻿using PathOfTerraria.Common.Buffs;
 using PathOfTerraria.Common.Systems.MobSystem;
+using PathOfTerraria.Common.Systems.Synchronization.Handlers;
 using ReLogic.Content;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using Terraria.GameContent;
 using Terraria.ID;
+using Terraria.ModLoader.IO;
 using Terraria.UI.Chat;
 
 namespace PathOfTerraria.Content.Buffs.ElementalBuffs;
@@ -45,6 +48,16 @@ internal class PoisonedDebuff : ModBuff
 
 	public static void Apply(NPC npc, int time, Player? player = null)
 	{
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			if (player is null || player.whoAmI == Main.myPlayer)
+			{
+				PoisonStackHandler.Send(npc, time);
+			}
+
+			return;
+		}
+
 		float damage = 4f;
 		float tickRate = 60;
 
@@ -62,6 +75,7 @@ internal class PoisonedDebuff : ModBuff
 
 		ref float tick = ref npc.GetGlobalNPC<PoisonNPC>().LastTickRate;
 		tick = MathF.Min(tickRate, tick);
+		npc.netUpdate = true;
 	}
 
 	public override void SetStaticDefaults()
@@ -129,6 +143,8 @@ internal class PoisonNPC : GlobalNPC
 
 	public override bool PreAI(NPC npc)
 	{
+		int previousStackCount = _stacks.Count;
+
 		for (int i = 0; i < _stacks.Count; i++)
 		{
 			PoisonStack stack = _stacks[i];
@@ -138,6 +154,12 @@ internal class PoisonNPC : GlobalNPC
 		}
 
 		_stacks.RemoveAll(x => x.Time <= 0);
+
+		if (Main.netMode == NetmodeID.Server && _stacks.Count != previousStackCount)
+		{
+			npc.netUpdate = true;
+		}
+
 		_timer++;
 
 		if (_timer > LastTickRate && _stacks.Count > 0 && ElapsedDoT >= 1)
@@ -158,6 +180,36 @@ internal class PoisonNPC : GlobalNPC
 		}
 
 		return true;
+	}
+
+	public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
+	{
+		binaryWriter.Write((ushort)_stacks.Count);
+
+		foreach (PoisonStack stack in _stacks)
+		{
+			binaryWriter.Write(stack.Time);
+			binaryWriter.Write(stack.DamagePerTick);
+		}
+
+		binaryWriter.Write(ElapsedDoT);
+		binaryWriter.Write(LastTickRate);
+		binaryWriter.Write(_timer);
+	}
+
+	public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
+	{
+		_stacks.Clear();
+		ushort count = binaryReader.ReadUInt16();
+
+		for (int i = 0; i < count; i++)
+		{
+			_stacks.Add(new PoisonStack(binaryReader.ReadInt32(), binaryReader.ReadSingle()));
+		}
+
+		ElapsedDoT = binaryReader.ReadSingle();
+		LastTickRate = binaryReader.ReadSingle();
+		_timer = binaryReader.ReadSingle();
 	}
 
 	public override Color? GetAlpha(NPC npc, Color drawColor)

--- a/Content/Conflux/ConfluxRift.cs
+++ b/Content/Conflux/ConfluxRift.cs
@@ -259,10 +259,14 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 				(Player? closestPlayer, float minSqrDist) = (null, float.PositiveInfinity);
 				foreach (Player player in Main.ActivePlayers)
 				{
-					(closestPlayer, minSqrDist) = (player, MathF.Min(minSqrDist, player.DistanceSQ(center)));
+					float sqrDist = player.DistanceSQ(center);
+					if (sqrDist < minSqrDist)
+					{
+						(closestPlayer, minSqrDist) = (player, sqrDist);
+					}
 				}
 
-				Vector2 compareSpot = Main.LocalPlayer.Center;
+				Vector2 compareSpot = closestPlayer?.Center ?? center;
 				bool isInteractible =
 					closestPlayer?.IsProjectileInteractibleAndInInteractionRange(Projectile, ref compareSpot) == true &&
 					CanInteract();
@@ -460,8 +464,6 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 
 		Main.spriteBatch.End();
 		Main.spriteBatch.Begin(sbArgs);
-
-		this.TryInteracting();
 
 		/*
 		(_, _, Color colorBase) = GetVisualParameters();
@@ -853,6 +855,23 @@ internal abstract class ConfluxRift : ModProjectile, IRightClickableProjectile, 
 }
 
 /// <summary>
+/// Processes rift input independently of projectile rendering so off-screen culling and draw-order changes cannot block interaction.
+/// </summary>
+internal sealed class RiftInteractionSystem : ModSystem
+{
+	public override void PostUpdateInput()
+	{
+		foreach (Projectile projectile in Main.ActiveProjectiles)
+		{
+			if (projectile.ModProjectile is ConfluxRift rift)
+			{
+				rift.TryInteracting();
+			}
+		}
+	}
+}
+
+/// <summary>
 /// Synchronizes right click interactions with rifts.
 /// </summary>
 internal class RiftInteractionHandler : Handler
@@ -866,22 +885,52 @@ internal class RiftInteractionHandler : Handler
 
 	internal override void Receive(BinaryReader reader, byte sender)
 	{
-		ModPacket packet = Networking.GetPacket(Id);
 		int riftIdentity = reader.ReadInt32();
 
 		if (Main.netMode != NetmodeID.Server) { return; }
 
-		if (Main.projectile.FirstOrDefault(p => p.identity == riftIdentity) is not { ModProjectile: ConfluxRift rift })
+		void LogRejection(string reason)
 		{
+			PoTMod.Instance.Logger.Debug(
+				$"Rejected rift interaction from player {sender} for identity {riftIdentity}: {reason}");
+		}
+
+		ConfluxRift? rift = null;
+		foreach (Projectile projectile in Main.ActiveProjectiles)
+		{
+			if (projectile.identity == riftIdentity && projectile.ModProjectile is ConfluxRift activeRift)
+			{
+				rift = activeRift;
+				break;
+			}
+		}
+
+		if (rift == null)
+		{
+			LogRejection("no active rift matched the projectile identity");
 			return;
 		}
 
-		if (Main.player[sender] is not { active: true } player) { return; }
+		if (Main.player[sender] is not { active: true } player)
+		{
+			LogRejection("the requesting player was inactive");
+			return;
+		}
+
+		if (rift.Activated || !rift.CanInteract())
+		{
+			LogRejection("the rift was already active or cannot be interacted with");
+			return;
+		}
 
 		// Increased reach distance for synchronization grace.
 		Point tileTarget = rift.Projectile.Hitbox.ClosestPointInRect(player.Center).ToTileCoordinates();
 		if (!player.IsInTileInteractionRange(tileTarget.X, tileTarget.Y,
-			    TileReachCheckSettings.Simple with { TileRangeMultiplier = 2 })) { return; }
+			    TileReachCheckSettings.Simple with { TileRangeMultiplier = 2 }))
+		{
+			LogRejection("the requesting player was out of interaction range");
+			return;
+		}
 
 		rift.Activate();
 	}

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -22,7 +22,7 @@ namespace PathOfTerraria.Content.Items.Consumables.Maps;
 #nullable enable
 
 public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.IItem, GenerateImplicits.IItem,
-	IPoTGlobalItem, GetItemLevel.IItem, SetItemLevel.IItem
+	IPoTGlobalItem, SetItemLevel.IItem
 {
 	protected sealed override bool CloneNewInstances => true;
 
@@ -198,11 +198,6 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 	public List<ItemAffix> GenerateAffixes()
 	{
 		return [];
-	}
-
-	int GetItemLevel.IItem.GetItemLevel(int realLevel)
-	{
-		return realLevel;
 	}
 
 	void SetItemLevel.IItem.SetItemLevel(int level, ref int realLevel)

--- a/Content/Items/Consumables/Maps/Map.cs
+++ b/Content/Items/Consumables/Maps/Map.cs
@@ -32,13 +32,11 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 	protected virtual bool RollsAdjacentTiers => true;
 
 	internal int Tier = 1;
-	internal int ItemLevel = 1;
 
 	public override ModItem Clone(Item newEntity)
 	{
 		var map = base.Clone(newEntity) as Map;
 		map!.Tier = Tier;
-		map.ItemLevel = ItemLevel;
 		return map;
 	}
 
@@ -131,7 +129,7 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 	public override void LoadData(TagCompound tag)
 	{
-		Tier = tag.GetShort("tier");
+		Tier = Math.Clamp((int)tag.GetShort("tier"), 1, MaxMapTier);
 	}
 
 	public override void NetSend(BinaryWriter writer)
@@ -141,7 +139,7 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 	public override void NetReceive(BinaryReader reader)
 	{
-		Tier = reader.ReadInt16();
+		Tier = Math.Clamp((int)reader.ReadInt16(), 1, MaxMapTier);
 	}
 
 	public abstract string GenerateName(string defaultName);
@@ -204,19 +202,18 @@ public abstract class Map : ModItem, GenerateNameAffixes.IItem, GenerateAffixes.
 
 	int GetItemLevel.IItem.GetItemLevel(int realLevel)
 	{
-		return ItemLevel;
+		return realLevel;
 	}
 
 	void SetItemLevel.IItem.SetItemLevel(int level, ref int realLevel)
 	{
-		if (RollsAdjacentTiers && level > MaxOverworldLevel)
+		if (RollsAdjacentTiers && level >= MaxOverworldLevel)
 		{
 			level = RollAdjacentMapLevel(level);
 		}
 
 		realLevel = level;
-		ItemLevel = realLevel;
-		Tier = GetMapTier(ItemLevel);
+		Tier = GetMapTier(realLevel);
 	}
 
 	private static int RollAdjacentMapLevel(int level)

--- a/Content/Items/Gear/GearAlternatives.cs
+++ b/Content/Items/Gear/GearAlternatives.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using PathOfTerraria.Common.Enums;
 using PathOfTerraria.Core.Items;
+using SubworldLibrary;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace PathOfTerraria.Content.Items.Gear;
 
@@ -44,6 +46,36 @@ internal class GearAlternativeGlobalItem : ModSystem
 
 internal class GearAlternativeChestReplacement : ModSystem
 {
+	private static class ContainerStyle
+	{
+		public const int Shadow = 3;
+		public const int LockedShadow = 4;
+		public const int RichMahogany = 8;
+		public const int Ivy = 10;
+		public const int Frozen = 11;
+		public const int Skyware = 13;
+		public const int Lihzahrd = 16;
+		public const int Water = 17;
+		public const int Jungle = 18;
+		public const int Corruption = 19;
+		public const int Crimson = 20;
+		public const int Hallowed = 21;
+		public const int Ice = 22;
+		public const int LockedJungle = 23;
+		public const int LockedCorruption = 24;
+		public const int LockedCrimson = 25;
+		public const int LockedHallowed = 26;
+		public const int LockedIce = 27;
+	}
+
+	private const int SurfaceChestLevel = 5;
+	private const int UndergroundChestLevel = 10;
+	private const int BiomeChestLevel = 15;
+	private const int DungeonChestLevel = 30;
+	private const int ShadowChestLevel = 40;
+	private const int HardmodeBiomeChestLevel = 50;
+	private const int TempleChestLevel = 60;
+
 	public override void PostWorldGen()
 	{
 		foreach (Chest chest in Main.chest)
@@ -52,6 +84,10 @@ internal class GearAlternativeChestReplacement : ModSystem
 			{
 				continue;
 			}
+
+			int chestLevel = SubworldSystem.Current is null
+				? GetOverworldChestLevel(chest)
+				: PoTItemHelper.PickItemLevel();
 
 			foreach (Item item in chest.item)
 			{
@@ -67,11 +103,53 @@ internal class GearAlternativeChestReplacement : ModSystem
 					{
 						data.Rarity = ItemRarity.Rare;
 					}
+				}
 
-					PoTItemHelper.ClearAffixes(item);
-					PoTItemHelper.Roll(item, PoTItemHelper.PickItemLevel());
+				// Chest contents are created before their final location is available, so gear defaults
+				// to level 1 during world generation. Roll it again once the chest has been placed.
+				if (GearGlobalItem.IsGearItem(item) && item.GetInstanceData().RealLevel <= 1)
+				{
+					PoTItemHelper.Roll(item, chestLevel);
 				}
 			}
 		}
+	}
+
+	private static int GetOverworldChestLevel(Chest chest)
+	{
+		Tile tile = Framing.GetTileSafely(chest.x, chest.y);
+
+		if (!tile.HasTile || !TileID.Sets.BasicChest[tile.TileType])
+		{
+			return UndergroundChestLevel;
+		}
+
+		if (tile.TileType != TileID.Containers)
+		{
+			return IsDungeonChest(tile)
+				? DungeonChestLevel
+				: chest.y < Main.worldSurface ? SurfaceChestLevel : UndergroundChestLevel;
+		}
+
+		int style = tile.TileFrameX / 36;
+		return style switch
+		{
+			ContainerStyle.Jungle or ContainerStyle.Corruption or ContainerStyle.Crimson
+				or ContainerStyle.Hallowed or ContainerStyle.Ice
+				or ContainerStyle.LockedJungle or ContainerStyle.LockedCorruption or ContainerStyle.LockedCrimson
+				or ContainerStyle.LockedHallowed or ContainerStyle.LockedIce => HardmodeBiomeChestLevel,
+			ContainerStyle.Shadow or ContainerStyle.LockedShadow => ShadowChestLevel,
+			ContainerStyle.Lihzahrd => TempleChestLevel,
+			ContainerStyle.RichMahogany or ContainerStyle.Ivy or ContainerStyle.Frozen => BiomeChestLevel,
+			ContainerStyle.Skyware or ContainerStyle.Water => UndergroundChestLevel,
+			_ when IsDungeonChest(tile) => DungeonChestLevel,
+			_ when chest.y < Main.worldSurface => SurfaceChestLevel,
+			_ => UndergroundChestLevel,
+		};
+	}
+
+	private static bool IsDungeonChest(Tile tile)
+	{
+		return tile.WallType < Main.wallDungeon.Length && Main.wallDungeon[tile.WallType];
 	}
 }

--- a/Content/NPCs/Town/TownScoutNPC.cs
+++ b/Content/NPCs/Town/TownScoutNPC.cs
@@ -6,6 +6,7 @@ using PathOfTerraria.Common.Subworlds.RavencrestContent;
 using PathOfTerraria.Common.Systems.Questing;
 using PathOfTerraria.Common.Systems.Questing.Quests.MainPath;
 using SubworldLibrary;
+using Terraria.DataStructures;
 using Terraria.GameContent.Bestiary;
 using Terraria.ID;
 
@@ -42,6 +43,14 @@ public sealed class TownScoutNPC : ModNPC
 	public override void SetBestiary(BestiaryDatabase database, BestiaryEntry bestiaryEntry)
 	{
 		bestiaryEntry.AddInfo(this, "Surface");
+	}
+
+	public override void OnSpawn(IEntitySource source)
+	{
+		if (Main.netMode != NetmodeID.MultiplayerClient && AnyPlayerCanEncounterSurveyor())
+		{
+			ModContent.GetInstance<RavencrestSystem>().SpawnedScout = true;
+		}
 	}
 
 	public override bool PreAI()
@@ -90,8 +99,6 @@ public sealed class TownScoutNPC : ModNPC
 		}
 
 		NPC.direction = NPC.spriteDirection = Math.Sign(NPC.velocity.X);
-		ModContent.GetInstance<RavencrestSystem>().SpawnedScout = true;
-
 		Collision.StepUp(ref NPC.position, ref NPC.velocity, NPC.width, NPC.height, ref NPC.stepSpeed, ref NPC.gfxOffY);
 
 		if (NPC.velocity.Y != 0)
@@ -155,6 +162,18 @@ public sealed class TownScoutNPC : ModNPC
 		foreach (Player plr in Main.ActivePlayers)
 		{
 			QuestModPlayer questPlayer = plr.GetModPlayer<QuestModPlayer>();
+
+			if (Main.netMode != NetmodeID.SinglePlayer)
+			{
+				if (questPlayer.ActiveQuestStepsByName.TryGetValue(questName, out string activeStep)
+					&& activeStep == WizardStartQuest.SurveyorStepId)
+				{
+					return 100f;
+				}
+
+				questCompleted |= questPlayer.CompletedQuestsByName.Contains(questName);
+				continue;
+			}
 
 			if (!questPlayer.QuestsByName.TryGetValue(questName, out Quest quest))
 			{

--- a/Content/Passives/Melee/Masteries/BloodRushMastery.cs
+++ b/Content/Passives/Melee/Masteries/BloodRushMastery.cs
@@ -11,7 +11,7 @@ internal class BloodRushMastery : Passive
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
 		{
 			if (target.life <= 0 && Player.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<BloodRushMastery>(out float value) 
-				&& Main.rand.NextFloat() < value)
+				&& Main.rand.NextFloat() < value / 100f)
 			{
 				Player.Heal((int)(Player.statLifeMax2 * (HealProportion / 100f)));
 

--- a/Content/Passives/Ranged/SmallPassives/IgnitingProjectilesPassive.cs
+++ b/Content/Passives/Ranged/SmallPassives/IgnitingProjectilesPassive.cs
@@ -10,7 +10,7 @@ internal class IgnitingProjectilesPassive : Passive
 		public override void OnHitNPC(Projectile projectile, NPC target, NPC.HitInfo hit, int damageDone)
 		{
 			if (projectile.TryGetOwner(out Player plr) && plr.GetModPlayer<PassiveTreePlayer>().TryGetCumulativeValue<IgnitingProjectilesPassive>(out float value) 
-				&& Main.rand.NextFloat() < value)
+				&& Main.rand.NextFloat() < value / 100f)
 			{
 				IgnitedDebuff.ApplyTo(plr, target, damageDone, 240);
 			}

--- a/Content/Projectiles/Utility/WoFRitualProj.cs
+++ b/Content/Projectiles/Utility/WoFRitualProj.cs
@@ -107,13 +107,17 @@ internal class WoFRitualProj : ModProjectile
 			SoundEngine.PlaySound(SoundID.Item14 with { Pitch = -0.2f, Volume = 1f }, Projectile.Center);
 			Digging.CircleOpening(Projectile.Center / 16f, 8);
 
-			if (Main.myPlayer == Projectile.owner)
+			IEntitySource src = Projectile.GetSource_Death();
+
+			if (Main.netMode != NetmodeID.MultiplayerClient)
 			{
-				IEntitySource src = Projectile.GetSource_Death();
 				int type = ModContent.ProjectileType<WoFPortal>();
 				Projectile.NewProjectile(src, Projectile.Center, new Vector2(0, -1), type, 0, 0, Main.myPlayer);
+			}
 
-				type = ModContent.ProjectileType<ExplosionHitbox>();
+			if (Main.myPlayer == Projectile.owner)
+			{
+				int type = ModContent.ProjectileType<ExplosionHitbox>();
 				Projectile.NewProjectile(src, Projectile.Center, Vector2.Zero, type, 30, 6f, Projectile.owner, 18 * 8, 18 * 8);
 			}
 		}

--- a/Content/Tiles/Furniture/MapDevicePlaceable.cs
+++ b/Content/Tiles/Furniture/MapDevicePlaceable.cs
@@ -465,14 +465,27 @@ internal class MapDeviceEntity : ModTileEntity
 			}
 		}
 
+		// World items are authoritative on the server. Letting clients collect them into their
+		// local tile entity creates storage that disappears on the next full synchronization.
+		if (Main.netMode == NetmodeID.MultiplayerClient)
+		{
+			return;
+		}
+
 		Vector2 center = Position.ToWorldCoordinates();
 		foreach (Item item in Main.ActiveItems)
 		{
-			if (item.ModItem is Map map && item.velocity.LengthSquared() < 4f && item.WithinRange(center, 128f) && Array.FindIndex(Storage, s => s.IsAir) is >= 0 and int freeSlot)
+			if (item.ModItem is Map && item.velocity.LengthSquared() < 4f && item.WithinRange(center, 128f) && Array.FindIndex(Storage, s => s.IsAir) is >= 0 and int freeSlot)
 			{
 				SoundEngine.PlaySound(SoundID.Grab, item.Center);
 				Storage[freeSlot] = item.Clone();
 				item.active = false;
+
+				if (Main.netMode == NetmodeID.Server)
+				{
+					NetMessage.SendData(MessageID.SyncItem, number: item.whoAmI);
+					MapDeviceSync.Send(ID, MapDeviceSync.Flags.Storage, [freeSlot]);
+				}
 			}
 		}
 	}
@@ -1166,28 +1179,15 @@ internal class MapDeviceSync : Handler
 
 		if (flags.HasFlag(Flags.Storage))
 		{
-			// Write preceding masks.
-			Span<BitMask<byte>> masks = stackalloc BitMask<byte>[(int)MathF.Ceiling(device.Storage.Length / 8f)];
-			foreach (int storageIndex in itemIndices ?? Enumerable.Range(0, device.Storage.Length))
-			{
-				if (device.Storage[storageIndex] is { IsAir: false })
-				{
-					(int div, int rem) = Math.DivRem(storageIndex, 8);
-					masks[div].Set(rem);
-				}
-			}
-			foreach (BitMask<byte> mask in masks)
-			{
-				writer.Write((byte)mask.Value);
-			}
+			int[] storageIndices = itemIndices is null
+				? [.. Enumerable.Range(0, device.Storage.Length)]
+				: [.. itemIndices.Where(i => i >= 0 && i < device.Storage.Length).Distinct()];
 
-			// Write item data.
-			for (int maskIndex = 0, storageIndex = 0; maskIndex < masks.Length; maskIndex++)
+			writer.Write7BitEncodedInt(storageIndices.Length);
+			foreach (int storageIndex in storageIndices)
 			{
-				foreach (int bitIndex in masks[maskIndex])
-				{
-					ItemIO.Send(device.Storage[storageIndex], writer, writeStack: true);
-				}
+				writer.Write((byte)storageIndex);
+				ItemIO.Send(device.Storage[storageIndex], writer, writeStack: true);
 			}
 		}
 
@@ -1242,22 +1242,16 @@ internal class MapDeviceSync : Handler
 
 		if (flags.HasFlag(Flags.Storage))
 		{
-			// Read masks.
-			Span<BitMask<byte>> masks = stackalloc BitMask<byte>[(int)MathF.Ceiling(MapDeviceEntity.StorageSize / 8f)];
-			for (int i = 0; i < masks.Length; i++) { masks[i] = new(reader.ReadByte()); }
-
 			// On servers, refuse applying client's storage items if they are not the one interacting with the device.
 			bool forceDummy = Main.netMode == NetmodeID.Server && mapEntity?.InteractingPlayer != sender;
 
-			// Read items.
-			for (int maskIndex = 0, storageIndex = 0; maskIndex < masks.Length; maskIndex++)
+			int itemCount = reader.Read7BitEncodedInt();
+			for (int i = 0; i < itemCount; i++)
 			{
-				foreach (int bitIndex in masks[maskIndex])
-				{
-					bool useDummy = forceDummy || mapEntity?.Storage[storageIndex] == null;
-					Item item = useDummy ? new() : mapEntity!.Storage[storageIndex];
-					ItemIO.Receive(item, reader, readStack: true);
-				}
+				int storageIndex = reader.ReadByte();
+				bool useDummy = forceDummy || storageIndex >= MapDeviceEntity.StorageSize || mapEntity?.Storage[storageIndex] == null;
+				Item item = useDummy ? new() : mapEntity!.Storage[storageIndex];
+				ItemIO.Receive(item, reader, readStack: true);
 			}
 		}
 

--- a/Core/Items/PoTGlobalItem.IO.cs
+++ b/Core/Items/PoTGlobalItem.IO.cs
@@ -68,6 +68,7 @@ partial class PoTGlobalItem : GlobalItem
 			}
 		}
 
+		RemoveInvalidZeroValueAffixes(item, data);
 		PostRoll.Invoke(item);
 	}
 
@@ -116,7 +117,16 @@ partial class PoTGlobalItem : GlobalItem
 			data.Affixes.Add(Affix.FromBReader(reader));
 		}
 
+		RemoveInvalidZeroValueAffixes(item, data);
 		PostRoll.Invoke(item);
+	}
+
+	private static void RemoveInvalidZeroValueAffixes(Item item, PoTInstanceItemData data)
+	{
+		int itemLevel = GetItemLevel.Invoke(item);
+		data.Affixes.RemoveAll(affix => affix is { IsImplicit: false, Value: 0f }
+			&& affix.TryGetData(item) is { } affixData
+			&& !affixData.CanRollAtLevel(itemLevel));
 	}
 
 	private static ItemType NormalizeLoadedItemType(Item item, ItemType itemType)

--- a/build.txt
+++ b/build.txt
@@ -2,4 +2,4 @@ displayName = Path of Terraria (BETA)
 author = ScottieKnowz & GabeHasWon
 modReferences = SubworldLibrary, HousingAPI
 dllReferences = NPCUtils, StructureHelper, Wayfarer
-version = 0.3.10
+version = 0.3.11

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,23 @@
 v0.3.10
-- Added in system for items to allow Flurry even if not (normally) able, add support for all PoT bows + Warden's Bow synergy
-- Made hardmode map drops not require area item level to drop
-- Prevented recursive Raging Spirits procs
-- Corrected flat block chance calculation
-- Added a defense breakdown with Alt
-- Added a proper affix tooltip for modified shield block chance (i.e. +10 block chance)
-- Fixed player immunities not being reset properly for elemental damage types
-- Fixed an issue where the player's elemental immunity would count towards the amount of damage the player does with that element
+Features
+
+- make it so chest contents have relative item levels for the chest style
+- Summoner QOL
+  - Bewitched and War Table buffs retain their remaining duration through world/subworld travel.
+  - Active minions and their summon buffs are restored after normal death.
+  - Minions are also restored after consuming a boss-domain life.
+  - Restoration is owner-gated for multiplayer and avoids duplicating surviving minions.
+- add in instanced item loot and queen slime jelly drop instanced
+
+Bug Fixes
+- Fixes blood rush and igniting projectile passives triggering 100% of the time
+- wof portal removed when owner enters
+- war shield not blocking projectiles when parrying
+- issues with affixes rolling when they shouldn't and maps having issues with tiers
+- syncing quest status for goblin surveyor spawn
+- poison damage over time not synced in MP
+- nerf mana regen by about 2/3
+- prevent ponds from blocking deerclops proogression
+- Crash related to augment slots
+- distance lookup with rifts for rifts not doing anything
+- map storage sync issues


### PR DESCRIPTION
﻿### Description of Work



<!-- pot-changelog-desc:start -->
### Features

- make it so chest contents have relative item levels for the chest style
- Summoner QOL
  - Bewitched and War Table buffs retain their remaining duration through world/subworld travel.
  - Active minions and their summon buffs are restored after normal death.
  - Minions are also restored after consuming a boss-domain life.
  - Restoration is owner-gated for multiplayer and avoids duplicating surviving minions.
- add in instanced item loot and queen slime jelly drop instanced
- update build

### Bug Fixes

- Fixes blood rush and igniting projectile passives triggering 100% of the time
- wof portal removed when owner enters
- war shield not blocking projectiles when parrying
- issues with affixes rolling when they shouldn't and maps having issues with tiers
- syncing quest status for goblin surveyor spawn
- poison damage over time not synced in MP
- nerf mana regen by about 2/3
- prevent ponds from blocking deerclops proogression
- Crash related to augment slots
- distance lookup with rifts for rifts not doing anything
- map storage sync issues
<!-- pot-changelog-desc:end -->
### Comments


<!-- pot-changelog-closes:start -->
Closes #2148
<!-- pot-changelog-closes:end -->